### PR TITLE
Cleanup

### DIFF
--- a/bin/newexp-desi
+++ b/bin/newexp-desi
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+"""
+Generate a new DESI exposure
+
+newexp-desi arc/flat/science [options]
+
+Stephen Bailey, LBL
+Fall 2014
+"""
+
+import sys
+import os
+import numpy as np
+import optparse
+import random
+import time
+import multiprocessing
+
+from desisim import obs, io
+from desispec.log import get_logger
+log = get_logger()
+
+#- Parse options
+parser = optparse.OptionParser(
+    usage = "%prog [options]",
+    epilog = "See $SPECTER_DIR/doc/datamodel.md for input format details"
+    )
+        
+parser.add_option("--flavor",   type=str,   help="arc/flat/science", default='science')
+parser.add_option("--tileid",   type=int,   help="tile id")
+parser.add_option("--expid",    type=int,   help="exposure id")
+parser.add_option("--exptime",  type=int,   help="exposure time in seconds")
+parser.add_option("--night",    type=str,   help="YEARMMDD")
+parser.add_option("--nspec",    type=int,   help="Number of spectra to simulate [%default]", default=5000)
+parser.add_option("--airmass",  type=float, help="Airmass [%default]", default=1.0)
+parser.add_option("--randseed", type=int,   help="random number seed")
+
+opts, args = parser.parse_args()
+
+#- Check environment
+envOK = True
+for envvar in ('DESIMODEL', 'PIXPROD', 'DESI_SPECTRO_SIM'):
+    if envvar not in os.environ:
+        log.fatal("${} is required".format(envvar))
+        envOK = False
+if not envOK:
+    print "Set those environment variable(s) and then try again"
+    sys.exit(1)
+
+#- Initialize tileid
+if opts.tileid is None:
+    opts.tileid = obs.get_next_tileid()
+
+if opts.expid is None:
+    opts.expid = obs.get_next_expid()
+
+if opts.night is None:
+    opts.night = obs.get_night(utc=time.gmtime())
+
+#- TODO: don't hardcode these default exposure times
+if opts.exptime is None:
+    if opts.flavor == 'arc':
+        opts.exptime = 5
+    elif opts.flavor == 'flat':
+        opts.exptime = 10
+    else:
+        opts.exptime = 1000
+    
+#- Initialize random seeds
+if opts.randseed is None:
+    opts.randseed = opts.tileid
+        
+random.seed(opts.randseed)
+np.random.seed(opts.randseed)
+
+#- Generate the new exposure
+obs.new_exposure(opts.flavor, nspec=opts.nspec, \
+    night=opts.night, expid=opts.expid,         \
+    tileid=opts.tileid, airmass=opts.airmass, exptime=opts.exptime)
+
+#-------------------------------------------------------------------------
+# if opts.debug:
+#     #--- DEBUG ---
+#     from pylab import *
+#     ion()
+#     import IPython
+#     IPython.embed()
+#     #--- DEBUG ---
+    

--- a/bin/pixsim-desi
+++ b/bin/pixsim-desi
@@ -32,11 +32,8 @@ parser = optparse.OptionParser(
     epilog = "See $SPECTER_DIR/doc/datamodel.md for input format details"
     )
         
-parser.add_option("--newexp", type=str, dest="flavor", help="create new arc/flat/science")
-parser.add_option("--tileid", type=int, help="tile id")
-parser.add_option("--expid", type=int, help="exposure id")
 parser.add_option("--night", type=str, help="YEARMMDD")
-parser.add_option("--airmass",  type=float, help="Airmass [%default]", default=1.0)
+parser.add_option("--expid", type=int, help="exposure id")
 ### parser.add_option("--simfile", type=str, help="input sim file")
 parser.add_option("--camera", type=str, help="camera (e.g. b0, r5, z9)")
 parser.add_option("--verbose", action="store_true", help="print more stuff")
@@ -66,27 +63,17 @@ if opts.camera is None:
 else:
     opts.camera = opts.camera.split(',')
 
