### PR TITLE
newexp-desi integrated with templates generated on-the-fly

### DIFF
--- a/bin/newexp-desi
+++ b/bin/newexp-desi
@@ -40,12 +40,12 @@ opts, args = parser.parse_args()
 
 #- Check environment
 envOK = True
-for envvar in ('DESIMODEL', 'PIXPROD', 'DESI_SPECTRO_SIM'):
+for envvar in ('DESIMODEL', 'PIXPROD', 'PRODNAME', 'DESI_SPECTRO_SIM'):
     if envvar not in os.environ:
         log.fatal("${} is required".format(envvar))
         envOK = False
 if not envOK:
-    print "Set those environment variable(s) and then try again"
+    print('Set those environment variable(s) and then try again.')
     sys.exit(1)
 
 #- Initialize tileid

--- a/bin/simulate-templates
+++ b/bin/simulate-templates
@@ -59,7 +59,7 @@ def main():
     elg_parser = parser.add_argument_group('options for objtype=ELG')
     elg_parser.add_argument('--zrange-elg', type=float, default=(0.6,1.6), nargs=2, metavar='', 
                             dest='zrange_elg', help='minimum and maximum redshift')
-    elg_parser.add_argument('--rmagrange-elg', type=float, default=(21.0,23.5), nargs=2, metavar='',
+    elg_parser.add_argument('--rmagrange-elg', type=float, default=(21.0,23.4), nargs=2, metavar='',
                             dest='rmagrange_elg', help='Minimum and maximum r-band (AB) magnitude range')
     elg_parser.add_argument('--minoiiflux', type=float, default='1E-17', metavar='',
                             help='Minimum integrated [OII] 3727 flux')
@@ -85,7 +85,7 @@ def main():
     star_parser = parser.add_argument_group('options for objtype=STAR')
     star_parser.add_argument('--vrad-star', type=float, default=(0,200), nargs=2, metavar='', 
                              help='mean and sigma radial velocity Gaussian prior (km/s)')
-    star_parser.add_argument('--rmagrange-star', type=float, default=(18,23.5), nargs=2, metavar='',
+    star_parser.add_argument('--rmagrange-star', type=float, default=(18,23.4), nargs=2, metavar='',
                             help='Minimum and maximum r-band (AB) magnitude range')
 
     wd_parser = parser.add_argument_group('options for objtype=WD')

--- a/etc/desisim.module
+++ b/etc/desisim.module
@@ -42,8 +42,8 @@ module-whatis "Sets up $product/$version in your environment."
 # A mandatory dependency is a module load command followed by a prereq
 # command.  An optional dependency is not followed by a prereq statement.
 #
-module load desiUtil
-prereq desiUtil
+module load desiutil
+prereq desiutil
 #
 # ENVIRONMENT SECTION
 #
@@ -75,4 +75,5 @@ setenv [string toupper $product] $PRODUCT_DIR
 {needs_idl}prepend-path IDL_PATH +$PRODUCT_DIR/pro
 #
 # Add any non-standard Module code below this point.
-#
+
+setenv DESI_BASIS_TEMPLATES $env(DESI_ROOT)/spectro/templates/basis_templates/v1.0

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -152,14 +152,15 @@ def write_simspec(meta, truth, expid, night, header=None, outfile=None):
             OBJTYPE     = 'Object type (ELG, LRG, QSO, STD, STAR)',
             REDSHIFT    = 'true object redshift',
             TEMPLATEID  = 'input template ID',
-            O2FLUX      = '[OII] flux [erg/s/cm2]',
+            OIIFLUX     = '[OII] flux [erg/s/cm2]',
+            D4000       = '4000-A break'
         )
     
         units = dict(
             # OBJTYPE     = 'Object type (ELG, LRG, QSO, STD, STAR)',
             # REDSHIFT    = 'true object redshift',
             # TEMPLATEID  = 'input template ID',
-            O2FLUX      = 'erg/s/cm2',
+            OIIFLUX      = 'erg/s/cm2',
         )
     
         write_bintable(outfile, meta, header=None, extname="METADATA",
@@ -591,6 +592,8 @@ def read_basis_templates(objtype='ELG'):
     objpath = os.getenv(key)
 
     ltype = objtype.lower()
+    if objtype == 'FSTD':
+        ltype = 'star'
     objfile = glob(os.path.join(objpath,ltype+'_templates_*.fits'))[0]
 
     if os.path.isfile(objfile):

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -411,6 +411,7 @@ def get_tile_radec(tileid):
 def _resample_flux(args):
     return resample_flux(*args)
 
+# This function may now be obsolete.
 def read_templates(wave, objtype, nspec=None, randseed=1, infile=None):
     """
     Returns n templates of type objtype sampled at wave

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -140,6 +140,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
             'OBJTYPE',
             'REDSHIFT',
             'TEMPLATEID',
+            'D4000',
             'OIIFLUX',
         )
         meta = {key: truth[key] for key in columns}
@@ -172,7 +173,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
     hdr['DATE-OBS'] = (time.strftime('%FT%T', dateobs), 'Start of exposure')
 
     simfile = io.write_simspec(meta, truth, expid, night, header=hdr)
-    print simfile
+    print(simfile)
 
     #- Update obslog that we succeeded with this exposure
     update_obslog(flavor, expid, dateobs, tileid)

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -140,7 +140,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
             'OBJTYPE',
             'REDSHIFT',
             'TEMPLATEID',
-            'O2FLUX',
+            'OIIFLUX',
         )
         meta = {key: truth[key] for key in columns}
         

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -115,6 +115,7 @@ def get_targets(nspec, tileid=None):
     truth['REDSHIFT'] = np.zeros(nspec, dtype='f4')
     truth['TEMPLATEID'] = np.zeros(nspec, dtype='i4')
     truth['OIIFLUX'] = np.zeros(nspec, dtype='f4')
+    truth['D4000'] = np.zeros(nspec, dtype='f4')
     truth['OBJTYPE'] = np.zeros(nspec, dtype='S10')
     #- Note: unlike other elements, first index of WAVE isn't spectrum index
     truth['WAVE'] = wave
@@ -171,10 +172,13 @@ def get_targets(nspec, tileid=None):
         fibermap['MAG'][ii, 0:3] = np.vstack( [magg, magr, magz] ).T
         fibermap['FILTER'][ii, 0:3] = ['DECAM_G', 'DECAM_R', 'DECAM_Z']
 
-        #- Only ELGs have [OII] flux
         if objtype == 'ELG':
             truth['OIIFLUX'][ii] = meta['OIIFLUX']
+            truth['D4000'][ii] = meta['D4000']
         
+        if objtype == 'LRG':
+            truth['D4000'][ii] = meta['D4000']
+            
     #- Load fiber -> positioner mapping and tile information
     fiberpos = desimodel.io.load_fiberpos()
 

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -215,7 +215,7 @@ class ELG():
             OIIIHBETA = 'logarithmic [OIII] 5007/H-beta ratio',
             OIIDOUBLET = '[OII] 3726/3729 doublet ratio',
             LINESIGMA = 'emission line velocity width',
-            D4000 = '4000-Angstrom break',
+            D4000 = '4000-Angstrom break'
         )
 
         nobj = 0
@@ -620,6 +620,7 @@ class LRG():
         meta['W1MAG'] = Column(np.zeros(self.nmodel,dtype='f4'))
         meta['ZMETAL'] = Column(np.zeros(self.nmodel,dtype='f4'))
         meta['AGE'] = Column(np.zeros(self.nmodel,dtype='f4'))
+        meta['D4000'] = Column(np.zeros(self.nmodel,dtype='f4'))
 
         meta['AGE'].unit = 'Gyr'
 
@@ -631,7 +632,8 @@ class LRG():
             ZMAG = 'DECam z-band AB magnitude',
             W1MAG = 'WISE W1-band AB magnitude',
             ZMETAL = 'stellar metallicity',
-            AGE = 'time since the onset of star formation'
+            AGE = 'time since the onset of star formation',
+            D4000 = '4000-Angstrom break'
         )
 
         nobj = 0
@@ -679,6 +681,7 @@ class LRG():
                     meta['W1MAG'][nobj] = -2.5*np.log10(w1flux)+22.5
                     meta['ZMETAL'][nobj] = self.basemeta['ZMETAL'][iobj]
                     meta['AGE'][nobj] = self.basemeta['AGE'][iobj]
+                    meta['D4000'][nobj] = self.basemeta['AGE'][iobj]
 
                     nobj = nobj+1
 

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -8,6 +8,7 @@ Functions to simulate spectral templates for DESI.
 from __future__ import division, print_function
 
 import os
+import sys
 import numpy as np
 
 from desispec.log import get_logger
@@ -106,7 +107,7 @@ class ELG():
 
         """
         from desisim.filterfunc import filterfunc as filt
-        from desisim.io import read_base_templates
+        from desisim.io import read_basis_templates
 
         self.objtype = 'ELG'
         self.nmodel = nmodel
@@ -121,7 +122,7 @@ class ELG():
         self.wave = wave
 
         # Read the rest-frame continuum basis spectra.
-        baseflux, basewave, basemeta = read_base_templates(objtype=self.objtype)
+        baseflux, basewave, basemeta = read_basis_templates(objtype=self.objtype)
         self.baseflux = baseflux
         self.basewave = basewave
         self.basemeta = basemeta
@@ -132,7 +133,7 @@ class ELG():
         self.zfilt = filt(filtername='decam_z.txt')
         self.w1filt = filt(filtername='wise_w1.txt')
 
-    def make_templates(self, zrange=(0.6,1.6), rmagrange=(21.0,23.5),
+    def make_templates(self, zrange=(0.6,1.6), rmagrange=(21.0,23.4),
                        oiiihbrange=(-0.5,0.1), oiidoublet_meansig=(0.73,0.05),
                        linesigma_meansig=(1.887,0.175), minoiiflux=1E-17,
                        no_colorcuts=False):
@@ -148,7 +149,7 @@ class ELG():
           zrange (float, optional): Minimum and maximum redshift range.  Defaults
             to a uniform distribution between (0.6,1.6).
           rmagrange (float, optional): Minimum and maximum DECam r-band (AB)
-            magnitude range.  Defaults to a uniform distribution between (21,23.5).
+            magnitude range.  Defaults to a uniform distribution between (21,23.4).
           oiiihbrange (float, optional): Minimum and maximum logarithmic
             [OIII] 5007/H-beta line-ratio.  Defaults to a uniform distribution
             between (-0.5,0.1).
@@ -270,9 +271,9 @@ class ELG():
                 else:
                     grzmask = [Cuts.ELG(gflux=gflux,rflux=rflux,zflux=zflux)]
 
-                # Not sure why this print statement doesn't work!
-                #print('Building model {}/{}'.format(nobj,self.nmodel-1),end='\r')
                 if all(grzmask) and all(oiimask):
+                    if ((nobj+1)%10)==0:
+                        print('Simulating {} template {}/{}'.format(self.objtype,nobj+1,self.nmodel))
                     outflux[nobj,:] = resample_flux(self.wave,zwave,flux)
 
                     meta['TEMPLATEID'][nobj] = nobj
@@ -553,7 +554,7 @@ class LRG():
 
         """
         from desisim.filterfunc import filterfunc as filt
-        from desisim.io import read_base_templates
+        from desisim.io import read_basis_templates
 
         self.objtype = 'LRG'
         self.nmodel = nmodel
@@ -568,7 +569,7 @@ class LRG():
         self.wave = wave
 
         # Read the rest-frame continuum basis spectra.
-        baseflux, basewave, basemeta = read_base_templates(objtype=self.objtype)
+        baseflux, basewave, basemeta = read_basis_templates(objtype=self.objtype)
         self.baseflux = baseflux
         self.basewave = basewave
         self.basemeta = basemeta
@@ -665,9 +666,9 @@ class LRG():
                 else:
                     rzW1mask = [Cuts.LRG(rflux=rflux,zflux=zflux,w1flux=w1flux)]
 
-                # Not sure why this print statement doesn't work!
-                #print('Building model {}/{}'.format(nobj,self.nmodel-1),end='\r')
                 if all(rzW1mask):
+                    if ((nobj+1)%10)==0:
+                        print('Simulating {} template {}/{}'.format(self.objtype,nobj+1,self.nmodel))
                     outflux[nobj,:] = resample_flux(self.wave,zwave,flux)
 
                     meta['TEMPLATEID'][nobj] = nobj
@@ -729,7 +730,7 @@ class STAR():
 
         """
         from desisim.filterfunc import filterfunc as filt
-        from desisim.io import read_base_templates
+        from desisim.io import read_basis_templates
 
         if FSTD:
             self.objtype = 'FSTD'
@@ -749,7 +750,7 @@ class STAR():
         self.wave = wave
 
         # Read the rest-frame continuum basis spectra.
-        baseflux, basewave, basemeta = read_base_templates(objtype=self.objtype)
+        baseflux, basewave, basemeta = read_basis_templates(objtype=self.objtype)
         self.baseflux = baseflux
         self.basewave = basewave
         self.basemeta = basemeta
@@ -759,7 +760,7 @@ class STAR():
         self.rfilt = filt(filtername='decam_r.txt')
         self.zfilt = filt(filtername='decam_z.txt')
 
-    def make_templates(self, vrad_meansig=(0.0,200.0), rmagrange=(18.0,23.5),
+    def make_templates(self, vrad_meansig=(0.0,200.0), rmagrange=(18.0,23.4),
                        gmagrange=(16.0,19.0)):
         """Build Monte Carlo set of spectra/templates for stars. 
 
@@ -773,7 +774,7 @@ class STAR():
             spectrum.  Defaults to a normal distribution with a mean of zero and
             sigma of 200 km/s.
           rmagrange (float, optional): Minimum and maximum DECam r-band (AB)
-            magnitude range.  Defaults to a uniform distribution between (18,23.5).
+            magnitude range.  Defaults to a uniform distribution between (18,23.4).
           gmagrange (float, optional): Minimum and maximum DECam g-band (AB)
             magnitude range.  Defaults to a uniform distribution between (16,19). 
 
@@ -875,6 +876,8 @@ class STAR():
                     grzmask = [True]
 
                 if all(grzmask):
+                    if ((nobj+1)%10)==0:
+                        print('Simulating {} template {}/{}'.format(self.objtype,nobj+1,self.nmodel))
                     outflux[nobj,:] = resample_flux(self.wave,zwave,flux)
 
                     if self.objtype=='WD':
@@ -948,7 +951,7 @@ class QSO():
 
         """
         from desisim.filterfunc import filterfunc as filt
-        from desisim.io import read_base_templates
+        from desisim.io import read_basis_templates
 
         self.objtype = 'QSO'
         self.nmodel = nmodel
@@ -963,7 +966,7 @@ class QSO():
         self.wave = wave
 
         # Read the basis spectra.
-        baseflux, basewave, basemeta = read_base_templates(objtype=self.objtype)
+        baseflux, basewave, basemeta = read_basis_templates(objtype=self.objtype)
         self.baseflux = baseflux
         self.basewave = basewave
         self.basemeta = basemeta
@@ -1066,9 +1069,9 @@ class QSO():
                 else:
                     grzW1W2mask = [True]
 
-                # Not sure why this print statement doesn't work!
-                #print('Building model {}/{}'.format(nobj,self.nmodel-1),end='\r')
                 if all(grzW1W2mask):
+                    if ((nobj+1)%10)==0:
+                        print('Simulating {} template {}/{}'.format(self.objtype,nobj+1,self.nmodel))
                     outflux[nobj,:] = resample_flux(self.wave,zwave,flux)
 
                     meta['TEMPLATEID'][nobj] = nobj

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -67,7 +67,7 @@ class ELG():
 
     """
     def __init__(self, nmodel=50, minwave=3600.0, maxwave=10000.0,
-                 cdelt=2.0, seed=None):
+                 cdelt=2.0, wave=None, seed=None):
         """Read the ELG basis continuum templates, grzW1 filter profiles and initialize
            the output wavelength array.
 
@@ -84,6 +84,8 @@ class ELG():
             array [default 10000 Angstrom].
           cdelt (float, optional): spacing of the output wavelength array
             [default 2 Angstrom/pixel].
+          wave (numpy.ndarray): Input/output observed-frame wavelength array,
+            overriding the minwave, maxwave, and cdelt arguments [Angstrom].
           seed (long, optional): input seed for the random numbers
     
         Attributes:
@@ -91,8 +93,7 @@ class ELG():
           nmodel (int): See Args.
           seed (long): See Args.
           rand (numpy.RandomState): instance of numpy.random.RandomState(seed)
-          wave (numpy.ndarray): Output wavelength array constructed from the input
-            wavelength arguments [Angstrom].
+          wave (numpy.ndarray): Output wavelength array [Angstrom].
           baseflux (numpy.ndarray): Array [nbase,npix] of the base rest-frame
             ELG continuum spectra [erg/s/cm2/A].
           basewave (numpy.ndarray): Array [npix] of rest-frame wavelengths 
@@ -112,9 +113,12 @@ class ELG():
         self.seed = seed
         self.rand = np.random.RandomState(seed=self.seed)
 
-        # Initialize the output wavelength array (linear spacing)
-        npix = (maxwave-minwave)/cdelt+1
-        self.wave = np.linspace(minwave,maxwave,npix) 
+        # Initialize the output wavelength array (linear spacing) unless it is
+        # already provided.
+        if wave is None:
+            npix = (maxwave-minwave)/cdelt+1
+            wave = np.linspace(minwave,maxwave,npix) 
+        self.wave = wave
 
         # Read the rest-frame continuum basis spectra.
         baseflux, basewave, basemeta = read_base_templates(objtype=self.objtype)
@@ -510,7 +514,7 @@ class LRG():
 
     """
     def __init__(self, nmodel=50, minwave=3600.0, maxwave=10000.0,
-                 cdelt=2.0, seed=None):
+                 cdelt=2.0, wave=None, seed=None):
         """Read the LRG basis continuum templates, grzW1 filter profiles and initialize
            the output wavelength array.
 
@@ -527,6 +531,8 @@ class LRG():
             array [default 10000 Angstrom].
           cdelt (float, optional): spacing of the output wavelength array
             [default 2 Angstrom/pixel].
+          wave (numpy.ndarray): Input/output observed-frame wavelength array,
+            overriding the minwave, maxwave, and cdelt arguments [Angstrom].
           seed (long, optional): input seed for the random numbers
     
         Attributes:
@@ -534,8 +540,7 @@ class LRG():
           nmodel (int): See Args.
           seed (long): See Args.
           rand (numpy.RandomState): instance of numpy.random.RandomState(seed)
-          wave (numpy.ndarray): Output wavelength array constructed from the input
-            wavelength arguments [Angstrom].
+          wave (numpy.ndarray): Output wavelength array [Angstrom].
           baseflux (numpy.ndarray): Array [nbase,npix] of the base rest-frame
             LRG continuum spectra [erg/s/cm2/A].
           basewave (numpy.ndarray): Array [npix] of rest-frame wavelengths 
@@ -555,9 +560,12 @@ class LRG():
         self.seed = seed
         self.rand = np.random.RandomState(seed=self.seed)
 
-        # Initialize the output wavelength array (linear spacing)
-        npix = (maxwave-minwave)/cdelt+1
-        self.wave = np.linspace(minwave,maxwave,npix) 
+        # Initialize the output wavelength array (linear spacing) unless it is
+        # already provided.
+        if wave is None:
+            npix = (maxwave-minwave)/cdelt+1
+            wave = np.linspace(minwave,maxwave,npix) 
+        self.wave = wave
 
         # Read the rest-frame continuum basis spectra.
         baseflux, basewave, basemeta = read_base_templates(objtype=self.objtype)
@@ -685,7 +693,7 @@ class STAR():
 
     """
     def __init__(self, nmodel=50, minwave=3600.0, maxwave=10000.0,
-                 cdelt=2.0, seed=None, FSTD=False, WD=False):
+                 cdelt=2.0, wave=None, seed=None, FSTD=False, WD=False):
         """Read the stellar basis continuum templates, grzW1 filter profiles and
            initialize the output wavelength array.
 
@@ -700,6 +708,8 @@ class STAR():
             array [default 10000 Angstrom].
           cdelt (float, optional): spacing of the output wavelength array
             [default 2 Angstrom/pixel].
+          wave (numpy.ndarray): Input/output observed-frame wavelength array,
+            overriding the minwave, maxwave, and cdelt arguments [Angstrom].
           seed (long, optional): input seed for the random numbers
     
         Attributes:
@@ -707,8 +717,7 @@ class STAR():
           nmodel (int): See Args.
           seed (long): See Args.
           rand (numpy.RandomState): instance of numpy.random.RandomState(seed)
-          wave (numpy.ndarray): Output wavelength array constructed from the input
-            wavelength arguments [Angstrom].
+          wave (numpy.ndarray): Output wavelength array [Angstrom].
           baseflux (numpy.ndarray): Array [nbase,npix] of the base rest-frame
             stellar continuum spectra [erg/s/cm2/A].
           basewave (numpy.ndarray): Array [npix] of rest-frame wavelengths 
@@ -732,9 +741,12 @@ class STAR():
         self.seed = seed
         self.rand = np.random.RandomState(seed=self.seed)
 
-        # Initialize the output wavelength array (linear spacing)
-        npix = (maxwave-minwave)/cdelt+1
-        self.wave = np.linspace(minwave,maxwave,npix) 
+        # Initialize the output wavelength array (linear spacing) unless it is
+        # already provided.
+        if wave is None:
+            npix = (maxwave-minwave)/cdelt+1
+            wave = np.linspace(minwave,maxwave,npix) 
+        self.wave = wave
 
         # Read the rest-frame continuum basis spectra.
         baseflux, basewave, basemeta = read_base_templates(objtype=self.objtype)
@@ -896,7 +908,7 @@ class QSO():
 
     """
     def __init__(self, nmodel=50, minwave=3600.0, maxwave=10000.0,
-                 cdelt=2.0, seed=None):
+                 cdelt=2.0, wave=None, seed=None):
         """Read the QSO basis continuum templates, grzW1W2 filter profiles and initialize 
            the output wavelength array.
 
@@ -913,6 +925,8 @@ class QSO():
             array [default 10000 Angstrom].
           cdelt (float, optional): spacing of the output wavelength array
             [default 2 Angstrom/pixel].
+          wave (numpy.ndarray): Input/output observed-frame wavelength array,
+            overriding the minwave, maxwave, and cdelt arguments [Angstrom].
           seed (long, optional): input seed for the random numbers
     
         Attributes:
@@ -920,8 +934,7 @@ class QSO():
           nmodel (int): See Args.
           seed (long): See Args.
           rand (numpy.RandomState): instance of numpy.random.RandomState(seed)
-          wave (numpy.ndarray): Output wavelength array constructed from the input
-            wavelength arguments [Angstrom].
+          wave (numpy.ndarray): Output wavelength array [Angstrom].
           baseflux (numpy.ndarray): Array [nbase,npix] of the base rest-frame
             QSO continuum spectra [erg/s/cm2/A].
           basewave (numpy.ndarray): Array [npix] of rest-frame wavelengths 
@@ -942,9 +955,12 @@ class QSO():
         self.seed = seed
         self.rand = np.random.RandomState(seed=self.seed)
 
-        # Initialize the output wavelength array (linear spacing)
-        npix = (maxwave-minwave)/cdelt+1
-        self.wave = np.linspace(minwave,maxwave,npix) 
+        # Initialize the output wavelength array (linear spacing) unless it is
+        # already provided.
+        if wave is None:
+            npix = (maxwave-minwave)/cdelt+1
+            wave = np.linspace(minwave,maxwave,npix) 
+        self.wave = wave
 
         # Read the basis spectra.
         baseflux, basewave, basemeta = read_base_templates(objtype=self.objtype)


### PR DESCRIPTION
I've tested the code, but independent eyes are welcome.  

The environment variables for all the individual target classes (DESI_ELG_TEMPLATES, DESI_LRG_TEMPLATES, etc.) are now obsolete.  All you need to set is
```
export DESI_BASIS_TEMPLATES=$DESI_ROOT/spectro/templates/basis_templates/v1.0
```

And then everything should "just work"
```
newexp-desi --nspec 500
```

FYI -- The following target classes are currently supported: ELG, LRG, QSO, STAR, STD (=FSTD), and WD.  In addition, BAD_QSO spectra are generated as interloper stars (although the stars don't yet satisfy the QSO color cuts.)