### PR TITLE
Update quickgen and quickbrick to new specsim API

### DIFF
--- a/bin/quickbrick
+++ b/bin/quickbrick
@@ -14,6 +14,7 @@ import scipy.sparse
 import string
 
 from astropy.table import Table, Column, vstack
+import astropy.units as u
 
 import desimodel.io
 import specsim
@@ -199,7 +200,7 @@ meta.add_column(Column(targetids, name='TARGETID'))
 meta.rename_column('REDSHIFT', 'TRUEZ')
 
 #- Actually do the simulations for each target
-fluxunits = specsim.spectrum.SpectralFluxDensity.fiducialFluxUnit * 1e17
+fluxunits = u.erg / (u.s * u.cm ** 2 * u.Angstrom)
 source = specsim.source.initialize(config)
 
 #- output arrays to fill; these cover wavelengths across all cameras

--- a/bin/quickbrick
+++ b/bin/quickbrick
@@ -17,7 +17,8 @@ from astropy.table import Table, Column, vstack
 import astropy.units as u
 
 import desimodel.io
-import specsim
+import specsim.config
+import specsim.simulator
 import desispec
 from desispec.log import get_logger
 import desisim.templates
@@ -201,7 +202,6 @@ meta.rename_column('REDSHIFT', 'TRUEZ')
 
 #- Actually do the simulations for each target
 fluxunits = u.erg / (u.s * u.cm ** 2 * u.Angstrom)
-source = specsim.source.initialize(config)
 
 #- output arrays to fill; these cover wavelengths across all cameras
 srcflux={}
@@ -217,9 +217,11 @@ for i in range(opts.nspec):
     #- if objtype is QSO_BAD or TEST then simulate a star
     if (truth['OBJTYPE'][i] == 'QSO_BAD' or truth['OBJTYPE'][i] == 'TEST'):
         truth['OBJTYPE'][i]='STAR'
-    source.update(truth['OBJTYPE'][i].lower(), truth['WAVE'],
-                  truth['FLUX'][i] * fluxunits)
-    results = qsim.simulate(source)
+    qsim.source.update_in(
+        'Quickbrick source {0}'.format(i), truth['OBJTYPE'][i].lower(),
+        truth['WAVE'] * u.Angstrom, truth['FLUX'][i] * fluxunits)
+    qsim.source.update_out()
+    results = qsim.simulate()
 
     #- output wavelength grid is the same for all spectra
     if obswave is None :

--- a/bin/quickbrick
+++ b/bin/quickbrick
@@ -71,7 +71,7 @@ config.update()
 wave = config.wavelength.value
 
 #- Create the quick simulator object
-qsim = specsim.quick.Quick(config)
+qsim = specsim.simulator.Simulator(config)
 
 #- If opts.objtype='MIX', get distribution of target types from sample_objtype
 if opts.objtype.lower() == 'mix':
@@ -219,7 +219,7 @@ for i in range(opts.nspec):
         truth['OBJTYPE'][i]='STAR'
     source.update(truth['OBJTYPE'][i].lower(), truth['WAVE'],
                   truth['FLUX'][i] * fluxunits)
-    results = qsim.simulate(source, downsampling=opts.downsampling)
+    results = qsim.simulate(source)
 
     #- output wavelength grid is the same for all spectra
     if obswave is None :

--- a/bin/quickbrick
+++ b/bin/quickbrick
@@ -47,20 +47,27 @@ assert opts.objtype is not None
 opts.objtype = opts.objtype.upper()
 assert opts.objtype in ['ELG', 'LRG', 'QSO', 'STAR', 'TEST', 'MIX']
 
-#- Set random seed if defined                                                                                                                                                                          
+#- Set random seed if defined
 if opts.seed is not None :
     np.random.seed(opts.seed)
-    
-#- Create the atmosphere module and the quick simulator object
-atmosphere = specsim.atmosphere.Atmosphere(
-    skyConditions='dark', basePath=os.environ['DESIMODEL'])
-qsim = specsim.quick.Quick(
-    atmosphere=atmosphere, basePath=os.environ['DESIMODEL'])
+
+#- Load the default DESI simulation configuration.
+config = specsim.config.load_config('desi')
+
+#- Modify defaults from command-line args.
+config.atmosphere.airmass = opts.airmass
+config.instrument.constants.exposure_time = '{0} s'.format(desiparams['exptime'])
+config.simulator.downsampling = opts.downsampling
 
 #- Wavelength grid to cover all channels
