### PR TITLE
Testlite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ env:
         - SCIPY_VERSION=0.14
         - ASTROPY_VERSION=1.0.4
         - SPHINX_VERSION=1.3
-        - DESIUTIL_VERSION=1.3.2
+        - DESIUTIL_VERSION=1.3.3
         - SPECTER_VERSION=0.3
         - DESISPEC_VERSION=0.3.1
         - DESIMODEL_VERSION=trunk

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,13 @@
 desisim
 =======
 
+.. image:: https://img.shields.io/travis/desihub/desisim.svg
+    :target: https://travis-ci.org/desihub/desisim
+    :alt: Travis Build Status
+.. image:: https://coveralls.io/repos/desihub/desisim/badge.svg?service=github
+    :target: https://coveralls.io/github/desihub/desisim
+    :alt: Test Coverage Status
+
 Introduction
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -8,47 +8,17 @@ desisim
 .. image:: https://coveralls.io/repos/desihub/desisim/badge.svg?service=github
     :target: https://coveralls.io/github/desihub/desisim
     :alt: Test Coverage Status
+.. image:: https://readthedocs.org/projects/desisim/badge/?version=latest
+    :target: http://desisim.readthedocs.org/en/latest/
+    :alt: Documentation Status
 
 Introduction
 ------------
 
 This package contains scripts and packages for simulating DESI spectra.
-
-
-Versioning
-----------
-
-If you have tagged a version and wish to set the package version based on your current git location::
-
-    $>  python setup.py version
-
-And then install as usual.
-
-Full Documentation
-------------------
-
-Please visit `desisim on Read the Docs`_
-
-.. image:: https://readthedocs.org/projects/desisim/badge/?version=latest
-    :target: http://desisim.readthedocs.org/en/latest/
-    :alt: Documentation Status
+For full documentation, please visit `desisim on Read the Docs`_
 
 .. _`desisim on Read the Docs`: http://desisim.readthedocs.org/en/latest/
-
-Travis Build Status
--------------------
-
-.. image:: https://img.shields.io/travis/desihub/desisim.svg
-    :target: https://travis-ci.org/desihub/desisim
-    :alt: Travis Build Status
-
-
-Test Coverage Status
---------------------
-
-.. image:: https://coveralls.io/repos/desihub/desisim/badge.svg?service=github
-    :target: https://coveralls.io/github/desihub/desisim
-    :alt: Test Coverage Status
 
 License
 -------

--- a/etc/travis_env_common.sh
+++ b/etc/travis_env_common.sh
@@ -56,7 +56,7 @@ export DESISIM=$PWD
 testdata_version=0.1
 cd ./data
 wget https://github.com/desihub/desisim-testdata/archive/$testdata_version.zip
-unzip $testdat_version.zip
+unzip $testdata_version.zip
 source desisim-testdata-$testdata_version/setup-testdata.sh
 # export DESI_ROOT=$PWD/desisim-testdata-master/desi
 # export DESI_BASIS_TEMPLATES=$DESI_ROOT/spectro/templates/basis_templates/test-v2.0

--- a/etc/travis_env_common.sh
+++ b/etc/travis_env_common.sh
@@ -36,14 +36,6 @@ fi
 # Now set up shortcut to conda install command to make sure the Python and Numpy
 # versions are always explicitly specified.
 
-# DESI_BASIS_TEMPLATES
-export DESISIM=$PWD
-cd ./data
-wget https://github.com/desihub/desisim-testdata/archive/master.zip
-unzip master.zip
-export DESI_BASIS_TEMPLATES=$PWD/desisim-testdata-master/basis_templates
-cd ..
-
 # OPTIONAL DEPENDENCIES
 if $OPTIONAL_DEPS
 then
@@ -58,6 +50,21 @@ $PIP_INSTALL git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg
 $PIP_INSTALL git+https://github.com/desihub/specter.git@${SPECTER_VERSION}#egg=specter
 $PIP_INSTALL svn+https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_VERSION}#egg=desimodel
 $PIP_INSTALL git+https://github.com/desihub/desispec.git@${DESISPEC_VERSION}#egg=desispec
