### PR TITLE
fix mag range of simulated stdstars

### DIFF
--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -200,7 +200,10 @@ def get_targets(nspec, flavor, tileid=None):
         elif objtype == 'STD':
             from desisim.templates import STAR
             star = STAR(wave=wave,FSTD=True)
-            simflux, wave1, meta = star.make_templates(nmodel=nobj)
+            rr = (16.0, 19.0)
+            gg = (16.0, 19.5)
+            simflux, wave1, meta = \
+                star.make_templates(nmodel=nobj, rmagrange=rr, gmagrange=gg)
 
         elif objtype == 'MWS_STAR':
             from desisim.templates import STAR


### PR DESCRIPTION
The default magnitude range for desisim.templates.STAR is not good for simulating standard stars, even when FSTD=True (that gets the colors right, but not the magnitudes).  This PR adds 16 < rmag < 19 constraints in desisim.targets.get_targets() when it generates stars to use as standard stars.

I think #64 will further clean this up by creating a separate FSTD class that could have appropriate magnitude ranges for FSTD.  This is an interim fix using the current multi-purpose STAR class.