-wavemin = desimodel.io.load_throughput('b').wavemin
-wavemax = desimodel.io.load_throughput('z').wavemax
-wave = np.arange(wavemin-1, wavemax+1, opts.wavestep)
+config.wavelength_grid.min = desimodel.io.load_throughput('b').wavemin
+config.wavelength_grid.max = desimodel.io.load_throughput('z').wavemax
+config.wavelength_grid.step = opts.wavestep
+config.update()
+wave = config.wavelength.value
+
+#- Create the quick simulator object
+qsim = specsim.quick.Quick(config)
 
 #- If opts.objtype='MIX', get distribution of target types from sample_objtype
 if opts.objtype.lower() == 'mix':
@@ -82,8 +89,8 @@ jj=list()
 for objtype in set(true_objtype):
     ii = np.where(true_objtype == objtype)[0]
     nobj = len(ii)
-    
-    truth['OBJTYPE'][ii]=objtype   
+
+    truth['OBJTYPE'][ii]=objtype
 
 #- Generate a set of templates
     if objtype == 'ELG':
@@ -122,10 +129,10 @@ for objtype in set(true_objtype):
         continuum   = (np.arange(opts.nspec)%2 == 1).astype(np.float32)
 
         for spec in range(opts.nspec) :
-            flux[spec,i] = single_line[spec]*ref_integrated_flux/np.gradient(wave)[i] # single line                                                                                                          
-            flux[spec]   += continuum[spec]*ref_cst_flux_density # flat continuum                                                                                                                            
+            flux[spec,i] = single_line[spec]*ref_integrated_flux/np.gradient(wave)[i] # single line
+            flux[spec]   += continuum[spec]*ref_cst_flux_density # flat continuum
 