+
+# DESI_BASIS_TEMPLATES
+export DESISIM=$PWD
+cd ./data
+wget https://github.com/desihub/desisim-testdata/archive/master.zip
+unzip master.zip
+export DESI_BASIS_TEMPLATES=$PWD/desisim-testdata-master/basis_templates
+cd ..
+
+# DESIMODEL
+git clone https://github.com/desihub/desimodel
+cd desimodel
+svn export https://desi.lbl.gov/svn/code/desimodel/branches/test-0.4/data
+export DESIMODEL=$PWD/data
+python setup.py install
 
 # DOCUMENTATION DEPENDENCIES
 # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that

--- a/etc/travis_env_common.sh
+++ b/etc/travis_env_common.sh
@@ -63,7 +63,7 @@ cd ..
 git clone https://github.com/desihub/desimodel
 cd desimodel
 svn export https://desi.lbl.gov/svn/code/desimodel/branches/test-0.4/data
-export DESIMODEL=$PWD/data
+export DESIMODEL=$PWD
 python setup.py install
 
 # DOCUMENTATION DEPENDENCIES

--- a/etc/travis_env_common.sh
+++ b/etc/travis_env_common.sh
@@ -56,7 +56,8 @@ export DESISIM=$PWD
 cd ./data
 wget https://github.com/desihub/desisim-testdata/archive/master.zip
 unzip master.zip
-export DESI_BASIS_TEMPLATES=$PWD/desisim-testdata-master/basis_templates
+export DESI_ROOT=$PWD/desisim-testdata-master/desi
+export DESI_BASIS_TEMPLATES=$DESI_ROOT/spectro/templates/basis_templates/test-v2.0
 cd ..
 
 # DESIMODEL

--- a/etc/travis_env_common.sh
+++ b/etc/travis_env_common.sh
@@ -36,6 +36,13 @@ fi
 # Now set up shortcut to conda install command to make sure the Python and Numpy
 # versions are always explicitly specified.
 
+# DESI_BASIS_TEMPLATES
+cd ./data
+wget https://github.com/desihub/desisim-testdata/archive/master.zip
+unzip master.zip
+export DESI_BASIS_TEMPLATES=$PWD/desisim-testdata-master/basis_templates
+cd ..
+
 # OPTIONAL DEPENDENCIES
 if $OPTIONAL_DEPS
 then

--- a/etc/travis_env_common.sh
+++ b/etc/travis_env_common.sh
@@ -60,11 +60,14 @@ export DESI_BASIS_TEMPLATES=$PWD/desisim-testdata-master/basis_templates
 cd ..
 
 # DESIMODEL
+# This gets cloned into desisim/desimodel - is that a problem?
 git clone https://github.com/desihub/desimodel
 cd desimodel
 svn export https://desi.lbl.gov/svn/code/desimodel/branches/test-0.4/data
 export DESIMODEL=$PWD
+echo DESIMODEL=$DESIMODEL
 python setup.py install
+cd ..
 
 # DOCUMENTATION DEPENDENCIES
 # build_sphinx needs sphinx and matplotlib (for plot_directive). Note that

--- a/etc/travis_env_common.sh
+++ b/etc/travis_env_common.sh
@@ -37,6 +37,7 @@ fi
 # versions are always explicitly specified.
 
 # DESI_BASIS_TEMPLATES
+export DESISIM=$PWD
 cd ./data
 wget https://github.com/desihub/desisim-testdata/archive/master.zip
 unzip master.zip

--- a/etc/travis_env_common.sh
+++ b/etc/travis_env_common.sh
@@ -53,10 +53,11 @@ $PIP_INSTALL git+https://github.com/desihub/desispec.git@${DESISPEC_VERSION}#egg
 
 # DESI_ROOT and DESI_BASIS_TEMPLATES with test data
 export DESISIM=$PWD