-#- Initialize tileid
-if opts.tileid is None:
-    opts.tileid = obs.get_next_tileid()
-
 #- Initialize random seeds
-if opts.randseed is None:
-    if opts.tileid >= 0:
-        opts.randseed = opts.tileid
+# if opts.randseed is None:
+#     if opts.tileid >= 0:
+#         opts.randseed = opts.tileid
         
 random.seed(opts.randseed)
 np.random.seed(opts.randseed)
 
-if opts.flavor is not None:
-    obs.new_exposure(opts.flavor, opts.nspec,   \
-        night=opts.night, expid=opts.expid,     \
-        tileid=opts.tileid, airmass=opts.airmass)
-    sys.exit(0)
-
 for camera in opts.camera:
-    pixsim.simulate(opts.night, opts.expid, camera,
-        verbose=opts.verbose, nspec=opts.nspec, ncpu=opts.ncpu, trimxy=opts.trimxy)
+    pixsim.simulate(opts.night, opts.expid, camera, verbose=opts.verbose,
+        nspec=opts.nspec, ncpu=opts.ncpu, trimxy=opts.trimxy)
 
 #-------------------------------------------------------------------------
 # if opts.debug:

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -46,7 +46,7 @@ def write_simspec(meta, truth, expid, night, header=None, outfile=None):
 
     #- Primary HDU is just a header from the input
     hx = fits.HDUList()
-    hx.append(fits.PrimaryHDU(np.zeros(0), header=desispec.io.util.fitsheader(header)))
+    hx.append(fits.PrimaryHDU(None, header=desispec.io.util.fitsheader(header)))
 
     #- Object flux HDU (might not exist, e.g. for an arc)
     if 'FLUX' in truth:

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -106,7 +106,7 @@ def write_simspec(meta, truth, expid, night, header=None, outfile=None):
     return outfile
     
 #- TODO: this is more than just I/O.  Refactor.
