### PR TITLE
Header keywords

### DIFF
--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -391,6 +391,9 @@ def get_tile_radec(tileid):
     If tileid is not in DESI, return (0.0, 0.0)
     TODO: should it raise and exception instead?
     """
+    if not isinstance(tileid, (int, np.int64, np.int32, np.int16)):
+        raise ValueError('tileid should be an int, not {}'.format(type(tileid)))
+
     tiles = desimodel.io.load_tiles()
     if tileid in tiles['TILEID']:
         i = np.where(tiles['TILEID'] == tileid)[0][0]

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -161,16 +161,16 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
         TELRA = (telera, 'Telescope pointing RA [degrees]'),
         TELDEC = (teledec, 'Telescope pointing dec [degrees]'),
         )
+    #- ISO 8601 DATE-OBS year-mm-ddThh:mm:ss
     fiberfile = desispec.io.findfile('fibermap', night, expid)
     desispec.io.write_fibermap(fiberfile, fibermap, header=hdr)
     print fiberfile
     
-    #- Write simspec
-    hdr = dict(
-        AIRMASS=(airmass, 'Airmass at middle of exposure'),
-        EXPTIME=(exptime, 'Exposure time [sec]'),
-        FLAVOR=(flavor, 'exposure flavor [arc, flat, science]'),
-        )
+    #- Write simspec; expand fibermap header
+    hdr['AIRMASS'] = (airmass, 'Airmass at middle of exposure')
+    hdr['EXPTIME'] = (exptime, 'Exposure time [sec]')
+    hdr['DATE-OBS'] = (time.strftime('%FT%T', dateobs), 'Start of exposure')
+
     simfile = io.write_simspec(meta, truth, expid, night, header=hdr)
     print simfile
 

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -173,11 +173,12 @@ def _project(args):
         img = psf.project(wave, phot, specmin=specmin, xyrange=xyrange)
         return (xyrange, img)
     except Exception, e:
-        import traceback
-        print '-'*60
-        print 'ERROR in _project', psf.wmin, psf.wmax, wave[0], wave[-1], phot.shape, specmin
-        traceback.print_exc()
-        print '-'*60
+        if os.getenv('UNITTEST_SILENT') is None:
+            import traceback
+            print '-'*60
+            print 'ERROR in _project', psf.wmin, psf.wmax, wave[0], wave[-1], phot.shape, specmin
+            traceback.print_exc()
+            print '-'*60
         raise e
 
 #- Move this into specter itself?

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -133,13 +133,17 @@ def simulate(night, expid, camera, nspec=None, verbose=False, ncpu=None,
     fm, fmhdr = desispec.io.read_fibermap(fibermapfile, header=True)
     meta = dict()
     try:
-        meta['TELRA']  = fmhdr['TELRA']
-        meta['TELDEC'] = fmhdr['TELDEC']
+        meta['TELRA']  = simspec.header['TELRA']
+        meta['TELDEC'] = simspec.header['TELDEC']
     except KeyError:  #- temporary backwards compatibilty
         meta['TELRA']  = fmhdr['TELERA']
         meta['TELDEC'] = fmhdr['TELEDEC']
         
-    meta['TILEID'] = fmhdr['TILEID']
+    meta['TILEID'] = simspec.header['TILEID']
+    meta['DATE-OBS'] = simspec.header['DATE-OBS']
+    meta['FLAVOR'] = simspec.header['FLAVOR']
+    meta['EXPTIME'] = simspec.header['EXPTIME']
+    meta['AIRMASS'] = simspec.header['AIRMASS']
 
     image = Image(pix, ivar, mask, readnoise=readnoise, camera=camera, meta=meta)
     pixfile = desispec.io.findfile('pix', night=night, camera=camera, expid=expid)

--- a/py/desisim/test/test_io.py
+++ b/py/desisim/test/test_io.py
@@ -87,8 +87,8 @@ class TestIO(unittest.TestCase):
         ra, dec = io.get_tile_radec(2)
         ra, dec = io.get_tile_radec(-1)
         self.assertTrue( (ra,dec) == (0.0, 0.0) )
-        ra, dec = io.get_tile_radec('blat')
-        self.assertTrue( (ra,dec) == (0.0, 0.0) )
+        with self.assertRaises(ValueError):
+            ra, dec = io.get_tile_radec('blat')
         
     def test_resize(self):
         image = np.random.uniform(size=(4,5))

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -84,11 +84,12 @@ class TestPixsim(unittest.TestCase):
         args = psf, wave, phot, specmin
         xyrange, pix = pixsim._project(args)
 
-        print("\nINFO This is supposed to raise a ValueError; don't panic")
         with self.assertRaises(ValueError):
             phot = np.ones((2,3,4))
             args = psf, wave, phot, specmin
+            os.environ['UNITTEST_SILENT'] = 'TRUE'
             xyrange, pix = pixsim._project(args)
+            del os.environ['UNITTEST_SILENT']
         
         
 #- This runs all test* functions in any TestCase class in this file


### PR DESCRIPTION
This addresses issue #19 by adding missing header keywords to the pix*.fits files: AIRMASS, EXPTIME, DATE-OBS, FLAVOR.  The keywords TELRA, TELDEC, and TILEID are propagated through the simspec file rather than the fibermap file, since the final real fibermap file may not have those.

Other items:
  * get_tile_radec(tileid) now raises an exception if tileid isn't an integer
  * quieter pixsim test of a case that was supposed to raise an error (details, if you care: exceptions that happen within a multiprocessing parallel processes can be obfuscated by the multiprocessing wrapper.  So _project was forcing a printout of any exceptions before passing it up the chain.  But when testing a case that is supposed to raise an exception, this was causing scary messages making it look like the tests had failed even though they were actually doing the right thing.)