+testdata_version=0.1
 cd ./data
-wget https://github.com/desihub/desisim-testdata/archive/master.zip
-unzip master.zip
-source desisim-testdata-master/setup-testdata.sh
+wget https://github.com/desihub/desisim-testdata/archive/$testdata_version.zip
+unzip $testdat_version.zip
+source desisim-testdata-$testdata_version/setup-testdata.sh
 # export DESI_ROOT=$PWD/desisim-testdata-master/desi
 # export DESI_BASIS_TEMPLATES=$DESI_ROOT/spectro/templates/basis_templates/test-v2.0
 cd ..

--- a/etc/travis_env_common.sh
+++ b/etc/travis_env_common.sh
@@ -51,13 +51,14 @@ $PIP_INSTALL git+https://github.com/desihub/specter.git@${SPECTER_VERSION}#egg=s
 $PIP_INSTALL svn+https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_VERSION}#egg=desimodel
 $PIP_INSTALL git+https://github.com/desihub/desispec.git@${DESISPEC_VERSION}#egg=desispec
 
-# DESI_BASIS_TEMPLATES
+# DESI_ROOT and DESI_BASIS_TEMPLATES with test data
 export DESISIM=$PWD
 cd ./data
 wget https://github.com/desihub/desisim-testdata/archive/master.zip
 unzip master.zip
-export DESI_ROOT=$PWD/desisim-testdata-master/desi
-export DESI_BASIS_TEMPLATES=$DESI_ROOT/spectro/templates/basis_templates/test-v2.0
+source desisim-testdata-master/setup-testdata.sh
+# export DESI_ROOT=$PWD/desisim-testdata-master/desi
+# export DESI_BASIS_TEMPLATES=$DESI_ROOT/spectro/templates/basis_templates/test-v2.0
 cd ..
 
 # DESIMODEL

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -278,25 +278,10 @@ def write_simpix(outfile, image, meta):
 #- Utility function to resize an image while preserving its 2D arrangement
 #- (unlike np.resize)
 def _resize(image, shape):
-    if (shape[0] > 2*image.shape[0]) or (shape[1] > 2*image.shape[1]):
-        raise ValueError('Can only reshape by up to a factor of 2')
-
-    newpix = np.empty(shape, dtype=image.dtype)
-    ny = min(shape[0], image.shape[0])
-    nx = min(shape[1], image.shape[1])
-    newpix[0:ny, 0:nx] = image[0:ny, 0:nx]
-    if shape[0] > image.shape[0]:
-        nn = shape[0] - image.shape[0]
-        newpix[ny:ny+nn, 0:nx] = image[0:nn, 0:nx]
-    if shape[1] > image.shape[1]:
-        nn = shape[1] - image.shape[1]
-        newpix[0:ny, nx:nx+nn] = image[0:ny, 0:nn]
-    if (shape[0] > image.shape[0]) and (shape[1] > image.shape[1]):
-        nny = shape[0] - image.shape[0]
-        nnx = shape[1] - image.shape[1]
-        newpix[ny:ny+nny, nx:nx+nnx] = image[0:nny, 0:nnx]
-
-    return newpix
+    ny = shape[0] // image.shape[0] + 1
+    nx = shape[1] // image.shape[1] + 1
+    newpix = np.tile(image, (ny, nx))
+    return newpix[0:shape[0], 0:shape[1]]
 
 def read_cosmics(filename, expid=1, shape=None, jitter=True):
     """

--- a/py/desisim/qso_template/desi_qso_templ.py
+++ b/py/desisim/qso_template/desi_qso_templ.py
@@ -180,7 +180,7 @@ def desi_qso_templates(z_wind=0.2, zmnx=(0.4,4.), outfil=None, N_perz=500,
                        boss_pca_fil=None, wvmnx=(3500., 10000.),
                        rebin_wave=None, rstate=None,
                        sdss_pca_fil=None, no_write=False,
-                       seed=None, old_read=False, ipad=5):
+                       seed=None, old_read=False, ipad=20):
     """ Generate QSO templates for DESI
 
     Rebins to input wavelength array (or log10 in wvmnx)

