### PR TITLE
add support for generating white dwarf and QSO templates

### DIFF
--- a/bin/simulate-templates
+++ b/bin/simulate-templates
@@ -64,11 +64,17 @@ def main():
     elg_parser.add_argument('--minoiiflux', type=float, default='1E-17', metavar='',
                             help='Minimum integrated [OII] 3727 flux')
     
-    star_parser = parser.add_argument_group('options for objtype=FSTD')
-    star_parser.add_argument('--vrad-fstd', type=float, default=(0,200), nargs=2, metavar='', 
+    fstd_parser = parser.add_argument_group('options for objtype=FSTD')
+    fstd_parser.add_argument('--vrad-fstd', type=float, default=(0,200), nargs=2, metavar='', 
                              help='mean and sigma radial velocity Gaussian prior (km/s)')
-    star_parser.add_argument('--rmagrange-fstd', type=float, default=(16.0,19.0), nargs=2, metavar='',
+    fstd_parser.add_argument('--rmagrange-fstd', type=float, default=(16.0,19.0), nargs=2, metavar='',
                             help='Minimum and maximum r-band (AB) magnitude range')
+
+    wd_parser = parser.add_argument_group('options for objtype=WD')
+    wd_parser.add_argument('--vrad-wd', type=float, default=(0,200), nargs=2, metavar='', 
+                             help='mean and sigma radial velocity Gaussian prior (km/s)')
+    wd_parser.add_argument('--gmagrange-wd', type=float, default=(16.0,19.0), nargs=2, metavar='',
+                            help='Minimum and maximum g-band (AB) magnitude range')
 
     lrg_parser = parser.add_argument_group('options for objtype=LRG')
     lrg_parser.add_argument('--zrange-lrg', type=float, default=(0.5,1.1), nargs=2, metavar='', 
@@ -141,14 +147,20 @@ def main():
         elif objtype == 'QSO':
             log.warning('{} objtype not yet supported!'.format(objtype))
             sys.exit(1)
-        elif objtype == 'STAR' or objtype == 'FSTD':
+        elif objtype == 'STAR' or objtype == 'FSTD' or objtype == 'WD':
             from desisim.templates import STAR
             FSTD = objtype=='FSTD'
+            WD = objtype=='WD'
             star = STAR(nmodel=args.nmodel,minwave=args.minwave,maxwave=args.maxwave,
-                        cdelt=args.cdelt,seed=args.seed,FSTD=FSTD)
+                        cdelt=args.cdelt,seed=args.seed,FSTD=FSTD,WD=WD)
             if FSTD: # simulate an F-standard
                 flux, meta = star.make_templates(vrad_meansig=args.vrad_fstd,
                                                  rmagrange=args.rmagrange_fstd,
+                                                 outfile=outfile,
+                                                 header_comments=header_comments)
+            elif WD: # simulate a white dwarf
+                flux, meta = star.make_templates(vrad_meansig=args.vrad_wd,
+                                                 gmagrange=args.gmagrange_wd,
                                                  outfile=outfile,
                                                  header_comments=header_comments)
             else: # simulate a normal star

--- a/bin/simulate-templates
+++ b/bin/simulate-templates
@@ -140,13 +140,16 @@ def main():
             from desisim.templates import LRG
             lrg = LRG(nmodel=args.nmodel,minwave=args.minwave,maxwave=args.maxwave,
                       cdelt=args.cdelt,seed=args.seed)
-            flux, meta = lrg.make_templates(zrange=args.zrange_lrg,
-                                            zmagrange=args.zmagrange_lrg,
-                                            outfile=outfile,
-                                            no_colorcuts=args.no_colorcuts)
+            flux, wave, meta = lrg.make_templates(zrange=args.zrange_lrg,
+                                                  zmagrange=args.zmagrange_lrg,
+                                                  no_colorcuts=args.no_colorcuts)
+            log.info('Writing {}'.format(outfile))
+            write_templates(outfile, flux, wave, meta, objtype)
+
         elif objtype == 'QSO':
             log.warning('{} objtype not yet supported!'.format(objtype))
             sys.exit(1)
+
         elif objtype == 'STAR' or objtype == 'FSTD' or objtype == 'WD':
             from desisim.templates import STAR
             FSTD = objtype=='FSTD'
@@ -154,17 +157,17 @@ def main():
             star = STAR(nmodel=args.nmodel,minwave=args.minwave,maxwave=args.maxwave,
                         cdelt=args.cdelt,seed=args.seed,FSTD=FSTD,WD=WD)
             if FSTD: # simulate an F-standard
-                flux, meta = star.make_templates(vrad_meansig=args.vrad_fstd,
-                                                 rmagrange=args.rmagrange_fstd,
-                                                 outfile=outfile)
+                flux, wave, meta = star.make_templates(vrad_meansig=args.vrad_fstd,
+                                                       rmagrange=args.rmagrange_fstd)
             elif WD: # simulate a white dwarf
-                flux, meta = star.make_templates(vrad_meansig=args.vrad_wd,
-                                                 gmagrange=args.gmagrange_wd,
-                                                 outfile=outfile)
+                flux, wave, meta = star.make_templates(vrad_meansig=args.vrad_wd,
+                                                       gmagrange=args.gmagrange_wd)
             else: # simulate a normal star
-                flux, meta = star.make_templates(vrad_meansig=args.vrad_star,
-                                                 rmagrange=args.rmagrange_star,
-                                                 outfile=outfile)
+                flux, wave, meta = star.make_templates(vrad_meansig=args.vrad_star,
+                                                       rmagrange=args.rmagrange_star)
+            log.info('Writing {}'.format(outfile))
+            write_templates(outfile, flux, wave, meta, objtype)
+
         else:
             log.warning('Object type {} not recognized'.format(objtype))
             sys.exit(1)

--- a/bin/simulate-templates
+++ b/bin/simulate-templates
@@ -70,23 +70,29 @@ def main():
     fstd_parser.add_argument('--rmagrange-fstd', type=float, default=(16.0,19.0), nargs=2, metavar='',
                             help='Minimum and maximum r-band (AB) magnitude range')
 
-    wd_parser = parser.add_argument_group('options for objtype=WD')
-    wd_parser.add_argument('--vrad-wd', type=float, default=(0,200), nargs=2, metavar='', 
-                             help='mean and sigma radial velocity Gaussian prior (km/s)')
-    wd_parser.add_argument('--gmagrange-wd', type=float, default=(16.0,19.0), nargs=2, metavar='',
-                            help='Minimum and maximum g-band (AB) magnitude range')
-
     lrg_parser = parser.add_argument_group('options for objtype=LRG')
     lrg_parser.add_argument('--zrange-lrg', type=float, default=(0.5,1.1), nargs=2, metavar='', 
                             help='minimum and maximum redshift')
     lrg_parser.add_argument('--zmagrange-lrg', type=float, default=(19.0,20.5), nargs=2, metavar='',
                             help='Minimum and maximum z-band (AB) magnitude range')
     
+    qso_parser = parser.add_argument_group('options for objtype=QSO')
+    qso_parser.add_argument('--zrange-qso', type=float, default=(0.5,4.0), nargs=2, metavar='', 
+                            help='minimum and maximum redshift')
+    qso_parser.add_argument('--gmagrange-qso', type=float, default=(21.0,23.0), nargs=2, metavar='',
+                            help='Minimum and maximum g-band (AB) magnitude range')
+    
     star_parser = parser.add_argument_group('options for objtype=STAR')
     star_parser.add_argument('--vrad-star', type=float, default=(0,200), nargs=2, metavar='', 
                              help='mean and sigma radial velocity Gaussian prior (km/s)')
     star_parser.add_argument('--rmagrange-star', type=float, default=(18,23.5), nargs=2, metavar='',
                             help='Minimum and maximum r-band (AB) magnitude range')
+
+    wd_parser = parser.add_argument_group('options for objtype=WD')
+    wd_parser.add_argument('--vrad-wd', type=float, default=(0,200), nargs=2, metavar='', 
+                             help='mean and sigma radial velocity Gaussian prior (km/s)')
+    wd_parser.add_argument('--gmagrange-wd', type=float, default=(16.0,19.0), nargs=2, metavar='',
+                            help='Minimum and maximum g-band (AB) magnitude range')
 
     args = parser.parse_args()
     if args.nmodel is None:
@@ -125,6 +131,7 @@ def main():
         if objtype == 'BGS':
             log.warning('{} objtype not yet supported!'.format(objtype))
             sys.exit(1)
+
         elif objtype == 'ELG':
             from desisim.templates import ELG
             elg = ELG(nmodel=args.nmodel,minwave=args.minwave,maxwave=args.maxwave,
@@ -147,8 +154,14 @@ def main():
             write_templates(outfile, flux, wave, meta, objtype)
 
         elif objtype == 'QSO':
-            log.warning('{} objtype not yet supported!'.format(objtype))
-            sys.exit(1)
+            from desisim.templates import QSO
+            qso = QSO(nmodel=args.nmodel,minwave=args.minwave,maxwave=args.maxwave,
+                      cdelt=args.cdelt,seed=args.seed)
+            flux, wave, meta = qso.make_templates(zrange=args.zrange_qso,
+                                                  gmagrange=args.gmagrange_qso,
+                                                  no_colorcuts=args.no_colorcuts)
+            log.info('Writing {}'.format(outfile))
+            write_templates(outfile, flux, wave, meta, objtype)
 
         elif objtype == 'STAR' or objtype == 'FSTD' or objtype == 'WD':
             from desisim.templates import STAR

--- a/bin/simulate-templates
+++ b/bin/simulate-templates
@@ -13,7 +13,7 @@ import os
 import sys
 import argparse
 
-from desispec.io.util import makepath
+from desisim.io import write_templates
 from desispec.log import get_logger
 
 def main():
@@ -115,10 +115,10 @@ def main():
     
     log.info('Building {} {} templates.'.format(args.nmodel, objtype))
 
-    # Pack the optional inputs into a dictionary to be added to the output FITS
-    # header.
-    #cmd = " ".join(sys.argv)
-    header_comments = vars(args)
+    # Possible pack the optional inputs into a dictionary to be added to the
+    # output FITS header.
+    # cmd = " ".join(sys.argv)
+    # header_comments = vars(args)
 
     # Call the right Class depending on the object type.
     if not args.no_templates:
@@ -129,12 +129,13 @@ def main():
             from desisim.templates import ELG
             elg = ELG(nmodel=args.nmodel,minwave=args.minwave,maxwave=args.maxwave,
                       cdelt=args.cdelt,seed=args.seed)
-            flux, meta = elg.make_templates(zrange=args.zrange_elg,
-                                            rmagrange=args.rmagrange_elg,
-                                            minoiiflux=args.minoiiflux,
-                                            outfile=outfile,
-                                            no_colorcuts=args.no_colorcuts,
-                                            header_comments=header_comments)
+            flux, wave, meta = elg.make_templates(zrange=args.zrange_elg,
+                                                  rmagrange=args.rmagrange_elg,
+                                                  minoiiflux=args.minoiiflux,
+                                                  no_colorcuts=args.no_colorcuts)
+            log.info('Writing {}'.format(outfile))
+            write_templates(outfile, flux, wave, meta, objtype)
+
         elif objtype == 'LRG':
             from desisim.templates import LRG
             lrg = LRG(nmodel=args.nmodel,minwave=args.minwave,maxwave=args.maxwave,
@@ -142,8 +143,7 @@ def main():
             flux, meta = lrg.make_templates(zrange=args.zrange_lrg,
                                             zmagrange=args.zmagrange_lrg,
                                             outfile=outfile,
-                                            no_colorcuts=args.no_colorcuts,
-                                            header_comments=header_comments)
+                                            no_colorcuts=args.no_colorcuts)
         elif objtype == 'QSO':
             log.warning('{} objtype not yet supported!'.format(objtype))
             sys.exit(1)
@@ -156,18 +156,15 @@ def main():
             if FSTD: # simulate an F-standard
                 flux, meta = star.make_templates(vrad_meansig=args.vrad_fstd,
                                                  rmagrange=args.rmagrange_fstd,
-                                                 outfile=outfile,
-                                                 header_comments=header_comments)
+                                                 outfile=outfile)
             elif WD: # simulate a white dwarf
                 flux, meta = star.make_templates(vrad_meansig=args.vrad_wd,
                                                  gmagrange=args.gmagrange_wd,
-                                                 outfile=outfile,
-                                                 header_comments=header_comments)
+                                                 outfile=outfile)
             else: # simulate a normal star
                 flux, meta = star.make_templates(vrad_meansig=args.vrad_star,
                                                  rmagrange=args.rmagrange_star,
-                                                 outfile=outfile,
-                                                 header_comments=header_comments)
+                                                 outfile=outfile)
         else:
             log.warning('Object type {} not recognized'.format(objtype))
             sys.exit(1)