-def write_simpix(img, camera, flavor, night, expid, header=None):
+def write_simpix(img, camera, night, expid, header):
     """
     Add noise to input image and write output simpix and pix files.
     
@@ -116,6 +116,8 @@ def write_simpix(img, camera, flavor, night, expid, header=None):
         flavor : arc or flat
         night  : YEARMMDD string
         expid  : integer exposure id
+        header : dict-like object that should include FLAVOR and EXPTIME,
+            e.g. from HDU0 FITS header of input simspec file
         
     Writes to $DESI_SPECTRO_SIM/$PIXPROD/{night}/
         simpix-{camera}-{expid}.fits
@@ -155,12 +157,12 @@ def write_simpix(img, camera, flavor, night, expid, header=None):
     #- Primary HDU: noisy image
     outfile = '{}/pix-{}-{:08d}.fits'.format(outdir, camera, expid)
     hdulist = fits.HDUList()
+    if 'EXTNAME' in header:
+        del header['EXTNAME']
     hdu = fits.PrimaryHDU(pix, header=header)
     hdu.header.append( ('CAMERA', camera, 'Spectograph Camera') )
     hdu.header.append( ('VSPECTER', '0.0.0', 'TODO: Specter version') )
-    hdu.header.append( ('EXPTIME', params['exptime'], 'Exposure time [sec]') )
     hdu.header.append( ('RDNOISE', rdnoise, 'Read noise [electrons]'))
-    hdu.header.append( ('FLAVOR', flavor, 'Exposure type (arc, flat, science)'))
     hdulist.append(hdu)
 
     #- IVAR: Inverse variance (IVAR)
@@ -292,7 +294,6 @@ def read_templates(wave, objtype, nspec=None, randseed=1, infile=None):
     outflux = pool.map(_resample_flux, args)        
         
     return outflux, outmeta
-    
     
 
 #-------------------------------------------------------------------------

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -165,7 +165,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
     desispec.io.write_fibermap(fiberfile, fibermap, header=hdr)
     print fiberfile
     
-    #- Write simfile
+    #- Write simspec
     hdr = dict(
         AIRMASS=(airmass, 'Airmass at middle of exposure'),
         EXPTIME=(exptime, 'Exposure time [sec]'),

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -96,10 +96,18 @@ def simulate(night, expid, camera, nspec=None, verbose=False, ncpu=None, trimxy=
         # hdr['CRVAL1'] = xmin+1
         # hdr['CRVAL2'] = ymin+1
 
-    #- Add noise and write output files
+    #- Prepare header
+    hdr = fits.getheader(simfile, 0)
     tmp = '/'.join(simfile.split('/')[-3:])  #- last 3 elements of path
     hdr['SIMFILE'] = (tmp, 'Input simulation file')
-    pixfile = io.write_simpix(img, camera, 'science', night, expid, header=hdr)
+
+    #- Strip unnecessary keywords
+    for key in ('EXTNAME', 'LOGLAM', 'AIRORVAC', 'CRVAL1', 'CDELT1'):
+        if key in hdr:
+            del hdr[key]
+
+    #- Add noise and write output files
+    pixfile = io.write_simpix(img, camera, night, expid, header=hdr)
 
     if verbose:
         print "Wrote "+pixfile

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -51,7 +51,8 @@ def simulate(night, expid, camera, nspec=None, verbose=False, ncpu=None, trimxy=
     nfibers = params['spectro']['nfibers']
 
     #- Check that this camera has simulated spectra
-    hdr = fits.getheader(simfile, 'PHOT_'+channel)
+    fx = fits.open(simfile)
+    hdr = fx['PHOT_'+channel].header
     nspec_in = hdr['NAXIS2']
     if ispec*nfibers >= nspec_in:
         print "ERROR: camera {} not in the {} spectra in {}/{}".format(
@@ -59,15 +60,11 @@ def simulate(night, expid, camera, nspec=None, verbose=False, ncpu=None, trimxy=
         return
 
     #- Load input photon data
-    phot = fits.getdata(simfile, 'PHOT_'+channel)
-    try:
-        phot += fits.getdata(simfile, 'SKYPHOT_'+channel)
-    except KeyError:
-        pass  #- arcs and flats don't have SKYPHOT
-    
-    nwave = phot.shape[1]
-    wave = hdr['CRVAL1'] + np.arange(nwave)*hdr['CDELT1']
-    
+    phot = fx['PHOT_'+channel].data
+    wave = fx['WAVE_'+channel].data
+    if 'SKYPHOT_'+channel in fx:
+        phot += fx['SKYPHOT_'+channel].data
+
     #- Load PSF
     psf = desimodel.io.load_psf(channel)
 
@@ -97,7 +94,7 @@ def simulate(night, expid, camera, nspec=None, verbose=False, ncpu=None, trimxy=
         # hdr['CRVAL2'] = ymin+1
 
     #- Prepare header
-    hdr = fits.getheader(simfile, 0)
+    hdr = fx[0].header
     tmp = '/'.join(simfile.split('/')[-3:])  #- last 3 elements of path
     hdr['SIMFILE'] = (tmp, 'Input simulation file')
 
@@ -108,6 +105,8 @@ def simulate(night, expid, camera, nspec=None, verbose=False, ncpu=None, trimxy=
 
     #- Add noise and write output files
     pixfile = io.write_simpix(img, camera, night, expid, header=hdr)
+
+    fx.close()
 
     if verbose:
         print "Wrote "+pixfile


### PR DESCRIPTION
This pull request implements several cleanup items:

* separate the creation of a new exposure from the pixel-level simulation of putting those photons onto a CCD.  Previously pixsim-desi did both, creating confusion since you had to run "pixsim-desi" as the starting point for later non-pixsim operations.
* fix header keyword bugs in propagating FLAVOR and EXPTIME
* fix wavelength bug in simspec files for arc exposures with a non-uniform wavelength grid.  Now the wavelength is kept as dedicated arrays in separate HDUs instead of just CRVAL1 and CDELT1 (which can't handle non-uniform grids)

There is more cleanup that could be done (e.g. desisim doesn't follow the guidelines of clearly separating I/O from algorithms), but these 3 changes are a reasonable set to merge in now before doing other cleanup.