--- a/py/desisim/test/test_io.py
+++ b/py/desisim/test/test_io.py
@@ -97,9 +97,11 @@ class TestIO(unittest.TestCase):
 
     def test_resize(self):
         image = np.random.uniform(size=(4,5))
-        for shape in [(3,4), (4,5), (3,6), (5,4), (5,6)]:
-            x = io._resize(image, shape)
-            self.assertEqual(x.shape, shape)
+        for ny in [3,4,5,7,9,15]:
+            for nx in [3,5,7,19]:
+                shape = (ny, nx)
+                x = io._resize(image, shape)
+                self.assertEqual(x.shape, shape)
 
     #- read_cosmics(filename, expid=1, shape=None, jitter=True):
     @unittest.skipUnless(desi_templates_available, 'The DESI templates directory ($DESI_ROOT/spectro/templates) was not detected.')

--- a/py/desisim/test/test_io.py
+++ b/py/desisim/test/test_io.py
@@ -8,17 +8,9 @@ import desisim
 from desisim import io
 from astropy.io import fits
 
-desimodel_data_available = True
-try:
-    foo = os.environ['DESIMODEL']
-except KeyError:
-    desimodel_data_available = False
-
-desi_templates_available = True
-try:
-    foo = os.environ['DESI_ROOT']
-except KeyError:
-    desi_templates_available = False
+desimodel_data_available = 'DESIMODEL' in os.environ
+desi_templates_available = 'DESI_ROOT' in os.environ
+desi_basis_templates_available = 'DESI_BASIS_TEMPLATES' in os.environ
 
 class TestIO(unittest.TestCase):
 
@@ -126,7 +118,7 @@ class TestIO(unittest.TestCase):
         self.assertTrue(np.any(c2.pix != c3.pix))
 
     #- read_templates(wave, objtype, nspec=None, randseed=1, infile=None):
-    @unittest.skipUnless(desi_templates_available, 'The DESI templates directory ($DESI_ROOT/spectro/templates) was not detected.')
+    @unittest.skipUnless(desi_basis_templates_available, '$DESI_BASIS_TEMPLATES not set')
     def test_read_templates(self):
         wave = np.arange(7000, 7020)
         nspec = 3

--- a/py/desisim/test/test_obs.py
+++ b/py/desisim/test/test_obs.py
@@ -8,12 +8,8 @@ from astropy.io import fits
 from desisim import io
 from desisim import obs
 
-desimodel_data_available = True
-try:
-    foo = os.environ['DESIMODEL']
-except KeyError:
-    desimodel_data_available = False
-
+desimodel_data_available = 'DESIMODEL' in os.environ
+desi_root_available = 'DESI_ROOT' in os.environ
 
 class TestObs(unittest.TestCase):
     #- Create test subdirectory
@@ -50,6 +46,7 @@ class TestObs(unittest.TestCase):
     # def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
     #     airmass=1.0, exptime=None):
     @unittest.skipUnless(desimodel_data_available, 'The desimodel data/ directory was not detected.')
+    @unittest.skipUnless(desi_root_available, '$DESI_ROOT not set')
     def test_newexp(self):
         night = '20150101'
         #- flavors 'bgs' and 'bright' not yet implemented

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -74,6 +74,7 @@ class TestPixsim(unittest.TestCase):
         self.assertTrue(os.path.exists(io.findfile('pix', night, expid, camera)))
 
     @unittest.skipUnless(desi_templates_available, 'The DESI templates directory ($DESI_ROOT/spectro/templates) was not detected.')
