### PR TITLE
Bright pixsim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
         - SCIPY_VERSION=0.14
         - ASTROPY_VERSION=1.0.4
         - SPHINX_VERSION=1.3
-        - DESIUTIL_VERSION=1.3.0
+        - DESIUTIL_VERSION=1.3.2
         - SPECTER_VERSION=0.3
         - DESISPEC_VERSION=0.3.1
         - DESIMODEL_VERSION=trunk

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -174,7 +174,7 @@ class SimSpec(object):
                  skyphot=None, metadata=None, header=None):
         """
         Args:
-            flavor : 'arc', 'flat', or 'science'
+            flavor : e.g. 'arc', 'flat', 'dark', 'mws', ...
             wave : dictionary with per-channel wavelength grids, keyed by
                 'b', 'r', 'z'.  Optionally also has 'brz' key for channel
                 independent wavelength grid

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -193,7 +193,6 @@ class SimSpec(object):
                 skyphot[channel] where channel = 'b', 'r', or 'z'
           * wave['brz'] is the wavelength grid for flux and skyflux
         """
-        assert flavor in ('arc', 'flat', 'science')
         for channel in ('b', 'r', 'z'):
             assert wave[channel].ndim == 1
             assert phot[channel].ndim == 2
@@ -239,7 +238,7 @@ def read_simspec(filename):
         fx.close()
         return SimSpec(flavor, wave, phot, flux=flux, header=hdr)
 
-    elif flavor == 'science':
+    else:  #- multiple science flavors: dark, bright, bgs, mws, etc.
         wave['brz'] = fx['WAVE'].data
         flux = fx['FLUX'].data
         metadata = fx['METADATA'].data
@@ -252,10 +251,6 @@ def read_simspec(filename):
         fx.close()
         return SimSpec(flavor, wave, phot, flux=flux, skyflux=skyflux,
             skyphot=skyphot, metadata=metadata, header=hdr)
-
-    else:
-        raise ValueError('unknown flavor '+flavor)
-
 
 
 def write_simpix(outfile, image, meta):

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -292,12 +292,12 @@ def get_night(t=None, utc=None):
     
 #- I'm not really sure this is a good idea.
 #- I'm sure I will want to change the schema later...
-def update_obslog(obstype='science', expid=None, dateobs=None,
+def update_obslog(obstype='dark', expid=None, dateobs=None,
     tileid=-1, ra=None, dec=None):
     """
     Update obslog with a new exposure
     
-    obstype : 'science', 'arc', 'flat', 'bias', 'dark', or 'test'
+    obstype : 'arc', 'flat', 'bias', 'dark', 'test', 'science', 'dark', ...
     expid   : integer exposure ID, default from get_next_expid()
     dateobs : time.struct_time tuple; default time.localtime()
     tileid  : integer TileID, default -1, i.e. not a DESI tile

--- a/py/desisim/test/test_obs.py
+++ b/py/desisim/test/test_obs.py
@@ -52,7 +52,8 @@ class TestObs(unittest.TestCase):
     @unittest.skipUnless(desimodel_data_available, 'The desimodel data/ directory was not detected.')
     def test_newexp(self):
         night = '20150101'
-        for expid, flavor in enumerate(['arc', 'flat', 'science']):
+        #- flavors 'bgs' and 'bright' not yet implemented
+        for expid, flavor in enumerate(['arc', 'flat', 'dark', 'mws']):
             fibermap, true = obs.new_exposure(flavor, nspec=10, night=night, expid=expid)
             simspecfile = io.findfile('simspec', night, expid=expid)
             self.assertTrue(os.path.exists(simspecfile))
@@ -64,11 +65,11 @@ class TestObs(unittest.TestCase):
                 maxphot = simspec.phot[channel].max()
                 self.assertTrue(maxphot > 1, 'suspiciously few {} photons ({}); wrong units?'.format(flavor, maxphot))
                 self.assertTrue(maxphot < 1e6, 'suspiciously many {} photons ({}); wrong units?'.format(flavor, maxphot))
-                if flavor == 'science':
+                if flavor not in ('arc', 'flat'):
                     self.assertTrue(simspec.skyphot[channel].max() > 1, 'suspiciously few sky photons; wrong units?')
                     self.assertTrue(simspec.skyphot[channel].max() < 1e6, 'suspiciously many sky photons; wrong units?')
 
-            if flavor == 'science':
+            if flavor not in ('arc', 'flat'):
                 fx = fits.open(simspecfile)
                 self.assertTrue(fx['FLUX'].header['BUNIT'].startswith('1e-17 '))
                 self.assertTrue(fx['SKYFLUX'].header['BUNIT'].startswith('1e-17 '))


### PR DESCRIPTION
A previous pull request on newexp-desi split --flavor 'science' into more specific categories like 'bright', 'dark', 'mws', 'bgs', 'elg', etc.  There were some leftover bugs in pixsim-desi expecting flavor='science'.  This PR fixes that.  Flavor is now propagated but for the most part not used other than distinguishing arc, flat, and other file formats for input spectra.