### PR TITLE
bump numpy/scipy/astropy versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,13 +38,13 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        - NUMPY_VERSION=1.9
-        - SCIPY_VERSION=0.14
-        - ASTROPY_VERSION=1.0.4
+        - NUMPY_VERSION=1.10
+        - SCIPY_VERSION=0.16
+        - ASTROPY_VERSION=1.1.1
         - SPHINX_VERSION=1.3
         - DESIUTIL_VERSION=1.3.3
         - SPECTER_VERSION=0.3
-        - DESISPEC_VERSION=0.3.1
+        - DESISPEC_VERSION=0.4
         - DESIMODEL_VERSION=trunk
         # desimodel/trunk requires fitsio
         - FITSIO_VERSION=0.9.7


### PR DESCRIPTION
This PR updates the numpy/scipy/astropy versions to match what is used in desispec.  I don't completely understand why this was necessary, but it fixes the travis tests.