+    @unittest.skipUnless(desimodel_data_available, '$DESIMODEL/data not available')
     def test_pixsim_cosmics(self):
         night = '20150105'
         expid = 124

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -10,18 +10,9 @@ from desisim import io
 from desisim import obs
 from desisim import pixsim
 
-desimodel_data_available = True
-try:
-    foo = os.environ['DESIMODEL']
-except KeyError:
-    desimodel_data_available = False
-
-desi_templates_available = True
-try:
-    foo = os.environ['DESI_ROOT']
-except KeyError:
-    desi_templates_available = False
-
+desimodel_data_available = 'DESIMODEL' in os.environ
+desi_templates_available = 'DESI_ROOT' in os.environ
+desi_root_available = 'DESI_ROOT' in os.environ
 
 class TestPixsim(unittest.TestCase):
     #- Create test subdirectory
@@ -69,6 +60,7 @@ class TestPixsim(unittest.TestCase):
     # def simulate(night, expid, camera, nspec=None, verbose=False, ncpu=None,
     #     trimxy=False, cosmics=None):
     @unittest.skipUnless(desimodel_data_available, 'The desimodel data/ directory was not detected.')
+    @unittest.skipUnless(desi_root_available, '$DESI_ROOT not set')
     def test_pixsim(self):
         night = '20150105'
         expid = 123

--- a/py/desisim/test/test_targets.py
+++ b/py/desisim/test/test_targets.py
@@ -4,12 +4,7 @@ import numpy as np
 
 import desisim.targets
 
-desimodel_data_available = True
-try:
-    foo = os.environ['DESIMODEL']
-except KeyError:
-    desimodel_data_available = False
-
+desimodel_data_available = 'DESIMODEL' in os.environ
 
 class TestObs(unittest.TestCase):
 

--- a/py/desisim/test/test_templates.py
+++ b/py/desisim/test/test_templates.py
@@ -5,23 +5,9 @@ import unittest
 import numpy as np
 from desisim.templates import ELG, LRG, QSO, STAR
 
-desimodel_data_available = True
-try:
-    foo = os.environ['DESIMODEL']
-except KeyError:
-    desimodel_data_available = False
-
-desi_templates_available = True
-try:
-    foo = os.environ['DESI_ROOT']
-except KeyError:
-    desi_templates_available = False
-
-desi_basis_templates_available = True
-try:
-    foo = os.environ['DESI_BASIS_TEMPLATES']
-except KeyError:
-    desi_basis_templates_available = False
+desimodel_data_available = 'DESIMODEL' in os.environ
+desi_templates_available = 'DESI_ROOT' in os.environ
+desi_basis_templates_available = 'DESI_BASIS_TEMPLATES' in os.environ
 
 class TestTemplates(unittest.TestCase):
 


### PR DESCRIPTION
I'm not ready to merge this yet, but turning it into a pull request so that I can see coverage statistics — it appears that Travis runs the coverage tests on branches but that doesn't get propagated to the coveralls badge or the coveralls gui.

Basic idea of this branch: I created a *separate* desispec-testdata repo with trimmed down basis templates (and the script that trims them down).  This can be used as a replacement for $DESI_BASIS_TEMPLATES for testing.  This can be fetched from https://github.com/desihub/desisim-testdata/archive/master.zip — it's pretty small and doesn't contain the history either.  At the same time, if it does get unwieldy we can blow that repo away and start over without losing our code history in this repo.

A lot of tests are still skipped due to needing cosmics templates under $DESI_ROOT and needing $DESIMODEL itself.  Trimmed down cosmics could be moved into desispec-testdata, and @weaverba137 is working on a trimmed down version of desimodel.

On my laptop, nosetests says there is 41% coverage with only $DESI_BASIS_TEMPLATES set (without $DESIMODEL or $DESI_ROOT).  Let's see if coveralls agrees...

@weaverba137 — please don't merge this yet, but please do take a look to see if you think this is a reasonable idea.

Credit to Kyle Barbary too for a brainstorming session that came up with this separate-repo-for-test-data idea.