-        #print "ref wave=",wave[i]                                                                                                                                                                              #print "ref integrated flux=",ref_integrated_flux,"ergs/s/cm2"                                                                                                                                       
+        #print "ref wave=",wave[i]                                                                                                                                                                              #print "ref integrated flux=",ref_integrated_flux,"ergs/s/cm2"
         meta1 = Table(dict(REDSHIFT=np.zeros(opts.nspec, dtype=np.float32),
                           LINE=wave[i]*np.ones(opts.nspec, dtype=np.float32),
                           LINEFLUX=single_line*ref_integrated_flux,
@@ -139,7 +146,7 @@ for objtype in set(true_objtype):
 #- sanity check on units; templates currently return ergs, not 1e-17 ergs...
     assert (objtype == 'SKY') or (np.max(truth['FLUX']) < 1e-6)
 
-#- Create a blank fake fibermap; this is re-used by all channels                                                                                                                                         
+#- Create a blank fake fibermap; this is re-used by all channels
 fibermap = desispec.io.empty_fibermap(opts.nspec)
 targetids = np.random.randint(2**62, size=opts.nspec)
 fibermap['TARGETID'] = targetids
@@ -154,50 +161,50 @@ for k in range(opts.nspec):
     meta_new=vstack([meta_new,meta[index]])
 meta=meta_new
 
-#- Add TARGETID and the true OBJTYPE to the template meta table                                                                                                                                         
+#- Add TARGETID and the true OBJTYPE to the template meta table
 meta.add_column(Column(true_objtype, dtype='S10', name='OBJTYPE'))
 meta.add_column(Column(targetids, name='TARGETID'))
 
-#- rename REDSHIFT -> TRUEZ anticipating later table joins with zbest.Z                                                                                                                                 
+#- rename REDSHIFT -> TRUEZ anticipating later table joins with zbest.Z
 meta.rename_column('REDSHIFT', 'TRUEZ')
 
 #- Actually do the simulations for each target
 fluxunits = specsim.spectrum.SpectralFluxDensity.fiducialFluxUnit * 1e17
-qsim.setWavelengthGrid(wavemin, wavemax, opts.wavestep)
+source = specsim.source.initialize(config)
 
 #- output arrays to fill; these cover wavelengths across all cameras
 srcflux={}
 trueflux={}
 obsivar={}
 obswave=None
-for channel in qsim.instrument.cameraBands :
-    trueflux[channel]=list()
-    obsivar[channel]=list()
+for camera in qsim.instrument.cameras:
+    trueflux[camera.name]=list()
+    obsivar[camera.name]=list()
 
 #- convert list of arrays to 2D arrays
 for i in range(opts.nspec):
-    inspec = specsim.spectrum.SpectralFluxDensity(truth['WAVE'], truth['FLUX'][i], fluxUnits=fluxunits, extrapolatedValue=True)
     #- if objtype is QSO_BAD or TEST then simulate a star
-    if (truth['OBJTYPE'][i] == 'QSO_BAD' or truth['OBJTYPE'][i] == 'TEST'): 
+    if (truth['OBJTYPE'][i] == 'QSO_BAD' or truth['OBJTYPE'][i] == 'TEST'):
         truth['OBJTYPE'][i]='STAR'
-    results = qsim.simulate(sourceType=truth['OBJTYPE'][i].lower(), sourceSpectrum=inspec, 
-        airmass = opts.airmass, expTime = desiparams['exptime'], downsampling=opts.downsampling)
-    
+    source.type_name = truth['OBJTYPE'][i].lower()
+    assert np.array_equal(truth['WAVE'], source.wavelength.value)
+    source.flux = truth['FLUX'][i] * fluxunits
+    results = qsim.simulate(source, downsampling=opts.downsampling)
+
     #- output wavelength grid is the same for all spectra
     if obswave is None :
         obswave=results.wave
     else :
         assert (np.sum((obswave-results.wave)**2)==0.)
-    
+
     # now we collect the results
-    for channel in qsim.instrument.cameraBands :
-        j = qsim.instrument.cameraBands.index(channel)
-        trueflux[channel].append(results.camflux[:,j])
-        obsivar[channel].append(results.camivar[:,j])
+    for j, camera in enumerate(qsim.instrument.cameras):
+        trueflux[camera.name].append(results.camflux[:,j])
+        obsivar[camera.name].append(results.camivar[:,j])
 
     # collect the source flux
     srcflux[i]=list()
-    srcflux[i]=qsim.sourceFlux    
+    srcflux[i]=qsim.sourceFlux
 
 srcfl=dict()
 srcfl['SOURCE']=np.zeros( (opts.nspec,len(qsim.wavelengthGrid)) )
@@ -206,38 +213,38 @@ for i in range(opts.nspec):
     srcfl['SOURCE'][i] = srcflux[i]
 
 #- convert list of arrays to 2D arrays
-for channel in qsim.instrument.cameraBands :
-    trueflux[channel] = np.array(trueflux[channel])
-    obsivar[channel] = np.array(obsivar[channel])
+for camera in qsim.instrument.cameras:
+    trueflux[camera.name] = np.array(trueflux[camera.name])
+    obsivar[camera.name] = np.array(obsivar[camera.name])
 
 #- add noise
 noisyflux={}
-for channel in qsim.instrument.cameraBands :
-    noisyflux[channel] = np.zeros_like(trueflux[channel])
-    ii = np.where(obsivar[channel] > 0.01)
-    sigma = 1/np.sqrt(obsivar[channel][ii])
-    noisyflux[channel][ii] = trueflux[channel][ii] + np.random.normal(loc=0, scale=sigma)
+for camera in qsim.instrument.cameras:
+    noisyflux[camera.name] = np.zeros_like(trueflux[camera.name])
+    ii = np.where(obsivar[camera.name] > 0.01)
+    sigma = 1/np.sqrt(obsivar[camera.name][ii])
+    noisyflux[camera.name][ii] = trueflux[camera.name][ii] + np.random.normal(loc=0, scale=sigma)
 
 #- Select the wavelengths for each camera and output brick files
-for channel in ['b', 'r', 'z']:    
+for j, camera in enumerate(qsim.instrument.cameras):
+    channel = camera.name
     #- Sparse full resolution matrix for this camera
-    j = qsim.instrument.cameraBands.index(channel)
     R = qsim.cameras[j].sparseKernel
-        
+
     #- Trim R to range with non-zeros in even multiples of the downsampling
     nd = opts.downsampling
     ii = np.where(R.sum(axis=0).A[0])[0]
     begin, end = (ii[0]//nd)*nd, ((ii[-1]+1)//nd)*nd
     R = R[begin:end, begin:end]
-    
+
     #- indices of downsampled flux, ivar to keep
     iiobs = np.arange(begin, end, nd) // nd
-        
+
     #- Downsample the resolution matrix
     s = R.shape[1]//nd, nd, R.shape[0]//nd, nd
     Rx = R.toarray().reshape(s).sum(-1).sum(1) / nd
     Rdata = scipy.sparse.dia_matrix(Rx).data
-    
+
     #- replicate for all spectra for the output file
     Rdata = np.array([Rdata for i in range(opts.nspec)])
 
@@ -251,7 +258,7 @@ for channel in ['b', 'r', 'z']:
         os.remove(filepath)
 
     header = dict(BRICKNAM=opts.brickname, CHANNEL=channel)
-    brick = desispec.io.Brick(filepath, mode='update', header=header)        
+    brick = desispec.io.Brick(filepath, mode='update', header=header)
     brick.add_objects(noisyflux[channel][:,iiobs].astype(np.float32), obsivar[channel][:,iiobs].astype(np.float32),
         obswave[iiobs].astype(np.float32), Rdata.astype(np.float32), fibermap, night, expid)
     brick.close()
@@ -261,7 +268,7 @@ for channel in ['b', 'r', 'z']:
     #-       This makes chi2 calculations easier
     from astropy.io import fits
 
-    if opts.outdir_truth is None : # add truth in same file 
+    if opts.outdir_truth is None : # add truth in same file
         fx = fits.open(filepath, mode='append')
         header = desispec.io.fitsheader(header)
         fx.append(fits.ImageHDU(trueflux[channel][:,iiobs].astype(np.float32), name='_TRUEFLUX', header=header))
@@ -282,5 +289,3 @@ for channel in ['b', 'r', 'z']:
         filename = 'truth-brick-{}-{}.fits'.format(channel, opts.brickname)
         filepath = os.path.join(opts.outdir_truth, filename)
         hdulist.writeto(filepath,clobber=True)
-
-    

--- a/bin/quickbrick
+++ b/bin/quickbrick
@@ -216,9 +216,8 @@ for i in range(opts.nspec):
     #- if objtype is QSO_BAD or TEST then simulate a star
     if (truth['OBJTYPE'][i] == 'QSO_BAD' or truth['OBJTYPE'][i] == 'TEST'):
         truth['OBJTYPE'][i]='STAR'
-    source.type_name = truth['OBJTYPE'][i].lower()
-    assert np.array_equal(truth['WAVE'], source.wavelength.value)
-    source.flux = truth['FLUX'][i] * fluxunits
+    source.update(truth['OBJTYPE'][i].lower(), truth['WAVE'],
+                  truth['FLUX'][i] * fluxunits)
     results = qsim.simulate(source, downsampling=opts.downsampling)
 
     #- output wavelength grid is the same for all spectra

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 #*******************************
-# A quick wrapper of quicksim simulation of spectra. 
+# A quick wrapper of quicksim simulation of spectra.
 # Outputs are in DESI specific format.
 # For each 500 input spectra, this wrapper Outputs Four files for each arm B,R,Z,
 #	1. frame file (x3)
@@ -10,8 +10,8 @@
 #	4. cframe file (x3)
 #
 # Example:
-# 
-# G. Dhungana+, Spring 2015 
+#
+# G. Dhungana+, Spring 2015
 #********************************
 
 import argparse
@@ -44,11 +44,6 @@ parser.add_argument("--nstart", type=int, default=0,help='starting spectra # for
 parser.add_argument("--spectrograph",type=int, default=None,help='Spectrograph no. 0-9')
 args = parser.parse_args()
 
-#must import desimodel
-if 'DESIMODEL' not in os.environ:
-    raise RuntimeError('The environment variable DESIMODEL must be set.')
-DESIMODEL_DIR=os.environ['DESIMODEL'] 
-
 # Derive spectrograph number from nstart if needed
 if args.spectrograph is None:
     args.spectrograph = args.nstart / 500
@@ -60,7 +55,7 @@ if args.spectrograph is None:
 
 # read fibermapfile to get objecttype,NIGHT and EXPID....
 if args.fibermap:
- 
+
     print "Reading fibermap file %s"%(args.fibermap)
     tbdata,hdr=desispec.io.fibermap.read_fibermap(args.fibermap, header=True)
     objtype=tbdata['OBJTYPE'].copy()
@@ -82,7 +77,7 @@ DESI_SPECTRO_REDUX_DIR="./quickGen"
 if 'DESI_SPECTRO_REDUX' not in os.environ:
 
     print 'DESI_SPECTRO_REDUX environment is not set.'
-    
+
 else:
     DESI_SPECTRO_REDUX_DIR=os.environ['DESI_SPECTRO_REDUX']
 
@@ -95,7 +90,7 @@ else:
         os.makedirs(DESI_SPECTRO_REDUX_DIR)
     except:
         raise
-        
+
 #---------PRODNAME-----------------
 
 PRODNAME_DIR='prodname'
@@ -134,22 +129,25 @@ if nspec < args.nspec:
     args.nspec = nspec
 
 # Here default run for nmax spectra. Fewer spectra can be run using 'nspec' and 'nstart' options
-nmax= min(args.nspec+args.nstart,objtype.shape[0]) 
+nmax= min(args.nspec+args.nstart,objtype.shape[0])
 print "Simulating spectra",args.nstart, "to", nmax
 
 print "************************************************"
 
 # Run Simulation for first Spectrum
 print "Initializing SpecSim"
-specObj0=specsim.spectrum.SpectralFluxDensity(wavelengths,spectra[args.nstart,:])
-qsim=specsim.quick.Quick(basePath=DESIMODEL_DIR)
+config = specsim.config.load_config('desi')
+config.atmosphere.airmass = simspec.header['AIRMASS']
+config.instrument.constants.exposure_time = '{0} s'.format(simspec.header['EXPTIME'])
+
+source = specsim.source.initialize(config)
+##specObj0=specsim.spectrum.SpectralFluxDensity(wavelengths,spectra[args.nstart,:])
+qsim=specsim.quick.Quick(config)
 
 #- simulate a fake object 0 just to get wavelength grids etc setup
-results=qsim.simulate(sourceType='star', sourceSpectrum=specObj0,
-    airmass=simspec.header['AIRMASS'], expTime=simspec.header['EXPTIME'])
+results=qsim.simulate(source, downsampling=config.simulator.downsampling)
 observedWavelengths=results.wave
 origin_wavelength=qsim.wavelengthGrid
-waveLimits={'b':(3569,5949),'r':(5625,7741),'z':(7435,9834)}
 
 #- Check if input simspec is for a continuum flat lamp instead of science
 #- This does not convolve to per-fiber resolution
@@ -164,37 +162,42 @@ if simspec.flavor == 'flat':
         fiberflat = np.random.normal(loc=0.0, scale=1.0/np.sqrt(meanspec), size=(nspec, len(wave)))
         ivar = np.tile(1.0/meanspec, nspec).reshape(nspec, len(meanspec))
         mask = np.zeros((simspec.nspec, len(wave)))
-        
+
         for kk in range((args.nspec+args.nstart-1)/500+1):
             camera = channel+str(kk)
             outfile = desispec.io.findfile('fiberflat', NIGHT, EXPID, camera)
-            start=max(500*kk,args.nstart) 
-            end=min(500*(kk+1),nmax) 
+            start=max(500*kk,args.nstart)
+            end=min(500*(kk+1),nmax)
 
             if (args.spectrograph <= kk):
                 print "writing files for channel:",channel,", spectrograph:",kk, ", spectra:", start,'to',end
 
-            ff = FiberFlat(wave, fiberflat[start:end,:], ivar[start:end,:], mask[start:end,:], meanspec)        
+            ff = FiberFlat(wave, fiberflat[start:end,:], ivar[start:end,:], mask[start:end,:], meanspec)
             write_fiberflat(outfile, ff)
     filePath=os.path.join(prod_Dir,'calib2d',NIGHT)
     print "Wrote files to", filePath
-    
-    sys.exit(0)    
 
-# Define wavelimits for B,R,Z camera(by hand this time), later simulated data is cropped within these limits
+    sys.exit(0)
 
-# Get the camera ranges from quicksim outputs and save the outputs for each camera
+# Get the camera ranges and resolution from the specsim instrument model.
+waveLimits=dict()
 waveRange=dict()
 waveMaxbin=dict()
 waves=dict()
-for i,channel in enumerate(['b','r','z']):
+sigma_vs_wave = dict()
+for i,camera in enumerate(qsim.instrument.cameras):
+    channel = camera.name
+    waveLimits[channel] = (camera.wavelength_min.value, camera.wavelength_max.value)
     waveRange[channel],=np.where((observedWavelengths>=waveLimits[channel][0])&(observedWavelengths<=waveLimits[channel][1]))
     waveMaxbin[channel],=waveRange[channel].shape
     waves[channel]=observedWavelengths[waveRange[channel]]
+    sigma_vs_wave[channel] = specsim.spectrum.WavelengthFunction(
+        origin_wavelength,
+        qsim.cameras[i].sigmaWavelength).getResampledValues(waves[channel])
 
 maxbin=max(waveMaxbin['b'],waveMaxbin['r'],waveMaxbin['z'])
 
-# Now break the simulated outputs in three different ranges. 
+# Now break the simulated outputs in three different ranges.
 
 nobj=np.zeros((nmax,3,maxbin))     # Object Photons
 nsky=np.zeros((nmax,3,maxbin))      # sky photons
@@ -208,28 +211,24 @@ cframe_rand_noise=np.zeros((nmax,3,maxbin))  # random Gaussian noise to calibrat
 
 np.random.seed(0)
 
-#construct resolution matrix from sigma_vs_wavelength. First resample to respective sigmas vs wavelengths
-
-sigma_vs_wave = dict()
-for i, channel in enumerate( ['b', 'r', 'z'] ):
-    sigma_vs_wave[channel] = specsim.spectrum.WavelengthFunction(origin_wavelength, qsim.cameras[i].sigma_wave).getResampledValues(waves[channel])
+#construct resolution matrix from sigma_vs_wave.
 
 #- Resolution data from gaussian sigmas
 def _calc_resolution_data(sigma, wavelengths, nspec):
     """
     Return resolution matrix data
-    
+
     Args:
         sigma : 1D array of sigmas in Angstroms
         wavelengths : 1D array of equally spaced wavelengths in Angstroms
-        
+
     TODO: check this.  Replace with desisim.resolution.Resolution.
     """
     ndiag = 21
     offsets = np.arange(-ndiag//2+1,ndiag//2+1,1.0)
     nwave = len(wavelengths)
     dw = np.gradient(wavelengths)
-    
+
     resolution_data = np.zeros((ndiag, nwave))
     for i in range(nwave):
         x = offsets * dw[i] / sigma[i]
@@ -240,12 +239,12 @@ def _calc_resolution_data(sigma, wavelengths, nspec):
 
         y = scipy.special.erf(edges)
         resolution_data[:, i] = (y[1:] - y[:-1])/2
-        
+
     #- Convert this to [nspec, ndiag, nwave]
     result = np.zeros((nspec, ndiag, nwave))
     for i in range(nspec):
         result[i] = resolution_data
-        
+
     return result
 
 #-------------------------------------------------------------------------
@@ -260,9 +259,8 @@ for i, channel in enumerate( ['b', 'r', 'z'] ):
 for j in xrange(args.nstart,nmax): # Exclusive
     print "\rSimulating spectrum %d,  object type=%s"%(j,objtype[j]),
     sys.stdout.flush()
-    specObj=specsim.spectrum.SpectralFluxDensity(wavelengths,spectra[j,:])
-    results=qsim.simulate(sourceType=objtype[j].lower(),sourceSpectrum=specObj,
-            airmass=simspec.header['AIRMASS'], expTime=simspec.header['EXPTIME'])
+    source.update(objtype[j].lower(), wavelengths, spectra[j, :], extrapolate_value=0.)
+    results=qsim.simulate(source, downsampling=config.simulator.downsampling)
 
     for i,channel in enumerate(['b','r','z']):
         nobj[j,i,:waveMaxbin[channel]]=results.nobj[waveRange[channel],i]
@@ -292,14 +290,14 @@ armName={"b":0,"r":1,"z":2}
 #3. flux calibration vector file (x3)
 #4. cframe file
 
-for channel in ["b","r","z"]:	
+for channel in ["b","r","z"]:
 
     #Before writing, convert from counts/bin to counts/A (as in Pixsim output)
     #Quicksim Default:
-    #FLUX - input spectrum resampled to this binning; no noise added [1e-17 erg/s/cm2/s/Ang] 
+    #FLUX - input spectrum resampled to this binning; no noise added [1e-17 erg/s/cm2/s/Ang]
     #COUNTS_OBJ - object counts in 0.5 Ang bin
     #COUNTS_SKY - sky counts in 0.5 Ang bin
- 
+
     dwave=np.gradient(waves[channel])
     nobj[:,armName[channel],:waveMaxbin[channel]]/=dwave
     frame_rand_noise[:,armName[channel],:waveMaxbin[channel]]/=dwave
@@ -308,14 +306,14 @@ for channel in ["b","r","z"]:
     nsky[:,armName[channel],:waveMaxbin[channel]]/=dwave
     sky_rand_noise[:,armName[channel],:waveMaxbin[channel]]/=dwave
     sky_ivar[:,armName[channel],:waveMaxbin[channel]]/=dwave**2
-    
+
 
 #### Now write the outputs in DESI standard file system.    None of the output file can have more than 500 spectra
 
 # Looping over spectrograph
 
     for ii in range((args.nspec+args.nstart-1)/500+1):
-         
+
         start=max(500*ii,args.nstart) # first spectrum for a given spectrograph
         end=min(500*(ii+1),nmax) # last spectrum for the spectrograph
 
@@ -324,7 +322,7 @@ for channel in ["b","r","z"]:
             print "writing files for channel:",channel,", spectrograph:",ii, ", spectra:", start,'to',end
 
 
-######----------------frame file----------------------------------- 
+######----------------frame file-----------------------------------
 
             framefileName=desispec.io.findfile("frame",NIGHT,EXPID,camera)
 
@@ -334,7 +332,7 @@ for channel in ["b","r","z"]:
             frame_ivar=nivar[start:end,armName[channel],:waveMaxbin[channel]]
 
             sh1=frame_flux.shape[0]  # required for slicing the resolution metric, resolusion matrix has (nspec,ndiag,wave)
-                                      # for example if nstart =400, nspec=150: two spectrographs: 
+                                      # for example if nstart =400, nspec=150: two spectrographs:
                                       # 400-499=> 0 spectrograph, 500-549 => 1
             if (args.nstart==start):
                 resol=resolution_data[channel][:sh1,:,:]
@@ -347,26 +345,26 @@ for channel in ["b","r","z"]:
 
 ############--------------------------------------------------------
     #cframe file
-    #TODO : for sky input spectrum (all zero), quicksim output flux is also zero and also ivar. Need to fix!! 
-    
+    #TODO : for sky input spectrum (all zero), quicksim output flux is also zero and also ivar. Need to fix!!
+
             cframeFileName=desispec.io.findfile("cframe",NIGHT,EXPID,camera)
             cframeFlux=cframe_observedflux[start:end,armName[channel],:waveMaxbin[channel]]+cframe_rand_noise[start:end,armName[channel],:waveMaxbin[channel]]
             cframeIvar=cframe_ivar[start:end,armName[channel],:waveMaxbin[channel]]
-    
+
             # write cframe file
             cframe = Frame(waves[channel], cframeFlux, cframeIvar, resolution_data=resol,spectrograph=ii)
             desispec.io.frame.write_frame(cframeFileName,cframe)
 
 ############-----------------------------------------------------
             #sky file
-    
+
             skyfileName=desispec.io.findfile("sky",NIGHT,EXPID,camera)
             skyflux=nsky[start:end,armName[channel],:waveMaxbin[channel]] + \
             sky_rand_noise[start:end,armName[channel],:waveMaxbin[channel]]
             skyivar=sky_ivar[start:end,armName[channel],:waveMaxbin[channel]]
             skymask=np.zeros(skyflux.shape, dtype=int)
-    
-            # write sky file 
+
+            # write sky file
             skymodel = SkyModel(waves[channel], skyflux, skyivar, skymask)
             desispec.io.sky.write_sky(skyfileName, skymodel)
 
@@ -376,7 +374,7 @@ for channel in ["b","r","z"]:
             calibVectorFile=desispec.io.findfile("calib",NIGHT,EXPID,camera)
             flux = cframe_observedflux[start:end,armName[channel],:waveMaxbin[channel]]
             phot = nobj[start:end,armName[channel],:waveMaxbin[channel]]
-            calibration = np.zeros_like(phot) 
+            calibration = np.zeros_like(phot)
             jj = (flux>0)
             calibration[jj] = phot[jj] / flux[jj]
 
@@ -389,8 +387,8 @@ for channel in ["b","r","z"]:
            # write flux calibration
             fluxcalib = FluxCalib(waves[channel], calibration, calibivar, mask)
             write_flux_calibration(calibVectorFile, fluxcalib)
-    
+
 filePath=os.path.join(prod_Dir,'exposures',NIGHT,"%08d"%EXPID)
 print "Wrote files to", filePath
- 
-#spectrograph=spectrograph+1	
+
+#spectrograph=spectrograph+1

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -23,7 +23,9 @@ import scipy.interpolate
 import sys
 import desispec
 import desisim.io
-import specsim
+import specsim.config
+import specsim.simulator
+import astropy.units as u
 from desispec.resolution import Resolution
 from desispec.io import write_flux_calibration, write_fiberflat
 from desispec.interpolation import resample_flux
@@ -148,11 +150,12 @@ config.wavelength_grid.max = 9834.
 config.wavelength_grid.step = 0.1
 config.update()
 
-source = specsim.source.initialize(config)
+#- Initialize the quick simulator.
 qsim=specsim.simulator.Simulator(config)
+fluxunits = 1e-17 * u.erg / (u.s * u.cm ** 2 * u.Angstrom)
 
 #- simulate a fake object 0 just to get wavelength grids etc setup
-results=qsim.simulate(source)
+results=qsim.simulate()
 observedWavelengths=results.wave
 origin_wavelength=qsim.wavelengthGrid
 
@@ -273,8 +276,11 @@ for i, channel in enumerate( ['b', 'r', 'z'] ):
 for j in xrange(args.nstart,nmax): # Exclusive
     print "\rSimulating spectrum %d,  object type=%s"%(j,objtype[j]),
     sys.stdout.flush()
-    source.update(objtype[j].lower(), wavelengths, spectra[j, :], extrapolate_value=0.)
-    results=qsim.simulate(source)
+    qsim.source.update_in(
+        'Quickgen source {0}'.format(j), objtype[j].lower(),
+        wavelengths * u.Angstrom, spectra[j, :] * fluxunits)
+    qsim.source.update_out()
+    results=qsim.simulate()
 
     for i,channel in enumerate(['b','r','z']):
         nobj[j,i,:waveMaxbin[channel]]=results.nobj[waveRange[channel],i]

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -140,6 +140,7 @@ print "Initializing SpecSim"
 config = specsim.config.load_config('desi')
 config.atmosphere.airmass = simspec.header['AIRMASS']
 config.instrument.constants.exposure_time = '{0} s'.format(simspec.header['EXPTIME'])
+config.simulator.downsampling = 5
 
 # Set the simulation wavelength grid.
 config.wavelength_grid.min = 3569.
@@ -148,10 +149,10 @@ config.wavelength_grid.step = 0.1
 config.update()
 
 source = specsim.source.initialize(config)
-qsim=specsim.quick.Quick(config)
+qsim=specsim.simulator.Simulator(config)
 
 #- simulate a fake object 0 just to get wavelength grids etc setup
-results=qsim.simulate(source, downsampling=config.simulator.downsampling)
+results=qsim.simulate(source)
 observedWavelengths=results.wave
 origin_wavelength=qsim.wavelengthGrid
 
@@ -273,7 +274,7 @@ for j in xrange(args.nstart,nmax): # Exclusive
     print "\rSimulating spectrum %d,  object type=%s"%(j,objtype[j]),
     sys.stdout.flush()
     source.update(objtype[j].lower(), wavelengths, spectra[j, :], extrapolate_value=0.)
-    results=qsim.simulate(source, downsampling=config.simulator.downsampling)
+    results=qsim.simulate(source)
 
     for i,channel in enumerate(['b','r','z']):
         nobj[j,i,:waveMaxbin[channel]]=results.nobj[waveRange[channel],i]

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -19,6 +19,7 @@ import os
 import os.path
 import numpy as np
 import scipy.special
+import scipy.interpolate
 import sys
 import desispec
 import desisim.io
@@ -147,7 +148,6 @@ config.wavelength_grid.step = 0.1
 config.update()
 
 source = specsim.source.initialize(config)
-##specObj0=specsim.spectrum.SpectralFluxDensity(wavelengths,spectra[args.nstart,:])
 qsim=specsim.quick.Quick(config)
 
 #- simulate a fake object 0 just to get wavelength grids etc setup
@@ -197,9 +197,16 @@ for i,camera in enumerate(qsim.instrument.cameras):
     waveRange[channel],=np.where((observedWavelengths>=waveLimits[channel][0])&(observedWavelengths<=waveLimits[channel][1]))
     waveMaxbin[channel],=waveRange[channel].shape
     waves[channel]=observedWavelengths[waveRange[channel]]
+    # Interpolate the RMS resolution from the simulation grid to the output grid.
+    interpolator = scipy.interpolate.interp1d(
+        origin_wavelength, qsim.cameras[i].sigmaWavelength,
+        kind='linear', copy=False, assume_sorted=True)
+    sigma_vs_wave[channel] = interpolator(waves[channel])
+    '''
     sigma_vs_wave[channel] = specsim.spectrum.WavelengthFunction(
         origin_wavelength,
         qsim.cameras[i].sigmaWavelength).getResampledValues(waves[channel])
+    '''
 
 maxbin=max(waveMaxbin['b'],waveMaxbin['r'],waveMaxbin['z'])
 

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -140,6 +140,12 @@ config = specsim.config.load_config('desi')
 config.atmosphere.airmass = simspec.header['AIRMASS']
 config.instrument.constants.exposure_time = '{0} s'.format(simspec.header['EXPTIME'])
 
+# Set the simulation wavelength grid.
+config.wavelength_grid.min = 3569.
+config.wavelength_grid.max = 9834.
+config.wavelength_grid.step = 0.1
+config.update()
+
 source = specsim.source.initialize(config)
 ##specObj0=specsim.spectrum.SpectralFluxDensity(wavelengths,spectra[args.nstart,:])
 qsim=specsim.quick.Quick(config)


### PR DESCRIPTION
This is not ready to merge until I tag and release specsim v0.3, but now passes my tests on #80 using desihub/specsim#29.  Please review if you are interested.  I am finding identical results after the updates, but your mileage may vary.

Note that there are some trivial diffs in this PR where my editor (atom) automatically removed the invisible white space from the end of lines.  Sorry about that.  Could we standardize our whitespace conventions using [editorconfig](http://editorconfig.org)?   For example, the conventions I use in specsim are specified [here](https://github.com/desihub/specsim/blob/master/.editorconfig).