### PR TITLE
options updates: redefine --nspec, add --arms and --spectrographs opt…

### DIFF
--- a/bin/pixsim-desi
+++ b/bin/pixsim-desi
@@ -37,11 +37,13 @@ parser = optparse.OptionParser(
 parser.add_option("--night", type=str, help="YEARMMDD")
 parser.add_option("--expid", type=int, help="exposure id")
 ### parser.add_option("--simfile", type=str, help="input sim file")
-parser.add_option("--camera", type=str, help="camera (e.g. b0, r5, z9)")
+parser.add_option("--cameras", type=str, help="cameras, e.g. b0,r5,z9")
+parser.add_option("--spectrographs", type=str, help="spectrograph numbers, e.g. 0,1,9", default='0')
+parser.add_option("--arms", type=str, help="spectrograph arms, e.g. b,r,z", default='b,r,z')
 parser.add_option("--verbose", action="store_true", help="print more stuff")
 parser.add_option("--trimxy", action="store_true", help="Trim image to fit spectra")
 parser.add_option("--randseed", type=int, help="random number seed")
-parser.add_option("--nspec", type=int, help="Number of spectra to simulate [%default]", default=500)
+parser.add_option("--nspec", type=int, help="Number of spectra to simulate per camera [%default]", default=500)
 parser.add_option("--ncpu",  type=int, help="Number of cpu cores to use [%default]", default=multiprocessing.cpu_count() // 2)
 
 opts, args = parser.parse_args()
@@ -56,25 +58,26 @@ if not envOK:
     print "Set those environment variable(s) and then try again"
     sys.exit(1)
 
-if opts.camera is None:
-    opts.camera = list()
-    for arm in ['b', 'r', 'z']:
-        for ispec in range((opts.nspec-1)//500 + 1):
-            opts.camera.append(arm+str(ispec))
+if opts.nspec > 500:
+    raise ValueError, "--nspec {}>500 is not allowed".format(opts.nspec)
+
+#- develop camera list
+if opts.cameras is None:
+    opts.cameras = list()
+    opts.spectrograph = [int(x) for x in opts.spectrographs.split(',')]
+    for arm in opts.arms.split(','):
+        for ispec in opts.spectrograph:
+            opts.cameras.append(arm+str(ispec))
 else:
-    opts.camera = opts.camera.split(',')
+    opts.cameras = opts.cameras.split(',')
 
 random.seed(opts.randseed)
 np.random.seed(opts.randseed)
 
-for camera in opts.camera:
-    #- opts.nspec is total; calc how many spectra to simulate on this camera
-    spectrograph = int(camera[-1])
-    nspec = min(opts.nspec - spectrograph*500, 500)
-
+for camera in opts.cameras:
     #- Simulate
     pixsim.simulate(opts.night, opts.expid, camera, verbose=opts.verbose,
-        nspec=nspec, ncpu=opts.ncpu, trimxy=opts.trimxy)
+        nspec=opts.nspec, ncpu=opts.ncpu, trimxy=opts.trimxy)
 
 #-------------------------------------------------------------------------
 # if opts.debug:


### PR DESCRIPTION
previous --nspec implementation didn't work when no including spectrograph 0.  Redoing options again.  now you can specify spectrographs, arms, or individual cameras.  --nspec option is now spectra per camera, not total number of spectra.