### PR TITLE
fix FLUX vs. SKYFLUX units

### DIFF
--- a/py/desisim/__init__.py
+++ b/py/desisim/__init__.py
@@ -12,7 +12,7 @@ from . import obs
 from . import io
 from . import targets
 
-__version__ = '0.6.dev0'
+__version__ = '0.6.dev1'
 def gitversion():
     from subprocess import Popen, PIPE
     try:

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -89,7 +89,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
             thru = desimodel.io.load_throughput(channel)
             ii = (thru.wavemin <= wave) & (wave <= thru.wavemax)
             phot = thru.photons(wave[ii], flux[:,ii], units=hdr['BUNIT'],
-                            objtype='CALIB', exptime=exptime)
+                            objtype='CALIB', exptime=10)
         
             truth['WAVE_'+channel] = wave[ii]
             truth['PHOT_'+channel] = phot

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -161,8 +161,8 @@ def get_targets(nspec, tileid=None):
             star = STAR(nmodel=nobj,wave=wave,FSTD=True)
             simflux, wave1, meta = star.make_templates()
 
-        truth['FLUX'][ii] = simflux
-        truth['UNITS'] = 'erg/s/cm2/A'
+        truth['FLUX'][ii] = 1e17 * simflux
+        truth['UNITS'] = '1e-17 erg/s/cm2/A'
         truth['TEMPLATEID'][ii] = meta['TEMPLATEID']
         truth['REDSHIFT'][ii] = meta['REDSHIFT']
 


### PR DESCRIPTION
This PR fixes a problem reported by Ryan Staten: the FLUX and SKYFLUX in the simspec files were written in different units (1e-17 vs not), even though the headers claimed they were the same units.  This uses 1e-17 for both.  The PHOT and SKYPHOT extensions appear to be ok already.  Tests were added to check for unusually large or small flux and photon values.