--- a/doc/tex/simulate-templates/simulate-templates.tex
+++ b/doc/tex/simulate-templates/simulate-templates.tex
@@ -6,17 +6,29 @@
 \usepackage{natbib}
 %%\usepackage{emulateapj}
 %\usepackage{footnote}
+\usepackage{floatrow}
+\floatsetup[table]{capposition=top}
 \usepackage{deluxetable}
+
+\newcommand{\ha}{H\ensuremath{\alpha}}
+\newcommand{\hb}{H\ensuremath{\beta}}
+\newcommand{\heli}{He~{\sc i}~\ensuremath{\lambda4471}}
+\newcommand{\hei}{He~{\sc i}}
+\newcommand{\hii}{H~{\sc ii}}
 
 \newcommand{\oii}{[O~{\sc ii}]}
 \newcommand{\oiii}{[O~{\sc iii}]}
 \newcommand{\nii}{[N~{\sc ii}]}
 \newcommand{\sii}{[N~{\sc ii}]}
-\newcommand{\hei}{He~{\sc i}}
-\newcommand{\simt}{{\tt simulate-templates.py}}
+\newcommand{\simt}{{\tt simulate-templates}}
 \newcommand{\ewoii}{EW([O~{\sc ii}])}
 
+\newcommand{\niilam}{[N~{\sc ii}]~\ensuremath{\lambda\lambda6548,84}}
+\newcommand{\siilam}{[S~{\sc ii}]~\ensuremath{\lambda\lambda6716,32}}
 \newcommand{\oiilam}{[O~{\sc ii}]~\ensuremath{\lambda\lambda3726,29}}
