### PR TITLE
fix units of object flux

### DIFF
--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -116,7 +116,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
             ii = np.where( (thru.wavemin <= wave) & (wave <= thru.wavemax) )[0]
         
             #- Project flux to photons
-            phot = thru.photons(wave[ii], flux[:,ii], units='1e-17 erg/s/cm2/A',
+            phot = thru.photons(wave[ii], flux[:,ii], units=truth['UNITS'],
                     objtype=truth['OBJTYPE'], exptime=exptime,
                     airmass=airmass)
                 

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -162,6 +162,7 @@ def get_targets(nspec, tileid=None):
             simflux, wave1, meta = star.make_templates()
 
         truth['FLUX'][ii] = simflux
+        truth['UNITS'] = 'erg/s/cm2/A'
         truth['TEMPLATEID'][ii] = meta['TEMPLATEID']
         truth['REDSHIFT'][ii] = meta['REDSHIFT']
 


### PR DESCRIPTION
This fixes #40 where new templates changed units but we didn't propagate those into the throughput calculations.  This topic could still use further cleanup (e.g. we still rely on magic knowledge that the sky spectrum in desimodel has units 1e-17 erg/s/cm2/A/arcsec2), but at least this PR gets us back to having photons on the CCD.  Nightly integration tests have been failing redshift fitting; this is likely why.

Tests are not yet automated with Travis, but they pass on my laptop.

Thanks to Govinda for noticing and reporting the problem.