### PR TITLE
use bright sky for flavor=bright,bgs,mws

### DIFF
--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -187,7 +187,7 @@ def get_targets(nspec, flavor, tileid=None):
         elif objtype == 'MWS_STAR':
             from desisim.templates import STAR
             star = STAR(wave=wave)
-            # todo: magranges for differet flavors of STAR targets should be in desimodel
+            # todo: mag ranges for different flavors of STAR targets should be in desimodel
             simflux, wave1, meta = star.make_templates(nmodel=nobj,rmagrange=(15.0,20.0))
             
         truth['FLUX'][ii] = 1e17 * simflux

--- a/py/desisim/test/test_obs.py
+++ b/py/desisim/test/test_obs.py
@@ -93,6 +93,18 @@ class TestObs(unittest.TestCase):
         fibermap, true = obs.new_exposure('arc', nspec=2)
 
     @unittest.skipUnless(desimodel_data_available, 'The desimodel data/ directory was not detected.')
+    def test_newexp_sky(self):
+        "Test different levels of sky brightness"
+        night = '20150101'
+        #- flavors 'bgs' and 'bright' not yet implemented
+        fibermap, truth_dark = obs.new_exposure('dark', nspec=10, night=night, expid=0)
+        fibermap, truth_mws  = obs.new_exposure('mws', nspec=10, night=night, expid=1)
+        for channel in ['B', 'R', 'Z']:
+            key = 'SKYPHOT_'+channel
+            self.assertTrue(np.all(truth_mws[key] > truth_dark[key]))
+        
+
+    @unittest.skipUnless(desimodel_data_available, 'The desimodel data/ directory was not detected.')
     def test_update_obslog(self):
         #- These shouldn't fail, but we don't really have verification
         #- code that they did anything correct.


### PR DESCRIPTION
If new_exposure flavor is 'bright', 'mws', or 'bgs', use the spec-sky-bright.dat file from desimodel instead of the default spec-sky.dat .  This will be superseded by a sky model that includes lunar phase, distance to moon, and elevation, but this change is better than simulating these targets with a dark night sky.

Includes tests that flavor='mws' indeed does produce a brighter sky than flavor='dark'.  Flavors 'bright' and 'bgs' are not yet implemented in other aspects of new_exposure and thus they aren't included in this test.