### PR TITLE
fix emission-line strengths in templates and ensure reproducibility

### DIFF
--- a/bin/simulate-templates
+++ b/bin/simulate-templates
@@ -134,9 +134,10 @@ def main():
 
         elif objtype == 'ELG':
             from desisim.templates import ELG
-            elg = ELG(nmodel=args.nmodel,minwave=args.minwave,maxwave=args.maxwave,
+            elg = ELG(minwave=args.minwave,maxwave=args.maxwave,
                       cdelt=args.cdelt,seed=args.seed)
-            flux, wave, meta = elg.make_templates(zrange=args.zrange_elg,
+            flux, wave, meta = elg.make_templates(nmodel=args.nmodel,
+                                                  zrange=args.zrange_elg,
                                                   rmagrange=args.rmagrange_elg,
                                                   minoiiflux=args.minoiiflux,
                                                   nocolorcuts=args.nocolorcuts)
@@ -145,9 +146,10 @@ def main():
 
         elif objtype == 'LRG':
             from desisim.templates import LRG
-            lrg = LRG(nmodel=args.nmodel,minwave=args.minwave,maxwave=args.maxwave,
+            lrg = LRG(minwave=args.minwave,maxwave=args.maxwave,
                       cdelt=args.cdelt,seed=args.seed)
-            flux, wave, meta = lrg.make_templates(zrange=args.zrange_lrg,
+            flux, wave, meta = lrg.make_templates(nmodel=args.nmodel,
+                                                  zrange=args.zrange_lrg,
                                                   zmagrange=args.zmagrange_lrg,
                                                   nocolorcuts=args.nocolorcuts)
             log.info('Writing {}'.format(outfile))
@@ -155,9 +157,10 @@ def main():
 
         elif objtype == 'QSO':
             from desisim.templates import QSO
-            qso = QSO(nmodel=args.nmodel,minwave=args.minwave,maxwave=args.maxwave,
+            qso = QSO(minwave=args.minwave,maxwave=args.maxwave,
                       cdelt=args.cdelt,seed=args.seed)
-            flux, wave, meta = qso.make_templates(zrange=args.zrange_qso,
+            flux, wave, meta = qso.make_templates(nmodel=args.nmodel,
+                                                  zrange=args.zrange_qso,
                                                   gmagrange=args.gmagrange_qso,
                                                   nocolorcuts=args.nocolorcuts)
             log.info('Writing {}'.format(outfile))
@@ -167,16 +170,19 @@ def main():
             from desisim.templates import STAR
             FSTD = objtype=='FSTD'
             WD = objtype=='WD'
-            star = STAR(nmodel=args.nmodel,minwave=args.minwave,maxwave=args.maxwave,
+            star = STAR(minwave=args.minwave,maxwave=args.maxwave,
                         cdelt=args.cdelt,seed=args.seed,FSTD=FSTD,WD=WD)
             if FSTD: # simulate an F-standard
-                flux, wave, meta = star.make_templates(vrad_meansig=args.vrad_fstd,
+                flux, wave, meta = star.make_templates(nmodel=args.nmodel,
+                                                       vrad_meansig=args.vrad_fstd,
                                                        rmagrange=args.rmagrange_fstd)
             elif WD: # simulate a white dwarf
-                flux, wave, meta = star.make_templates(vrad_meansig=args.vrad_wd,
+                flux, wave, meta = star.make_templates(nmodel=args.nmodel,
+                                                       vrad_meansig=args.vrad_wd,
                                                        gmagrange=args.gmagrange_wd)
             else: # simulate a normal star
-                flux, wave, meta = star.make_templates(vrad_meansig=args.vrad_star,
+                flux, wave, meta = star.make_templates(nmodel=args.nmodel,
+                                                       vrad_meansig=args.vrad_star,
                                                        rmagrange=args.rmagrange_star)
             log.info('Writing {}'.format(outfile))
             write_templates(outfile, flux, wave, meta, objtype)

--- a/bin/simulate-templates
+++ b/bin/simulate-templates
@@ -35,13 +35,13 @@ def main():
     parser.add_argument('-s', '--seed', type=long, default=None, metavar='', 
                         help='random number seed')
     # Boolean keywords.
-    parser.add_argument('--no-colorcuts', action='store_true', 
+    parser.add_argument('--nocolorcuts', action='store_true', 
                         help="""do not apply color cuts to select objects (only used for
                         object types ELG, LRG, and QSO)""")
-    parser.add_argument('--no-templates', action='store_true', 
+    parser.add_argument('--notemplates', action='store_true', 
                         help="""do not generate templates
                         (but do generate the diagnostic plots if OUTFILE exists)""")
-    parser.add_argument('--no-plots', action='store_true', 
+    parser.add_argument('--noplots', action='store_true', 
                         help='do not generate diagnostic (QA) plots')
     # Output filenames.
     parser.add_argument('--outfile', type=str, default='OBJTYPE-templates.fits', metavar='', 
@@ -127,7 +127,7 @@ def main():
     # header_comments = vars(args)
 
     # Call the right Class depending on the object type.
-    if not args.no_templates:
+    if not args.notemplates:
         if objtype == 'BGS':
             log.warning('{} objtype not yet supported!'.format(objtype))
             sys.exit(1)
@@ -139,7 +139,7 @@ def main():
             flux, wave, meta = elg.make_templates(zrange=args.zrange_elg,
                                                   rmagrange=args.rmagrange_elg,
                                                   minoiiflux=args.minoiiflux,
-                                                  no_colorcuts=args.no_colorcuts)
+                                                  nocolorcuts=args.nocolorcuts)
             log.info('Writing {}'.format(outfile))
             write_templates(outfile, flux, wave, meta, objtype)
 
@@ -149,7 +149,7 @@ def main():
                       cdelt=args.cdelt,seed=args.seed)
             flux, wave, meta = lrg.make_templates(zrange=args.zrange_lrg,
                                                   zmagrange=args.zmagrange_lrg,
-                                                  no_colorcuts=args.no_colorcuts)
+                                                  nocolorcuts=args.nocolorcuts)
             log.info('Writing {}'.format(outfile))
             write_templates(outfile, flux, wave, meta, objtype)
 
@@ -159,7 +159,7 @@ def main():
                       cdelt=args.cdelt,seed=args.seed)
             flux, wave, meta = qso.make_templates(zrange=args.zrange_qso,
                                                   gmagrange=args.gmagrange_qso,
-                                                  no_colorcuts=args.no_colorcuts)
+                                                  nocolorcuts=args.nocolorcuts)
             log.info('Writing {}'.format(outfile))
             write_templates(outfile, flux, wave, meta, objtype)
 
@@ -186,7 +186,7 @@ def main():
             sys.exit(1)
     
     # Generate diagnostic QAplots (just a placeholder right now).
-    if not args.no_plots:
+    if not args.noplots:
         import matplotlib.pyplot as plt
         if args.qafile:
             qafile = args.qafile

--- a/bin/simulate-templates
+++ b/bin/simulate-templates
@@ -134,34 +134,34 @@ def main():
 
         elif objtype == 'ELG':
             from desisim.templates import ELG
-            elg = ELG(minwave=args.minwave,maxwave=args.maxwave,
-                      cdelt=args.cdelt,seed=args.seed)
+            elg = ELG(minwave=args.minwave,maxwave=args.maxwave,cdelt=args.cdelt)
             flux, wave, meta = elg.make_templates(nmodel=args.nmodel,
                                                   zrange=args.zrange_elg,
                                                   rmagrange=args.rmagrange_elg,
                                                   minoiiflux=args.minoiiflux,
+                                                  seed=args.seed,
                                                   nocolorcuts=args.nocolorcuts)
             log.info('Writing {}'.format(outfile))
             write_templates(outfile, flux, wave, meta, objtype)
 
         elif objtype == 'LRG':
             from desisim.templates import LRG
-            lrg = LRG(minwave=args.minwave,maxwave=args.maxwave,
-                      cdelt=args.cdelt,seed=args.seed)
+            lrg = LRG(minwave=args.minwave,maxwave=args.maxwave,cdelt=args.cdelt)
             flux, wave, meta = lrg.make_templates(nmodel=args.nmodel,
                                                   zrange=args.zrange_lrg,
                                                   zmagrange=args.zmagrange_lrg,
+                                                  seed=args.seed,
                                                   nocolorcuts=args.nocolorcuts)
             log.info('Writing {}'.format(outfile))
             write_templates(outfile, flux, wave, meta, objtype)
 
         elif objtype == 'QSO':
             from desisim.templates import QSO
-            qso = QSO(minwave=args.minwave,maxwave=args.maxwave,
-                      cdelt=args.cdelt,seed=args.seed)
+            qso = QSO(minwave=args.minwave,maxwave=args.maxwave,cdelt=args.cdelt)
             flux, wave, meta = qso.make_templates(nmodel=args.nmodel,
                                                   zrange=args.zrange_qso,
                                                   gmagrange=args.gmagrange_qso,
+                                                  seed=args.seed,
                                                   nocolorcuts=args.nocolorcuts)
             log.info('Writing {}'.format(outfile))
             write_templates(outfile, flux, wave, meta, objtype)
@@ -171,19 +171,22 @@ def main():
             FSTD = objtype=='FSTD'
             WD = objtype=='WD'
             star = STAR(minwave=args.minwave,maxwave=args.maxwave,
-                        cdelt=args.cdelt,seed=args.seed,FSTD=FSTD,WD=WD)
+                        cdelt=args.cdelt,FSTD=FSTD,WD=WD)
             if FSTD: # simulate an F-standard
                 flux, wave, meta = star.make_templates(nmodel=args.nmodel,
                                                        vrad_meansig=args.vrad_fstd,
-                                                       rmagrange=args.rmagrange_fstd)
+                                                       rmagrange=args.rmagrange_fstd,
+                                                       seed=args.seed)
             elif WD: # simulate a white dwarf
                 flux, wave, meta = star.make_templates(nmodel=args.nmodel,
                                                        vrad_meansig=args.vrad_wd,
-                                                       gmagrange=args.gmagrange_wd)
+                                                       gmagrange=args.gmagrange_wd,
+                                                       seed=args.seed)
             else: # simulate a normal star
                 flux, wave, meta = star.make_templates(nmodel=args.nmodel,
                                                        vrad_meansig=args.vrad_star,
-                                                       rmagrange=args.rmagrange_star)
+                                                       rmagrange=args.rmagrange_star,
+                                                       seed=args.seed)
             log.info('Writing {}'.format(outfile))
             write_templates(outfile, flux, wave, meta, objtype)
 

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -135,31 +135,31 @@ def get_targets(nspec, tileid=None):
 
         elif objtype == 'ELG':
             from desisim.templates import ELG
-            elg = ELG(nmodel=nobj,wave=wave)
-            simflux, wave1, meta = elg.make_templates()
+            elg = ELG(wave=wave)
+            simflux, wave1, meta = elg.make_templates(nmodel=nobj)
 
         elif objtype == 'LRG':
             from desisim.templates import LRG
-            lrg = LRG(nmodel=nobj,wave=wave)
-            simflux, wave1, meta = lrg.make_templates()
+            lrg = LRG(wave=wave)
+            simflux, wave1, meta = lrg.make_templates(nmodel=nobj)
 
         elif objtype == 'QSO':
             from desisim.templates import QSO
-            qso = QSO(nmodel=nobj,wave=wave)
-            simflux, wave1, meta = qso.make_templates()
+            qso = QSO(wave=wave)
+            simflux, wave1, meta = qso.make_templates(nmodel=nobj)
 
         # For a "bad" QSO simulate a normal star without color cuts, which isn't
         # right. We need to apply the QSO color-cuts to the normal stars to pull
         # out the correct population of contaminating stars.
         elif objtype == 'QSO_BAD': 
             from desisim.templates import STAR
-            star = STAR(nmodel=nobj,wave=wave)
-            simflux, wave1, meta = star.make_templates()
+            star = STAR(wave=wave)
+            simflux, wave1, meta = star.make_templates(nmodel=nobj)
 
         elif objtype == 'STD':
             from desisim.templates import STAR
-            star = STAR(nmodel=nobj,wave=wave,FSTD=True)
-            simflux, wave1, meta = star.make_templates()
+            star = STAR(wave=wave,FSTD=True)
+            simflux, wave1, meta = star.make_templates(nmodel=nobj)
 
         truth['FLUX'][ii] = 1e17 * simflux
         truth['UNITS'] = '1e-17 erg/s/cm2/A'

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -68,8 +68,8 @@ class ELG():
 
     """
     def __init__(self, minwave=3600.0, maxwave=10000.0, cdelt=2.0, wave=None):
-        """Read the ELG basis continuum templates, grzW1 filter profiles and initialize
-           the output wavelength array.
+        """Read the ELG basis continuum templates, grzWISE filter profiles and
+           initialize the output wavelength array.
 
         Only a linearly-spaced output wavelength array is currently supported.
 
@@ -97,6 +97,7 @@ class ELG():
           rfilt (FILTERFUNC instance): DECam r-band filter profile class.
           zfilt (FILTERFUNC instance): DECam z-band filter profile class.
           w1filt (FILTERFUNC instance): WISE W1-band filter profile class.
+          w2filt (FILTERFUNC instance): WISE W2-band filter profile class.
 
         """
         from desisim.filterfunc import filterfunc as filt
@@ -122,6 +123,7 @@ class ELG():
         self.rfilt = filt(filtername='decam_r.txt')
         self.zfilt = filt(filtername='decam_z.txt')
         self.w1filt = filt(filtername='wise_w1.txt')
+        self.w2filt = filt(filtername='wise_w2.txt')
 
     def make_templates(self, nmodel=100, zrange=(0.6,1.6), rmagrange=(21.0,23.4),
                        oiiihbrange=(-0.5,0.1), oiidoublet_meansig=(0.73,0.05),
@@ -188,6 +190,7 @@ class ELG():
         meta['RMAG'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['ZMAG'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['W1MAG'] = Column(np.zeros(nmodel,dtype='f4'))
+        meta['W2MAG'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['OIIFLUX'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['EWOII'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['OIIIHBETA'] = Column(np.zeros(nmodel,dtype='f4'))
@@ -207,6 +210,7 @@ class ELG():
             RMAG = 'DECam r-band AB magnitude',
             ZMAG = 'DECam z-band AB magnitude',
             W1MAG = 'WISE W1-band AB magnitude',
+            W2MAG = 'WISE W2-band AB magnitude',
             OIIFLUX = '[OII] 3727 flux',
             EWOII = 'rest-frame equivalenth width of [OII] 3727',
             OIIIHBETA = 'logarithmic [OIII] 5007/H-beta ratio',
@@ -271,6 +275,7 @@ class ELG():
                 gflux = self.gfilt.get_maggies(zwave,flux)*10**(0.4*22.5) 
                 zflux = self.zfilt.get_maggies(zwave,flux)*10**(0.4*22.5) 
                 w1flux = self.w1filt.get_maggies(zwave,flux)*10**(0.4*22.5) 
+                w2flux = self.w2filt.get_maggies(zwave,flux)*10**(0.4*22.5) 
 
                 oiimask = [zoiiflux>minoiiflux]
 
@@ -290,6 +295,7 @@ class ELG():
                     meta['RMAG'][nobj] = rmag[ii]
                     meta['ZMAG'][nobj] = -2.5*np.log10(zflux)+22.5
                     meta['W1MAG'][nobj] = -2.5*np.log10(w1flux)+22.5
+                    meta['W2MAG'][nobj] = -2.5*np.log10(w2flux)+22.5
                     meta['OIIFLUX'][nobj] = zoiiflux
                     meta['EWOII'][nobj] = ewoii[ii]
                     meta['OIIIHBETA'][nobj] = oiiihbeta[ii]
@@ -519,8 +525,8 @@ class LRG():
 
     """
     def __init__(self, minwave=3600.0, maxwave=10000.0, cdelt=2.0, wave=None):
-        """Read the LRG basis continuum templates, grzW1 filter profiles and initialize
-           the output wavelength array.
+        """Read the LRG basis continuum templates, grzWISE filter profiles and
+           initialize the output wavelength array.
 
         Only a linearly-spaced output wavelength array is currently supported.
 
@@ -548,6 +554,7 @@ class LRG():
           rfilt (FILTERFUNC instance): DECam r-band filter profile class.
           zfilt (FILTERFUNC instance): DECam z-band filter profile class.
           w1filt (FILTERFUNC instance): WISE W1-band filter profile class.
+          w2filt (FILTERFUNC instance): WISE W2-band filter profile class.
 
         """
         from desisim.filterfunc import filterfunc as filt
@@ -573,6 +580,7 @@ class LRG():
         self.rfilt = filt(filtername='decam_r.txt')
         self.zfilt = filt(filtername='decam_z.txt')
         self.w1filt = filt(filtername='wise_w1.txt')
+        self.w2filt = filt(filtername='wise_w2.txt')
 
     def make_templates(self, nmodel=100, zrange=(0.5,1.1), zmagrange=(19.0,20.5),
                        seed=None, nocolorcuts=False):
@@ -616,6 +624,7 @@ class LRG():
         meta['RMAG'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['ZMAG'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['W1MAG'] = Column(np.zeros(nmodel,dtype='f4'))
+        meta['W2MAG'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['ZMETAL'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['AGE'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['D4000'] = Column(np.zeros(nmodel,dtype='f4'))
@@ -629,6 +638,7 @@ class LRG():
             RMAG = 'DECam r-band AB magnitude',
             ZMAG = 'DECam z-band AB magnitude',
             W1MAG = 'WISE W1-band AB magnitude',
+            W2MAG = 'WISE W2-band AB magnitude',
             ZMETAL = 'stellar metallicity',
             AGE = 'time since the onset of star formation',
             D4000 = '4000-Angstrom break'
@@ -655,11 +665,12 @@ class LRG():
                 znorm = 10.0**(-0.4*zmag[ii])/self.zfilt.get_maggies(zwave,restflux)
                 flux = restflux*znorm # [erg/s/cm2/A, @redshift[ii]]
 
-                # [grzW1]flux are in nanomaggies
+                # [grzW1W2]flux are in nanomaggies
                 zflux = 10.0**(-0.4*(zmag[ii]-22.5))                      
                 gflux = self.gfilt.get_maggies(zwave,flux)*10**(0.4*22.5) 
                 rflux = self.rfilt.get_maggies(zwave,flux)*10**(0.4*22.5) 
                 w1flux = self.w1filt.get_maggies(zwave,flux)*10**(0.4*22.5) 
+                w2flux = self.w2filt.get_maggies(zwave,flux)*10**(0.4*22.5) 
 
                 if nocolorcuts:
                     rzW1mask = [True]
@@ -677,6 +688,7 @@ class LRG():
                     meta['RMAG'][nobj] = -2.5*np.log10(rflux)+22.5
                     meta['ZMAG'][nobj] = zmag[ii]
                     meta['W1MAG'][nobj] = -2.5*np.log10(w1flux)+22.5
+                    meta['W2MAG'][nobj] = -2.5*np.log10(w2flux)+22.5
                     meta['ZMETAL'][nobj] = self.basemeta['ZMETAL'][iobj]
                     meta['AGE'][nobj] = self.basemeta['AGE'][iobj]
                     meta['D4000'][nobj] = self.basemeta['AGE'][iobj]
@@ -696,7 +708,7 @@ class STAR():
     """
     def __init__(self, minwave=3600.0, maxwave=10000.0, cdelt=2.0, wave=None, 
                  FSTD=False, WD=False):
-        """Read the stellar basis continuum templates, grzW1 filter profiles and
+        """Read the stellar basis continuum templates, grzWISE filter profiles and
            initialize the output wavelength array.
 
         Only a linearly-spaced output wavelength array is currently supported.
@@ -722,6 +734,8 @@ class STAR():
           gfilt (FILTERFUNC instance): DECam g-band filter profile class.
           rfilt (FILTERFUNC instance): DECam r-band filter profile class.
           zfilt (FILTERFUNC instance): DECam z-band filter profile class.
+          w1filt (FILTERFUNC instance): WISE W1-band filter profile class.
+          w2filt (FILTERFUNC instance): WISE W2-band filter profile class.
 
         """
         from desisim.filterfunc import filterfunc as filt
@@ -751,6 +765,8 @@ class STAR():
         self.gfilt = filt(filtername='decam_g.txt')
         self.rfilt = filt(filtername='decam_r.txt')
         self.zfilt = filt(filtername='decam_z.txt')
+        self.w1filt = filt(filtername='wise_w1.txt')
+        self.w2filt = filt(filtername='wise_w2.txt')
 
     def make_templates(self, nmodel=100, vrad_meansig=(0.0,200.0), rmagrange=(18.0,23.4),
                        gmagrange=(16.0,19.0), seed=None):
@@ -795,6 +811,8 @@ class STAR():
         meta['GMAG'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['RMAG'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['ZMAG'] = Column(np.zeros(nmodel,dtype='f4'))
+        meta['W1MAG'] = Column(np.zeros(nmodel,dtype='f4'))
+        meta['W2MAG'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['LOGG'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['TEFF'] = Column(np.zeros(nmodel,dtype='f4'))
 
@@ -808,6 +826,8 @@ class STAR():
                 GMAG = 'DECam g-band AB magnitude',
                 RMAG = 'DECam r-band AB magnitude',
                 ZMAG = 'DECam z-band AB magnitude',
+                W1MAG = 'WISE W1-band AB magnitude',
+                W2MAG = 'WISE W2-band AB magnitude',
                 LOGG = 'log10 of the effective gravity',
                 TEFF = 'stellar effective temperature'
             )
@@ -819,6 +839,8 @@ class STAR():
                 GMAG = 'DECam g-band AB magnitude',
                 RMAG = 'DECam r-band AB magnitude',
                 ZMAG = 'DECam z-band AB magnitude',
+                W1MAG = 'WISE W1-band AB magnitude',
+                W2MAG = 'WISE W2-band AB magnitude',
                 LOGG = 'log10 of the effective gravity',
                 TEFF = 'stellar effective temperature',
                 FEH = 'log10 iron abundance relative to solar',
@@ -856,6 +878,8 @@ class STAR():
                     gflux = 10.0**(-0.4*(gmag[ii]-22.5))                      
                     rflux = self.rfilt.get_maggies(zwave,flux)*10**(0.4*22.5) 
                     zflux = self.zfilt.get_maggies(zwave,flux)*10**(0.4*22.5)
+                    w1flux = self.w1filt.get_maggies(zwave,flux)*10**(0.4*22.5) 
+                    w2flux = self.w2filt.get_maggies(zwave,flux)*10**(0.4*22.5) 
                 else:
                     rnorm = 10.0**(-0.4*rmag[ii])/self.rfilt.get_maggies(zwave,restflux)
                     flux = restflux*rnorm # [erg/s/cm2/A, @redshift[ii]]
@@ -863,6 +887,8 @@ class STAR():
                     rflux = 10.0**(-0.4*(rmag[ii]-22.5))                      
                     gflux = self.gfilt.get_maggies(zwave,flux)*10**(0.4*22.5) 
                     zflux = self.zfilt.get_maggies(zwave,flux)*10**(0.4*22.5)
+                    w1flux = self.w1filt.get_maggies(zwave,flux)*10**(0.4*22.5) 
+                    w2flux = self.w2filt.get_maggies(zwave,flux)*10**(0.4*22.5) 
 
                 # Color cuts on just on the standard stars.
                 if self.objtype=='FSTD':
@@ -883,6 +909,8 @@ class STAR():
                         meta['GMAG'][nobj] = gmag[ii]
                         meta['RMAG'][nobj] = -2.5*np.log10(rflux)+22.5
                         meta['ZMAG'][nobj] = -2.5*np.log10(zflux)+22.5
+                        meta['W1MAG'][nobj] = -2.5*np.log10(w1flux)+22.5
+                        meta['W2MAG'][nobj] = -2.5*np.log10(w2flux)+22.5
                         meta['LOGG'][nobj] = self.basemeta['LOGG'][iobj]
                         meta['TEFF'][nobj] = self.basemeta['TEFF'][iobj]
                     else:
@@ -891,6 +919,8 @@ class STAR():
                         meta['GMAG'][nobj] = -2.5*np.log10(gflux)+22.5
                         meta['RMAG'][nobj] = rmag[ii]
                         meta['ZMAG'][nobj] = -2.5*np.log10(zflux)+22.5
+                        meta['W1MAG'][nobj] = -2.5*np.log10(w1flux)+22.5
+                        meta['W2MAG'][nobj] = -2.5*np.log10(w2flux)+22.5
                         meta['LOGG'][nobj] = self.basemeta['LOGG'][iobj]
                         meta['TEFF'][nobj] = self.basemeta['TEFF'][iobj]
                         meta['FEH'][nobj] = self.basemeta['FEH'][iobj]
@@ -1014,17 +1044,17 @@ class QSO():
         meta['GMAG'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['RMAG'] = Column(np.zeros(nmodel,dtype='f4'))
         meta['ZMAG'] = Column(np.zeros(nmodel,dtype='f4'))
-        # meta['W1MAG'] = Column(np.zeros(nmodel,dtype='f4'))
-        # meta['W2MAG'] = Column(np.zeros(nmodel,dtype='f4'))
+        meta['W1MAG'] = Column(np.zeros(nmodel,dtype='f4'))
+        meta['W2MAG'] = Column(np.zeros(nmodel,dtype='f4'))
 
         comments = dict(
             TEMPLATEID = 'template ID',
             REDSHIFT = 'object redshift',
             GMAG = 'DECam g-band AB magnitude',
             RMAG = 'DECam r-band AB magnitude',
-            ZMAG = 'DECam z-band AB magnitude'
-            # W1MAG = 'WISE W1-band AB magnitude',
-            # W2MAG = 'WISE W2-band AB magnitude'
+            ZMAG = 'DECam z-band AB magnitude',
+            W1MAG = 'WISE W1-band AB magnitude',
+            W2MAG = 'WISE W2-band AB magnitude'
         )
 
         nobj = 0
@@ -1053,8 +1083,8 @@ class QSO():
                 gflux = 10.0**(-0.4*(gmag[ii]-22.5))                      
                 rflux = self.rfilt.get_maggies(zwave,flux)*10**(0.4*22.5) 
                 zflux = self.zfilt.get_maggies(zwave,flux)*10**(0.4*22.5) 
-                # w1flux = self.w1filt.get_maggies(zwave,flux)*10**(0.4*22.5) 
-                # w2flux = self.w1filt.get_maggies(zwave,flux)*10**(0.4*22.5) 
+                w1flux = self.w1filt.get_maggies(zwave,flux)*10**(0.4*22.5) 
+                w2flux = self.w1filt.get_maggies(zwave,flux)*10**(0.4*22.5) 
 
                 if nocolorcuts:
                     grzW1W2mask = [True]
@@ -1071,7 +1101,8 @@ class QSO():
                     meta['GMAG'][nobj] = gmag[ii]
                     meta['RMAG'][nobj] = -2.5*np.log10(rflux)+22.5
                     meta['ZMAG'][nobj] = -2.5*np.log10(zflux)+22.5
-                    # meta['W1MAG'][nobj] = -2.5*np.log10(w1flux)+22.5
+                    meta['W1MAG'][nobj] = -2.5*np.log10(w1flux)+22.5
+                    meta['W2MAG'][nobj] = -2.5*np.log10(w2flux)+22.5
 
                     nobj = nobj+1
 

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -348,7 +348,7 @@ class EMSpectrum():
         if log10wave is None:
             cdelt = cdelt_kms/2.99792458E5/np.log(10) # pixel size [log-10 A]
             npix = (np.log10(maxwave)-np.log10(minwave))/cdelt+1
-            self.log10wave = np.linspace(np.log10(minwave),np.log10(maxwave),cdelt)
+            self.log10wave = np.linspace(np.log10(minwave),np.log10(maxwave),npix)
         else:
             self.log10wave = log10wave
 

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -151,7 +151,7 @@ class ELG():
             [OII] 3726/3729 doublet ratio distribution.  Defaults to (0.73,0.05).
           linesigma_meansig (float, optional): *Logarithmic* mean and sigma values for the
             (Gaussian) emission-line velocity width distribution.  Defaults to
-            log10-sigma(=1.887+/0.175) km/s.
+            log10-sigma(=1.9+/0.15) km/s.
 
           minoiiflux (float, optional): Minimum [OII] 3727 flux [default 1E-17 erg/s/cm2].
             Set this parameter to zero to not have a minimum flux cut.

--- a/py/desisim/test/test_templates.py
+++ b/py/desisim/test/test_templates.py
@@ -1,0 +1,98 @@
+from __future__ import division
+
+import unittest
+import numpy as np
+from desisim.templates import ELG, LRG, QSO, STAR
+
+class TestTemplates(unittest.TestCase):
+    
+    def setUp(self):
+        self.wavemin = 5000
+        self.wavemax = 8000
+        self.dwave = 2.0
+        self.wave = np.arange(self.wavemin, self.wavemax+self.dwave/2, self.dwave)
+        self.nspec = 5
+
+    def _check_output_size(self, flux, wave, meta):
+        self.assertEqual(len(meta), self.nspec)
+        self.assertEqual(len(wave), len(self.wave))
+        self.assertEqual(flux.shape, (self.nspec, len(self.wave)))
+
+    def test_simple(self):
+        '''Confirm that creating templates works at all'''
+        for T in [ELG, LRG, QSO, STAR]:
+            template_factory = T(wave=self.wave)
+            flux, wave, meta = template_factory.make_templates(self.nspec)
+            self._check_output_size(flux, wave, meta)
+
+        #- Can also specify minwave, maxwave, dwave
+        elg = ELG(self.wavemin, self.wavemax, self.dwave)
+        flux, wave, meta = elg.make_templates(self.nspec)
+        self._check_output_size(flux, wave, meta)
+                
+    def test_OII(self):
+        '''Confirm that ELG [OII] flux matches meta table description'''
+        wave = np.arange(5000, 9800.1, 0.2)
+        flux, ww, meta = ELG(wave=wave).make_templates(
+            nmodel=20, nocolorcuts=True, nocontinuum=True,
+            linesigma_meansig=[np.log10(75),0.0])
+
+        for i in range(len(meta)):
+            z = meta['REDSHIFT'][i]
+            ii = (3722*(1+z) < wave) & (wave < 3736*(1+z))
+            OIIflux = np.sum(flux[i,ii]*np.gradient(wave[ii]))
+            self.assertAlmostEqual(OIIflux, meta['OIIFLUX'][i], 2)
+            
+    def test_stars(self):
+        '''Test options specific to star templates'''
+        star = STAR(wave=self.wave)
+        flux, wave, meta = star.make_templates(self.nspec)
+        self._check_output_size(flux, wave, meta)
+        self.assertTrue('LOGG' in meta.dtype.names)
+        self.assertTrue('TEFF' in meta.dtype.names)
+        self.assertTrue('FEH' in meta.dtype.names)
+
+        star = STAR(wave=self.wave, FSTD=True)
+        flux, wave, meta = star.make_templates(self.nspec)
+        self._check_output_size(flux, wave, meta)
+        self.assertTrue('LOGG' in meta.dtype.names)
+        self.assertTrue('TEFF' in meta.dtype.names)
+        self.assertTrue('FEH' in meta.dtype.names)
+
+        star = STAR(wave=self.wave, WD=True)
+        flux, wave, meta = star.make_templates(self.nspec)
+        self._check_output_size(flux, wave, meta)
+        self.assertTrue('LOGG' in meta.dtype.names)
+        self.assertTrue('TEFF' in meta.dtype.names)
+        self.assertTrue('FEH' not in meta.dtype.names)  #- note: *no* FEH
+
+    def test_random_seed(self):
+        '''Test that random seed works to get the same results back'''
+        for T in [ELG, LRG, QSO, STAR]:
+            template_factory = T(wave=self.wave)
+            flux1, wave1, meta1 = template_factory.make_templates(self.nspec, seed=1)
+            flux2, wave2, meta2 = template_factory.make_templates(self.nspec, seed=1)
+            flux3, wave3, meta3 = template_factory.make_templates(self.nspec, seed=2)
+            self.assertTrue(np.all(flux1==flux2))
+            self.assertTrue(np.any(flux1!=flux3))
+            self.assertTrue(np.all(wave1==wave2))
+            for col in meta1.dtype.names:
+                #- QSO currently has NaN; catch that
+                if ((T != QSO) and (T != STAR)) or ((col != 'W1MAG') and (col != 'W2MAG')):
+                    self.assertTrue(np.all(meta1[col] == meta2[col]))
+
+    @unittest.expectedFailure
+    def test_missing_wise_mags(self):
+        '''QSO and stellar templates don't have WISE mags.  Flag that'''
+        qso = QSO(wave=self.wave)
+        flux, wave, meta = qso.make_templates(self.nspec)
+        self.assertTrue(not np.any(np.isnan(meta['W1MAG'])))
+        self.assertTrue(not np.any(np.isnan(meta['W2MAG'])))
+
+        star = STAR(wave=self.wave)
+        flux, wave, meta = star.make_templates(self.nspec)
+        self.assertTrue(not np.any(np.isnan(meta['W1MAG'])))
+        self.assertTrue(not np.any(np.isnan(meta['W2MAG'])))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR fixes issues #48 and, critically, #47, among other minor bugs.

The incorrect emission-line strengths/fluxes (raised in #47) were due to a disastrous bug in which the emission-line width should have been *sigma* (km/s), when in fact it was being passed as *log10-sigma*.  I was also missing a factor of 1+z because apparently I didn't miss enough 1+z factors when I was in grad school.

While tracking this down, I decided to generate a new set of continuum (basis) templates for ELGs (now v1.5) which have better wavelength sampling around the positions of emission lines.  The wavelength sampling in the v1.4 templates was just sparse enough that a non-negligible amount of flux was being lost in the emission lines.  Because of this change, once this PR has been merged the DESI_BASIS_TEMPLATES environment variable will need to point to the new templates, to wit:
```
export DESI_BASIS_TEMPLATES=$DESI_ROOT/spectro/templates/basis_templates/v1.1
```
Note that this change only affected the ELG templates.

Finally, the simulated templates (for all classes) are also now fully reproducible via the 'seed' optional input (thanks to @dkirkby for pointing out that this wasn't working).  However, I only tested this reproducibility via the bin/simulate-templates script; it would be great if someone could test this behavior when calling newexp-desi.