### PR TITLE
update fibermap format for target masks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,8 @@ env:
         - ASTROPY_VERSION=1.1.1
         - SPHINX_VERSION=1.3
         - DESIUTIL_VERSION=1.3.3
-        - SPECTER_VERSION=0.3
-        - DESISPEC_VERSION=0.4
+        - SPECTER_VERSION=0.4
+        - DESISPEC_VERSION=0.4.1
         - DESITARGET_VERSION=0.3.2
         - DESIMODEL_VERSION=trunk
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'

--- a/bin/pixsim-desi
+++ b/bin/pixsim-desi
@@ -46,6 +46,8 @@ parser.add_option("--trimxy", action="store_true", help="Trim image to fit spect
 parser.add_option("--randseed", type=int, help="random number seed")
 parser.add_option("--nspec", type=int, help="Number of spectra to simulate per camera [%default]", default=500)
 parser.add_option("--ncpu",  type=int, help="Number of cpu cores to use [%default]", default=multiprocessing.cpu_count() // 2)
+parser.add_option("--wavemin",  type=float, help="Minimum wavelength to simulate")
+parser.add_option("--wavemax",  type=float, help="Maximum wavelength to simulate")
 
 opts, args = parser.parse_args()
 

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -270,7 +270,6 @@ def get_targets(nspec, flavor, tileid=None):
     fibermap['TARGETID'] = np.random.randint(sys.maxint, size=nspec)
     fibermap['TARGETCAT'] = np.zeros(nspec, dtype='|S20')
     fibermap['LAMBDAREF'] = np.ones(nspec, dtype=np.float32)*5400
-    fibermap['DESI_TARGET'] = np.zeros(nspec, dtype='i8')
     fibermap['RA_TARGET'] = ra
     fibermap['DEC_TARGET'] = dec
     fibermap['X_TARGET'] = x

--- a/py/desisim/test/test_targets.py
+++ b/py/desisim/test/test_targets.py
@@ -19,6 +19,12 @@ class TestObs(unittest.TestCase):
         n = 5
         for flavor in ['DARK', 'BRIGHT', 'LRG', 'ELG', 'QSO', 'BGS', 'MWS']:
             fibermap, truth = desisim.targets.get_targets(n, flavor)
+            
+    def test_sample_objtype(self):
+        for flavor in ['DARK', 'BRIGHT', 'LRG', 'ELG', 'QSO', 'BGS', 'MWS']:
+            for n in [5,10,50]:
+                for i in range(10):
+                    truetype, targettype = desisim.targets.sample_objtype(n, flavor)
 
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':


### PR DESCRIPTION
Starting a PR so that I can comment on this branch and its tests.

This PR updates the fibermap format to include the targeting mask bits and fills those in.

Tests will fail until the fibermap_format branch of desispec is merged into master.  That is in progress (i.e. don't merge this yet).