+\newcommand{\oiiilam}{[O~{\sc iii}]~\ensuremath{\lambda\lambda4959,5007}}
+\newcommand{\neonlam}{[Ne~{\sc iii}]~\ensuremath{\lambda3869}}
+
 \newcommand{\ewoiilam}{EW([O~{\sc ii}]~\ensuremath{\lambda\lambda3726,29})}
 
 \newcommand{\kms}{km~s$^{-1}$}
@@ -29,7 +41,10 @@
 \newcommand{\TODO}[1]{{\it \color{red} (#1)}}
 
 \begin{document}
-\title{Simulating State-of-the-Art Spectral Templates for DESI} 
+\title{Simulating State-of-the-Art Spectral Templates \\ for DESI} 
+
+%{\bf TODO: Write a test script which ensures everything has been properly
+%  installed/configured.}
 
 \author{John Moustakas (Siena College)}
 \maketitle
@@ -42,9 +57,10 @@
 This document describes the methodology and code which was developed to generate
 one-dimensional, noiseless, high-resolution spectral templates for DESI.  The
 initial focus of this effort has been on emission-line galaxies (ELG), luminous
-red galaxies (LRG), bright-galaxy survey galaxies (BGS), and stars (STAR), but
-eventually quasars (QSO), including Ly$\alpha$-QSOs (QSO$\alpha$), and standard
-stars (STD) will be supported.
+red galaxies (LRG), (normal) stars (STAR), including F-type standard stars
+(FSTD), and white dwarfs (WD), but eventually bright-galaxy survey galaxies
+(BGS), quasars (QSO), including Ly$\alpha$-QSOs (QSO$\alpha$), and other
+spectral types will be supported.
 
 The spectral templates are constructed using a combination of empirical
 constraints (e.g., spectroscopy and photometry of galaxies and quasars over a
@@ -60,27 +76,28 @@ repository {\tt
   desihub/desisim}\footnote{\url{https://github.com/desihub/desisim}} under the
 {\tt py/desisim} and {\tt doc/tex/simulate-templates} directories, respectively.
 
-Finally, everything all the code has been developed on {\tt Github} in {\tt
-  Python} using the same coding standards adopted by the {\tt DESI-Data} team,
-such that other members of the collaboration can contribute to its future
-development.   Lots of qaplots get written out and DESI color cuts are
-optionally written out!
+%Finally, everything all the code has been developed on {\tt Github} in {\tt
+%  Python} using the same coding standards adopted by the {\tt DESI-Data} team,
+%such that other members of the collaboration can contribute to its future
+%development.   Lots of qaplots get written out and DESI color cuts are
+%optionally written out!
 
 \section{Getting Started Quickly}
 
 This section presents several high-level examples so that you can get started
-building templates quickly.  To install the software and its dependencies please
-see Appendix~\ref{sec:install}.
+building templates quickly.  Before you try these examples please see
+Appendix~\ref{sec:install} for instructions on how to install the software and
+its dependencies.
 
 The only mandatory input required by \simt{} is to specify the number of
-templates/models via the {\tt nmodel} input and, optionally, the object type
-(although the default is {\tt ELG}); the code is initialized with sensible
-defaults for all the other optional inputs.  The following sections demonstrate
-how to build templates for a few different object types.
+templates via the {\tt nmodel} input and, optionally, the object type (although
+the default is {\tt ELG}); the code is initialized with sensible defaults for
+all the other optional inputs.  The following sections demonstrate how to build
+templates for a few different object types.
 
 \subsection{Example: ELGs}
 
-To generate 100 {\tt ELG} spectra 
+To generate 20 {\tt ELG} spectra with the default parameters type:
 
 \begin{verbatim}
 simulate-templates.py --nmodel 100 --objtype ELG
@@ -90,7 +107,7 @@ simulate-templates.py --nmodel 100 --objtype ELG
 
 Give some examples.
 
-\section{The Details}
+\section{Implementation Details}
 
 The following sections describe each specific DESI spectral class in more
 detail, as well as various planned (and unplanned) avenues for improving the
@@ -98,14 +115,53 @@ models.
 
 %\section{Building a Realistic Emission-Line Spectrum}
 
-\subsection{ELGs}
+\subsection{Emission Line Galaxies (ELGs)}
 
-\subsubsection{Preliminary Templates}\label{elg:prelim}
+\subsubsection{Background}
+
+ELGs are characterized by nebular emission lines superposed on an underlying
+stellar continuum.  The stellar continuum is typically blue, dominated by hot,
+newly formed stars, although emission lines can be found in galaxies with more
+evolved (i.e., older) stellar populations as well.  A nebular emission-line
+spectrum consists of hydrogen and helium recombination lines (e.g., \ha, \hb,
+\heli), as well as numerous forbidden metal-line transitions from singly and
+doubly ionized oxygen (\oiilam{} and \oiiilam), nitrogen (\niilam), neon
+(\neonlam), sulfur (\siilam), among many others.  The strengths of these lines
+relative to \hb{} (or to one another) depends on the physical conditions (metal
+abundance, ionizing radiation field, dust content, etc.) in the star-forming
+\hii{} regions, and on the portion of the integrated light of the galaxy
+captured by the spectroscopic observations.\footnote{This latter distinction is
+  important because galaxies exhibit radial gradients in many of these
+  properties, such as gas-phase abundance, leading to what is known as {\em
+    aperture bias}.}  The absolute strength of an emission line is characterized
+by its equivalent width, which is roughly given by the integrated line-flux
+divided by the underlying stellar continuum flux.
 
 A preliminary set of $7876$ ELG templates for DESI were developed in late-2014
 using high-resolution spectroscopy and broadband photometry of galaxies from the
 DEEP2 survey (see {\tt
   DESI-doc-870}).\footnote{\url{https://desi.lbl.gov/DocDB/cgi-bin/private/RetrieveFile?docid=870;filename=elg-templates.pdf;version=1}}
+The current ELG templates build upon these templates but add significantly more
+flexibility in how the nebular emission-line spectrum for each template is
+constructed, as well as how that spectrum is linked to the underlying stellar
+continuum spectrum.
+
+\subsubsection{Methodology}
+
+Generating templates for ELGs is challenging because the emission-line spectrum
+of a galaxy cannot be constructed using theoretical models (i.e., from first
+principles).\footnote{While photoionization models do exist, galaxies---and in
+  particular the integrated spectra of galaxies---are too complex to model
+  adequately using these models.}  Moreover, although they are often correlated,
+the emission-line and stellar continuum spectra of a galaxy can exhibit large
+variations due to stochastic star formation histories among star-forming
+galaxies and differential dust attenuation effects.  Consequently, we have
+developed an empirical approach for generating templates for ELGs.
+
+
+
+
+
 Briefly, these templates were constructed by selecting a statistically complete
 sample of DEEP2 galaxies at $z=0.75-1.45$ with $r_{\rm CFHTLS}<23.5$, a
 well-measured \oiilam{} emission-line doublet, and at least six bands of optical
@@ -126,12 +182,7 @@ were combined into the \emph{preliminary} ELG templates described in {\tt
 
 %intermediate-resolution ($\mathcal{R}\approx2200$) 
 
-\subsubsection{Improved Templates}
-
-Here, we build on the preliminary templates described in \S\ref{elg:prelim} in
-several key ways.  First, we add significantly more flexibility in how the
-nebular emission-line spectrum is constructed, as well as how that spectrum is
-linked to the underlying stellar continuum spectrum.  The method we use is
+The method we use is
 empirically calibrated using observed emission-line sequences and emission-line
 equivalent width measurements of galaxies at $z=0-2$, ensuring that the ELG
 templates exhibit the same range and variation in dust content, gas-phase
@@ -281,23 +332,28 @@ two extensions:
 }
 \end{enumerate}
 
-\subsection{Luminous Red Galaxy (LRG) Templates} 
+\subsection{Luminous Red Galaxies (LRGs)}
 
 LRGs
 
 
-\subsection{Bright-Galaxy Survey (BGS) Templates} 
+\subsection{Normal Stars (STAR)}
 
-BGS.
+Talk about stuff.
 
+\subsection{F-Type Standard Stars (FSTD)}
 
-\subsection{Quasar (QSO) Templates }
+\subsection{White Dwarfs (WD)}
 
+Stuff.
 
-\subsection{Stellar Templates (STAR)}
+\subsection{Bright-Galaxy Survey Galaxies (BGS)}
 
+BGS.  Not yet supported.
 
-\subsection{Standard Stars (STD)}
+\subsection{Quasars (QSO)}
+
+Lyman-alpha quasars.
 
 \subsection{Future Improvements}
 
@@ -329,6 +385,29 @@ order):
 
 \section{Installation Instructions}\label{sec:install}
 
+\subsection{Basis Templates}
+
+The template-generating code relies on a set of basis templates for each
+spectral class.  The latest basis templates are kept at {\tt NERSC} under the
+{\tt \$DESI\_ROOT/spectro/templates} top-level directory.  The latest version of
+each template file must be downloaded to your local machine, or the code must be
+run exclusively at {\tt NERSC}.
+
+Environment variables must be set to point to the latest version of each set of
+basis templates.  For example, on {\tt NERSC} (as of the date of this document)
+you would define the following environment variables in your {\tt .bashrc.ext}
+startup file:
+\begin{itemize*}
+  \item[\%]{{\tt DESI\_ROOT=/project/projectdirs/desi}}
+  \item[\%]{{\tt DESI\_TEMPLATES=\$DESI\_ROOT/spectro/templates}}
+  \item[\%]{{\tt DESI\_ELG\_TEMPLATES=\$DESI\_TEMPLATES/elg\_templates/v1.3/elg\_templates\_v1.3.fits}}
+  \item[\%]{{\tt DESI\_LRG\_TEMPLATES=\$DESI\_TEMPLATES/lrg\_templates/v1.1/lrg\_templates\_v1.1.fits}}
+  \item[\%]{{\tt DESI\_STAR\_TEMPLATES=\$DESI\_TEMPLATES/star\_templates/v1.1/star\_templates\_v1.1.fits}}
+  \item[\%]{{\tt DESI\_WD\_TEMPLATES=\$DESI\_TEMPLATES/wd\_templates/v1.0/wd\_templates\_v1.0.fits}}
+\end{itemize*}
+
+\subsection{Code}
+
 First, be sure you have recent installations of the {\tt astropy} (needed to
 manipulate FITS files), {\tt numpy} (numerical Python library), and {\tt
   matplotlib} (plotting library) packages, or install (or upgrade) them using
@@ -339,108 +418,87 @@ manipulate FITS files), {\tt numpy} (numerical Python library), and {\tt
   \item[\%]{{\tt pip install astropy [--upgrade]}}
 \end{itemize*}
 
-\noindent Next, clone the {\tt desihub/desisim}, {\tt desihub/desispec}, and
-          {\tt desihub/imaginglss} repositories:
+\noindent Next, clone the {\tt desihub/desisim} and {\tt desihub/desispec}
+repositories.  For example:
 \begin{itemize*}
   \item[\%]{{\tt mkdir desihub ; cd desihub}}
   \item[\%]{{\tt git clone https://github.com/desihub/desisim.git}}
   \item[\%]{{\tt git clone https://github.com/desihub/desispec.git}}
-  \item[\%]{{\tt git clone https://github.com/desihub/imaginglss.git}}
 \end{itemize*}
 
 \noindent The {\tt desispec} package is needed for the standardized set of I/O
 routines which have been written for reading and writing DESI spectra (and the
-associated metadata), while the {\tt imaginglss} package contains the DESI
-target-selection algorithms.\footnote{Note that the target-selection criteria
-  coded in {\tt imaginglss} eventually may be moved to the {\tt desitarget}
-  product.}  Next, add these packages to your {\tt PYTHONPATH} environment.  For
-example, in the {\tt bash} shell add the following lines to your {\tt .bashrc}
-file:
+associated metadata).  Next, add these packages to your {\tt PYTHONPATH}
+environment.  For example, in the {\tt bash} shell add the following lines to
+your {\tt .bashrc} file:
 \begin{itemize*}
   \item[\%]{{\tt DESIHUB=/path/to/desihub}}
   \item[\%]{{\tt
-      PYTHONPATH=\$DESIHUB/desisim/py:\$DESIHUB/desispec/py:\$DESIHUB/imaginglss}}
+      PYTHONPATH=\$DESIHUB/desisim/py:\$DESIHUB/desispec/py}}
 \end{itemize*}
 
 \noindent If you wish, create an alias which points to the top-level executable
-script, {\tt simulate-templates.py}:
+script, \simt:
 \begin{itemize*}
-  \item[\%]{{\tt alias simulate-templates \$DESIHUB/desisim/bin/simulate-templates.py}}
+  \item[\%]{{\tt alias \simt{} \$DESIHUB/desisim/bin/\simt}}
 \end{itemize*}
 
-\noindent Finally, create environment variables which point to the latest set of
-continuum (basis) spectra for each object type.  For example, on {\tt NERSC} you
-would define the following variables in your {\tt .bashrc} startup file:
-\begin{itemize*}
-  \item[\%]{{\tt DESI\_ROOT=/project/projectdirs/desi}}
-  \item[\%]{{\tt DESI\_TEMPLATES=\$DESI\_ROOT/spectro/templates}}
-  \item[\%]{{\tt DESI\_ELG\_TEMPLATES=\$DESI\_TEMPLATES/elg\_templates/v1.3/elg\_templates\_v1.3.fits}}
-  \item[\%]{{\tt DESI\_LRG\_TEMPLATES=\$DESI\_TEMPLATES/lrg\_templates/v1.1/lrg\_templates\_v1.1.fits}}
-  \item[\%]{{\tt DESI\_BGS\_TEMPLATES=\$DESI\_TEMPLATES/bgs\_templates/v1.1/bgs\_templates\_v1.0.fits}}
-  \item[\%]{{\tt DESI\_STAR\_TEMPLATES=\$DESI\_TEMPLATES/star\_templates/v1.1/star\_templates\_v1.1.fits}}
-\end{itemize*}
+%Random seed can be specified.
 
-\noindent Alternatively, you can transfer these binary FITS files to your local
-machine or laptop and put them wherever you would like.  \noindent {\bf TODO:
-  Write a test script which ensures everything has been properly
-  installed/configured.}
-
-Random seed can be specified.
+To check that the code is installed and in your path try running the following
+command, which should print the \emph{help} file for the code.
 
 \begin{verbatim}
-
-usage: simulate-templates.py [-h] [--nmodel] [--objtype] [--minwave]
-                             [--maxwave] [--cdelt] [--nocolorcuts]
-                             [--notemplates] [--noplot] [--outfile] [--qafile]
-                             [--zrange-elg ] [--rmagrange-elg ] [--minoiiflux]
-                             [--zrange-lrg ] [--zmagrange-lrg ]
-                             [--zrange-bgs ] [--rmagrange-bgs ]
-
-Simulate noiseless, infinite-resolution spectral templates for DESI.
-
-optional arguments:
-  -h, --help         show this help message and exit
-  --nmodel           number of model (template) spectra to generate (required
-                     input) (default: None)
-  --objtype          object type (ELG, LRG, QSO, BGS, STD, or STAR) (default:
-                     ELG)
-  --minwave          minimum output wavelength range [Angstrom] (default:
-                     3600)
-  --maxwave          maximum output wavelength range [Angstrom] (default:
-                     10000)
-  --cdelt            dispersion of output wavelength array [Angstrom/pixel]
-                     (default: 2)
-  --nocolorcuts      do not apply color cuts to select objects (only used for
-                     object types ELG, LRG, and QSO) (default: False)
-  --notemplates      do not generate templates (but do generate the diagnostic
-                     plots if OUTFILE exists) (default: False)
-  --noplot           do not generate diagnostic (QA) plots (default: False)
-  --outfile          output FITS file name (default: OBJTYPE-templates.fits)
-  --qafile           output file name for the diagnostic (QA) plots (default:
-                     OBJTYPE-templates.pdf)
-
-options for objtype=ELG:
-  --zrange-elg       minimum and maximum redshift (default: (0.6, 1.6))
-  --rmagrange-elg    Minimum and maximum r-band (AB) magnitude range (default:
-                     (21.0, 23.5))
-  --minoiiflux       Minimum integrated [OII] 3727 flux (default: 1E-17)
-
-options for objtype=LRG:
-  --zrange-lrg       minimum and maximum redshift (default: (0.5, 1.1))
-  --zmagrange-lrg    Minimum and maximum z-band (AB) magnitude range (default:
-                     (19.5, 20.6))
-
-options for objtype=BGS:
-  --zrange-bgs       minimum and maximum redshift (default: (0.01, 0.4))
-  --rmagrange-bgs    Minimum and maximum r-band (AB) magnitude range (default:
-                     (15.0, 19.0))
-
+% simulate-templates -h
 \end{verbatim}
 
+%\begin{verbatim}
+%\end{verbatim}
 
+\clearpage
 \section{Tables of Nebular Emission Lines}
 
-The following appendices do stuff.
+The following tables summarize the forbidden (Table~\ref{table:forb}) and
+hydrogen recombination (Table~\ref{table:recomb}) lines included in the
+emission-line spectrum class.  Additional lines may be added in the future. 
+
+%\begin{center}
+%\begin{table}[h!]
+%\begin{tabular}{cc}
+%\hline
+%\hline
+%Emission Line & Vacuum Wavelength (\AA) \\
+%\hline
+% \oii~$\lambda3726$ & 3727.092 \\
+% \oii~$\lambda3729$ & 3729.874 \\
+%\oiii~$\lambda5007$ & 5008.239 \\
+%\oiii~$\lambda4959$ & 4960.295 \\
+% \nii~$\lambda6584$ & 6585.277 \\
+% \nii~$\lambda6548$ & 6549.852 \\
+% \sii~$\lambda6716$ & 6718.294 \\
+% \sii~$\lambda6731$ & 6732.673 \\
+%\hline
+%\end{tabular}
+%\caption{Stuff}
+%\end{table}
+%\end{center}
+
+\begin{deluxetable}{cc}
+\tablecaption{Nebular forbidden lines\label{table:forb}}
+\tablewidth{0pt}
+\tablehead{\colhead{Emission Line} & \colhead{Vacuum Wavelength (\AA)}}
+\startdata
+ \oii~$\lambda3726$ & 3727.092 \\
+ \oii~$\lambda3729$ & 3729.874 \\
+\oiii~$\lambda5007$ & 5008.239 \\
+\oiii~$\lambda4959$ & 4960.295 \\
+ \nii~$\lambda6584$ & 6585.277 \\
+ \nii~$\lambda6548$ & 6549.852 \\
+ \sii~$\lambda6716$ & 6718.294 \\
+ \sii~$\lambda6731$ & 6732.673
+\enddata
+\end{deluxetable}
+
 
 \begin{deluxetable}{ccc}
 \tablecaption{Nebular recombination lines\label{table:recomb}} 
@@ -495,22 +553,6 @@ Pa$\epsilon$ & 9548.591 &  0.03656680 \\
 \hei~$\lambda10830$ & 10833.22 &   0.2404832
 \enddata
 \tablenotetext{a}{Ratio with respect to H$\beta$ assuming case~B recombination.} 
-\end{deluxetable}
-
-\begin{deluxetable}{cc}
-\tablecaption{Nebular forbidden lines\label{table:forb}}
-\tablewidth{0pt}
-\tablehead{\colhead{Emission Line} & \colhead{Vacuum Wavelength (\AA)}}
-\startdata
- \oii~$\lambda3726$ & 3727.092 \\
- \oii~$\lambda3729$ & 3729.874 \\
-\oiii~$\lambda5007$ & 5008.239 \\
-\oiii~$\lambda4959$ & 4960.295 \\
- \nii~$\lambda6584$ & 6585.277 \\
- \nii~$\lambda6548$ & 6549.852 \\
- \sii~$\lambda6716$ & 6718.294 \\
- \sii~$\lambda6731$ & 6732.673
-\enddata
 \end{deluxetable}
 
 \end{document}

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -573,6 +573,7 @@ def write_templates(outfile, flux, wave, meta, objtype=None,
         Raises
 
     """
+    from astropy.io import fits
     from desispec.io.util import fitsheader, write_bintable, makepath
 
     # Create the path to OUTFILE if necessary.
@@ -590,8 +591,9 @@ def write_templates(outfile, flux, wave, meta, objtype=None,
         )
     hdr = fitsheader(header)
 
+    fits.writeto(outfile,flux.astype(np.float32),header=hdr,clobber=True)
     write_bintable(outfile, meta, header=hdr, comments=comments,
-                   units=units, extname='METADATA', clobber=True)
+                   units=units, extname='METADATA')
 
 
 #-------------------------------------------------------------------------

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -17,6 +17,9 @@ import desimodel.io
 from desispec.image import Image
 import desispec.io.util
 
+from desispec.log import get_logger
+log = get_logger()
+
 #-------------------------------------------------------------------------
 def findfile(filetype, night, expid, camera=None, outdir=None, mkdir=True):
     """
@@ -558,16 +561,22 @@ def read_base_templates(objtype='ELG', observed=False, emlines=False):
 
     return flux, wave, meta
 
-def write_templates(flux, wave, meta, objtype, outfile=None, comments=None,
-                    units=None, header_comments=None):
+def write_templates(outfile, flux, wave, meta, objtype=None,
+                    comments=None, units=None):
     """Write out simulated galaxy templates.  (Incomplete documentation...)
 
-    """
-    from astropy.io import fits
-    from desispec.io import util
+        Args:
+          outfile (str): Output file name.
     
-    if outfile is None:
-        pass
+        Returns:
+    
+        Raises
+
+    """
+    from desispec.io.util import fitsheader, write_bintable, makepath
+
+    # Create the path to OUTFILE if necessary.
+    outfile = makepath(outfile)
     
     header = dict(
         OBJTYPE = (objtype, 'Object type'),
@@ -579,17 +588,10 @@ def write_templates(flux, wave, meta, objtype, outfile=None, comments=None,
         AIRORVAC = ('vac', 'wavelengths in vacuum (vac) or air'),
         BUNIT = ('erg/s/cm2/A', 'spectrum flux units')
         )
-    hdr = util.fitsheader(header)
+    hdr = fitsheader(header)
 
-    if header_comments is None:
-        header_comments = dict()
-    #for key in header_comments.keys():
-    #    hdr[key] = header_comments[key]
-    fits.writeto(outfile,flux.astype(np.float32),header=hdr,clobber=True)
-
-    log.info('Writing {}'.format(outfile))
-    util.write_bintable(outfile, meta, header=None, extname='METADATA',
-                        comments=comments, units=units)
+    write_bintable(outfile, meta, header=hdr, comments=comments,
+                   units=units, extname='METADATA', clobber=True)
 
 
 #-------------------------------------------------------------------------

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -131,7 +131,7 @@ class ELG():
     def make_templates(self, zrange=(0.6,1.6), rmagrange=(21.0,23.5),
                        oiiihbrange=(-0.5,0.1), oiidoublet_meansig=(0.73,0.05),
                        linesigma_meansig=(1.887,0.175), minoiiflux=1E-17,
-                       no_colorcuts=False, header_comments=None, outfile=None):
+                       no_colorcuts=False):
         """Build Monte Carlo set of ELG spectra/templates.
 
         This function chooses random subsets of the ELG continuum spectra, constructs
@@ -160,9 +160,6 @@ class ELG():
           no_colorcuts (bool, optional): Do not apply the fiducial grz color-cuts
             cuts (default False).
         
-          outfile (str, optional): Write the template spectra (with header information) and
-            the corresponding meta-data table to this file (default None).
-
         Returns:
           outflux (numpy.ndarray): Array [nmodel,npix] of observed-frame spectra [erg/s/cm2/A]. 
           meta (astropy.Table): Table of meta-data for each output spectrum [nmodel].
@@ -173,7 +170,6 @@ class ELG():
         from astropy.table import Table, Column
 
         from desisim.templates import EMSpectrum
-        from desisim.io import write_templates
         from desispec.interpolation import resample_flux
 
         # Initialize the EMSpectrum object with the same wavelength array as
@@ -196,6 +192,26 @@ class ELG():
         meta['OIIDOUBLET'] = Column(np.zeros(self.nmodel,dtype='f4'))
         meta['LINESIGMA'] = Column(np.zeros(self.nmodel,dtype='f4'))
         meta['D4000'] = Column(np.zeros(self.nmodel,dtype='f4'))
+
+        meta['OIIFLUX'].unit = 'erg/s/cm2'
+        meta['EWOII'].unit = 'Angstrom'
+        meta['OIIIHBETA'].unit = 'dex'
+        meta['LINESIGMA'].unit = 'km/s'
+
+        comments = dict(
+            TEMPLATEID = 'template ID',
+            REDSHIFT = 'object redshift',
+            GMAG = 'DECam g-band AB magnitude',
+            RMAG = 'DECam r-band AB magnitude',
+            ZMAG = 'DECam z-band AB magnitude',
+            W1MAG = 'WISE W1-band AB magnitude',
+            OIIFLUX = '[OII] 3727 flux',
+            EWOII = 'rest-frame equivalenth width of [OII] 3727',
+            OIIIHBETA = 'logarithmic [OIII] 5007/H-beta ratio',
+            OIIDOUBLET = '[OII] 3726/3729 doublet ratio',
+            LINESIGMA = 'emission line velocity width',
+            D4000 = '4000-Angstrom break',
+        )
 
         nobj = 0
         nbase = len(self.basemeta)
@@ -274,36 +290,7 @@ class ELG():
                 if nobj>=(self.nmodel-1):
                     break
 
-        # Optionally write out and then return.  There's probably a smarter way
-        # to do this with astropy Tables...
-        if outfile is not None:
-            comments = dict(
-                TEMPLATEID = 'template ID',
-                REDSHIFT = 'object redshift',
-                GMAG = 'DECam g-band AB magnitude',
-                RMAG = 'DECam r-band AB magnitude',
-                ZMAG = 'DECam z-band AB magnitude',
-                W1MAG = 'WISE W1-band AB magnitude',
-                OIIFLUX = '[OII] 3727 flux',
-                EWOII = 'rest-frame equivalenth width of [OII] 3727',
-                OIIIHBETA = 'logarithmic [OIII] 5007/H-beta ratio',
-                OIIDOUBLET = '[OII] 3726/3729 doublet ratio',
-                LINESIGMA = 'emission line velocity width',
-                D4000 = '4000-Angstrom break',
-            )
-    
-            units = dict(
-                OIIFLUX = 'erg/s/cm2',
-                EWOII = 'Angstrom',
-                OIIIHBETA = 'dex',
-                LINESIGMA = 'km/s',
-            )
-            
-            write_templates(outflux, self.wave, meta, self.objtype, outfile=outfile,
-                            comments=comments, units=units,
-                            header_comments=header_comments)
-
-        return outflux, meta
+        return outflux, self.wave, meta
 
 class EMSpectrum():
     """Construct a complete nebular emission-line spectrum.
@@ -585,7 +572,7 @@ class LRG():
         self.w1filt = filt(filtername='wise_w1.txt')
 
     def make_templates(self, zrange=(0.5,1.1), zmagrange=(19.0,20.5),
-                       no_colorcuts=False, header_comments=None, outfile=None):
+                       no_colorcuts=False, outfile=None):
         """Build Monte Carlo set of LRG spectra/templates.
 
         This function chooses random subsets of the LRG continuum spectra and
@@ -701,8 +688,7 @@ class LRG():
             )
             
             write_templates(outflux, self.wave, meta, self.objtype,
-                            outfile=outfile, comments=comments, units=units,
-                            header_comments=header_comments)
+                            outfile=outfile, comments=comments, units=units)
 
         return outflux, meta
 
@@ -775,7 +761,7 @@ class STAR():
         self.zfilt = filt(filtername='decam_z.txt')
 
     def make_templates(self, vrad_meansig=(0.0,200.0), rmagrange=(18.0,23.5),
-                       gmagrange=(16.0,19.0), header_comments=None, outfile=None):
+                       gmagrange=(16.0,19.0), outfile=None):
         """Build Monte Carlo set of spectra/templates for stars. 
 
         This function chooses random subsets of the continuum spectra for stars,
@@ -925,7 +911,6 @@ class STAR():
             )
             
             write_templates(outflux, self.wave, meta, self.objtype, outfile=outfile,
-                            comments=comments, units=units,
-                            header_comments=header_comments)
+                            comments=comments, units=units)
 
         return outflux, meta

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -105,7 +105,7 @@ class ELG():
 
         """
         from desisim.filterfunc import filterfunc as filt
-        from desisim.templates import read_base_templates
+        from desisim.io import read_base_templates
 
         self.objtype = 'ELG'
         self.nmodel = nmodel
@@ -173,6 +173,7 @@ class ELG():
         from astropy.table import Table, Column
 
         from desisim.templates import EMSpectrum
+        from desisim.io import write_templates
         from desispec.interpolation import resample_flux
 
         # Initialize the EMSpectrum object with the same wavelength array as
@@ -560,7 +561,7 @@ class LRG():
 
         """
         from desisim.filterfunc import filterfunc as filt
-        from desisim.templates import read_base_templates
+        from desisim.io import read_base_templates
 
         self.objtype = 'LRG'
         self.nmodel = nmodel
@@ -613,6 +614,7 @@ class LRG():
         from astropy.table import Table, Column
 
         from desisim.templates import EMSpectrum
+        from desisim.io import write_templates
         from desispec.interpolation import resample_flux
 
         # Initialize the output flux array and metadata Table.
@@ -745,7 +747,7 @@ class STAR():
 
         """
         from desisim.filterfunc import filterfunc as filt
-        from desisim.templates import read_base_templates
+        from desisim.io import read_base_templates
 
         if FSTD:
             self.objtype = 'FSTD'
@@ -800,6 +802,7 @@ class STAR():
 
         """
         from astropy.table import Table, Column
+        from desisim.io import write_templates
         from desispec.interpolation import resample_flux
 
         # Initialize the output flux array and metadata Table.
@@ -926,98 +929,3 @@ class STAR():
                             header_comments=header_comments)
 
         return outflux, meta
-
-def read_base_templates(objtype='ELG', observed=False, emlines=False):
-    """Return the base, rest-frame, spectral continuum templates for each objtype.
-
-    The appropriate environment variable must be set depending on OBJTYPE.  For example,
-    DESI_ELG_TEMPLATES, DESI_LRG_TEMPLATES, etc., otherwise an exception will be raised.
-
-    Args:
-      objtype (str, optional): object type to read (ELG, LRG, QSO, BGS, STD, or STAR;
-        defaults to 'ELG').
-      observed (bool): Read the observed-frame templates (defaults to False).
-      emlines (bool): Read the spectral templates which include emission lines (defaults
-        to False; only applies to object types ELG and BGS).
-
-    Returns:
-      flux (numpy.ndarray): Array [ntemplate,npix] of flux values [erg/s/cm2/A].
-      wave (numpy.ndarray): Array [npix] of wavelengths for FLUX [Angstrom].
-      meta (astropy.Table): Meta-data table for each object.  The contents of this
-        table varies depending on what OBJTYPE has been read.
-
-    Raises:
-      EnvironmentError: If the appropriate environment variable is not set.
-      IOError: If the base templates are not found.
-    
-    """
-    from astropy.io import fits
-    from astropy.table import Table
-    from desispec.io.util import header2wave
-
-    otype = objtype.upper()
-    if otype=='FSTD':
-        otype = 'STAR'
-
-    key = 'DESI_'+otype+'_TEMPLATES'
-    if key not in os.environ:
-        log.error('Required ${} environment variable not set'.format(key))
-        raise EnvironmentError
-
-    objfile = os.getenv(key)
-
-    # Handle special cases for the ELG & BGS templates.
-    if otype=='ELG' or otype=='BGS':
-        if observed:
-            objfile = objfile.replace('templates_','templates_obs_')
-        elif emlines is not True:
-            objfile = objfile.replace('templates_','continuum_templates_')
-
-    if os.path.isfile(objfile):
-        log.info('Reading {}'.format(objfile))
-    else: 
-        log.error('Base templates file {} not found'.format(objfile))
-        raise IOError()
-
-    flux, hdr = fits.getdata(objfile, 0, header=True)
-    meta = Table(fits.getdata(objfile, 1))
-    wave = header2wave(hdr)
-
-    return flux, wave, meta
-
-def write_templates(flux, wave, meta, objtype, outfile=None, comments=None,
-                    units=None, header_comments=None):
-    """Write out simulated galaxy templates.
-
-    Incomplete documentation.  Should this go in the desisim.io module, or is
-    there a better way to write these spectra?
-
-    """
-    from astropy.io import fits
-    from desispec.io import util
-    
-    if outfile is None:
-        pass
-    
-    header = dict(
-        OBJTYPE = (objtype, 'Object type'),
-        CUNIT = ('Angstrom', 'units of wavelength array'),
-        CRPIX1 = (1, 'reference pixel number'),
-        CRVAL1 = (wave[0], 'Starting wavelength [Angstrom]'),
-        CDELT1 = (wave[1]-wave[0], 'Wavelength step [Angstrom]'),
-        LOGLAM = (0, 'linear wavelength steps, not log10'),
-        AIRORVAC = ('vac', 'wavelengths in vacuum (vac) or air'),
-        BUNIT = ('erg/s/cm2/A', 'spectrum flux units')
-        )
-    hdr = util.fitsheader(header)
-
-    if header_comments is None:
-        header_comments = dict()
-    #for key in header_comments.keys():
-    #    hdr[key] = header_comments[key]
-    fits.writeto(outfile,flux.astype(np.float32),header=hdr,clobber=True)
-
-    log.info('Writing {}'.format(outfile))
-    util.write_bintable(outfile, meta, header=None, extname='METADATA',
-                        comments=comments, units=units)
-


### PR DESCRIPTION
Dedicated templates for white dwarfs can now be generated.  For example, to generate 100 templates with g-band magnitudes in the range [16,19] and no radial velocity jitter do:
```
simulate-templates -o WD -n 100 --gmagrange-wd 16 19 --vrad-wd 0 0
```
Note that you first need to set the DESI_WD_TEMPLATES environment variable and to grab the corresponding "basis" templates from NERSC, e.g.,
```
export DESI_WD_TEMPLATES  ${DESI_ROOT}/spectro/templates/wd_templates/v1.0/wd_templates_v1.0.fits 
```

These templates are based on the theoretical DA white dwarf models built by Carlos Allende Prieto spanning a range of Teff [20,000-65,000 K] and log-g [7.0-9.5 cm/s] at high spectral resolution from 0.2-2.5 micron.

The I/O routines in desisim.templates were also moved to desisim.io.

Proper documentation for these templates plus optional QA plots on output are still forthcoming...