### PR TITLE
Streamline use of specsim by quickgen and quickbrick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Binary output files.
+*.fits

--- a/bin/quickbrick
+++ b/bin/quickbrick
@@ -36,7 +36,6 @@ parser.add_option("-o", "--outdir", type=str,  help="output data directory; defa
 parser.add_option("-a", "--airmass", type=float,  help="airmass [%default]", default=1.25)
 parser.add_option("-t", "--testwavelength", type=float,  help="test quickbrick with a single emission line", default=None)
 parser.add_option("-s", "--seed", type=int,  help="random seed", default=None)
-parser.add_option("--wavestep", type=float,  help="initial sampling of templates", default=0.2)
 parser.add_option("--outdir_truth", type=str,  help="optional alternative outdir for truth files")
 parser.add_option("-z","--zrange", type=str, help="redshift range of the form zmin:zmax (applies only to ELG,LRG,QSO)",default=None)
 

--- a/bin/quickbrick
+++ b/bin/quickbrick
@@ -32,6 +32,7 @@ parser.add_option("-b", "--brickname", type=str,  help="brickname")
 parser.add_option(      "--objtype", type=str,  help="elg,lrg,qso,star or mix")
 parser.add_option("-n", "--nspec", type=int,  help="number of spectra to simulate")
 parser.add_option("-o", "--outdir", type=str,  help="output data directory; default .", default='.')
+parser.add_option("--config", type=str, help="specsim configuration", default="desi")
 #- Average DESI airmass 1.25; (See Science Req. Doc L3.3.2)
 parser.add_option("-a", "--airmass", type=float,  help="airmass [%default]", default=1.25)
 parser.add_option("-t", "--testwavelength", type=float,  help="test quickbrick with a single emission line", default=None)
@@ -53,7 +54,7 @@ assert opts.objtype in ['ELG', 'LRG', 'QSO', 'STAR', 'TEST', 'MIX']
 random_state = np.random.RandomState(opts.seed)
 
 #- Initialize the quick simulator object
-qsim = specsim.simulator.Simulator('desi')
+qsim = specsim.simulator.Simulator(opts.config)
 qsim.atmosphere.airmass = opts.airmass
 qsim.instrument.exposure_time = desiparams['exptime'] * u.s
 

--- a/bin/quickbrick
+++ b/bin/quickbrick
@@ -52,9 +52,8 @@ assert opts.objtype is not None
 opts.objtype = opts.objtype.upper()
 assert opts.objtype in ['ELG', 'LRG', 'QSO', 'STAR', 'TEST', 'MIX']
 
-#- Set random seed if defined
-if opts.seed is not None :
-    np.random.seed(opts.seed)
+#- Initialize random state to use throughput.
+random_state = np.random.RandomState(opts.seed)
 
 #- Initialize the quick simulator object
 qsim = specsim.simulator.Simulator('desi')
@@ -170,7 +169,7 @@ for objtype in set(true_objtype):
 
 #- Create a blank fake fibermap; this is re-used by all channels
 fibermap = desispec.io.empty_fibermap(opts.nspec)
-targetids = np.random.randint(2**62, size=opts.nspec)
+targetids = random_state.randint(2**62, size=opts.nspec)
 fibermap['TARGETID'] = targetids
 night = desisim.obs.get_night()
 expid = 0
@@ -222,7 +221,7 @@ for i in range(opts.nspec):
 
     #- Run the simulation for this source and add noise.
     qsim.simulate()
-    qsim.generate_random_noise()
+    qsim.generate_random_noise(random_state)
 
     #- Fill brick arrays from the results.
     for camera, output in zip(qsim.instrument.cameras, qsim.camera_output):

--- a/bin/quickbrick
+++ b/bin/quickbrick
@@ -10,7 +10,6 @@ Fall 2015
 
 import sys, os
 import numpy as np
-import scipy.sparse
 import string
 
 from astropy.table import Table, Column, vstack
@@ -19,11 +18,10 @@ from astropy.io import fits
 
 import desimodel.io
 import specsim.simulator
-import desispec
+import desispec.io
 from desispec.log import get_logger
 from desispec.resolution import Resolution
 import desisim.templates
-import desisim.obs
 
 import desisim.targets
 

--- a/bin/quickbrick
+++ b/bin/quickbrick
@@ -15,12 +15,13 @@ import string
 
 from astropy.table import Table, Column, vstack
 import astropy.units as u
+from astropy.io import fits
 
 import desimodel.io
-import specsim.config
 import specsim.simulator
 import desispec
 from desispec.log import get_logger
+from desispec.resolution import Resolution
 import desisim.templates
 import desisim.obs
 
@@ -38,7 +39,6 @@ parser.add_option("-a", "--airmass", type=float,  help="airmass [%default]", def
 parser.add_option("-t", "--testwavelength", type=float,  help="test quickbrick with a single emission line", default=None)
 parser.add_option("-s", "--seed", type=int,  help="random seed", default=None)
 parser.add_option("--wavestep", type=float,  help="initial sampling of templates", default=0.2)
-parser.add_option("--downsampling", type=int,  help="downsampling value", default=3)
 parser.add_option("--outdir_truth", type=str,  help="optional alternative outdir for truth files")
 parser.add_option("-z","--zrange", type=str, help="redshift range of the form zmin:zmax (applies only to ELG,LRG,QSO)",default=None)
 
@@ -56,23 +56,13 @@ assert opts.objtype in ['ELG', 'LRG', 'QSO', 'STAR', 'TEST', 'MIX']
 if opts.seed is not None :
     np.random.seed(opts.seed)
 
-#- Load the default DESI simulation configuration.
-config = specsim.config.load_config('desi')
+#- Initialize the quick simulator object
+qsim = specsim.simulator.Simulator('desi')
+qsim.atmosphere.airmass = opts.airmass
+qsim.instrument.exposure_time = desiparams['exptime'] * u.s
 
-#- Modify defaults from command-line args.
-config.atmosphere.airmass = opts.airmass
-config.instrument.constants.exposure_time = '{0} s'.format(desiparams['exptime'])
-config.simulator.downsampling = opts.downsampling
-
-#- Wavelength grid to cover all channels
-config.wavelength_grid.min = desimodel.io.load_throughput('b').wavemin
-config.wavelength_grid.max = desimodel.io.load_throughput('z').wavemax
-config.wavelength_grid.step = opts.wavestep
-config.update()
-wave = config.wavelength.value
-
-#- Create the quick simulator object
-qsim = specsim.simulator.Simulator(config)
+#- Lookup the source wavelength grid.
+wave = qsim.source.wavelength_out.to(u.Angstrom).value
 
 #- If opts.objtype='MIX', get distribution of target types from sample_objtype
 if opts.objtype.lower() == 'mix':
@@ -200,90 +190,63 @@ meta.add_column(Column(targetids, name='TARGETID'))
 #- rename REDSHIFT -> TRUEZ anticipating later table joins with zbest.Z
 meta.rename_column('REDSHIFT', 'TRUEZ')
 
+#- Initialize per-camera output arrays that will be saved to the brick files.
+cwave, trueflux, noisyflux, obsivar, resolution, sflux = {}, {}, {}, {}, {}, {}
+for camera in qsim.instrument.cameras:
+    cwave[camera.name] = (
+        camera.output_wavelength.to(u.Angstrom).value.astype(np.float32))
+    nwave = len(cwave[camera.name])
+    trueflux[camera.name] = np.empty((opts.nspec, nwave), dtype=np.float32)
+    noisyflux[camera.name] = np.empty_like(trueflux[camera.name])
+    obsivar[camera.name] = np.empty_like(trueflux[camera.name])
+    # Lookup this camera's resolution matrix and convert to the sparse
+    # format used in desispec.
+    R = Resolution(camera.get_output_resolution_matrix())
+    resolution[camera.name] = np.tile(R.to_fits_array(), [opts.nspec, 1, 1])
+    # Source flux uses the high-resolution simulation grid.
+    sflux = np.empty((opts.nspec, len(wave)), dtype=np.float32)
+
 #- Actually do the simulations for each target
 fluxunits = u.erg / (u.s * u.cm ** 2 * u.Angstrom)
-
-#- output arrays to fill; these cover wavelengths across all cameras
-srcflux={}
-trueflux={}
-obsivar={}
-obswave=None
-for camera in qsim.instrument.cameras:
-    trueflux[camera.name]=list()
-    obsivar[camera.name]=list()
-
-#- convert list of arrays to 2D arrays
 for i in range(opts.nspec):
     #- if objtype is QSO_BAD or TEST then simulate a star
     if (truth['OBJTYPE'][i] == 'QSO_BAD' or truth['OBJTYPE'][i] == 'TEST'):
         truth['OBJTYPE'][i]='STAR'
+
+    #- Update the source model to simulate.
     qsim.source.update_in(
         'Quickbrick source {0}'.format(i), truth['OBJTYPE'][i].lower(),
         truth['WAVE'] * u.Angstrom, truth['FLUX'][i] * fluxunits)
     qsim.source.update_out()
-    results = qsim.simulate()
+    sflux[i][:] = 1e17 * qsim.source.flux_out.to(fluxunits).value
 
-    #- output wavelength grid is the same for all spectra
-    if obswave is None :
-        obswave=results.wave
-    else :
-        assert (np.sum((obswave-results.wave)**2)==0.)
+    #- Run the simulation for this source and add noise.
+    qsim.simulate()
+    qsim.generate_random_noise()
 
-    # now we collect the results
-    for j, camera in enumerate(qsim.instrument.cameras):
-        trueflux[camera.name].append(results.camflux[:,j])
-        obsivar[camera.name].append(results.camivar[:,j])
+    #- Fill brick arrays from the results.
+    for camera, output in zip(qsim.instrument.cameras, qsim.camera_output):
+        assert output['observed_flux'].unit == fluxunits
+        trueflux[camera.name][i][:] = 1e17 * output['observed_flux']
+        noisyflux[camera.name][i][:] = 1e17 * (
+            output['observed_flux'] +
+            output['flux_calibration'] * output['random_noise_electrons'])
+        obsivar[camera.name][i][:] = 1e-34 * output['flux_inverse_variance']
 
-    # collect the source flux
-    srcflux[i]=list()
-    srcflux[i]=qsim.sourceFlux
+#- Define a utility function for adding truth to an output FITS file.
+def add_truth(hdus, header, channel):
+    header = desispec.io.fitsheader(header)
+    hdus.append(
+        fits.ImageHDU(trueflux[channel], name='_TRUEFLUX', header=header))
+    if channel == 'b':
+        swave = wave.astype(np.float32)
+        hdus.append(fits.ImageHDU(swave, name='_SOURCEWAVE', header=header))
+        hdus.append(fits.ImageHDU(sflux, name='_SOURCEFLUX', header=header))
+    hdus.append(fits.BinTableHDU(meta.as_array(), name='_TRUTH'))
 
-srcfl=dict()
-srcfl['SOURCE']=np.zeros( (opts.nspec,len(qsim.wavelengthGrid)) )
-for i in range(opts.nspec):
-    srcflux[i]=np.array(srcflux[i])
-    srcfl['SOURCE'][i] = srcflux[i]
+#- Write brick output
+for channel in 'brz':
 
-#- convert list of arrays to 2D arrays
-for camera in qsim.instrument.cameras:
-    trueflux[camera.name] = np.array(trueflux[camera.name])
-    obsivar[camera.name] = np.array(obsivar[camera.name])
-
-#- add noise
-noisyflux={}
-for camera in qsim.instrument.cameras:
-    noisyflux[camera.name] = np.zeros_like(trueflux[camera.name])
-    ii = np.where(obsivar[camera.name] > 0.01)
-    sigma = 1/np.sqrt(obsivar[camera.name][ii])
-    noisyflux[camera.name][ii] = trueflux[camera.name][ii] + np.random.normal(loc=0, scale=sigma)
-
-#- Select the wavelengths for each camera and output brick files
-for j, camera in enumerate(qsim.instrument.cameras):
-    channel = camera.name
-    #- Sparse full resolution matrix for this camera
-    R = qsim.cameras[j].sparseKernel
-
-    #- Trim R to range with non-zeros in even multiples of the downsampling
-    nd = opts.downsampling
-    ii = np.where(R.sum(axis=0).A[0])[0]
-    begin, end = (ii[0]//nd)*nd, ((ii[-1]+1)//nd)*nd
-    R = R[begin:end, begin:end]
-
-    #- indices of downsampled flux, ivar to keep
-    iiobs = np.arange(begin, end, nd) // nd
-
-    #- Downsample the resolution matrix
-    s = R.shape[1]//nd, nd, R.shape[0]//nd, nd
-    Rx = R.toarray().reshape(s).sum(-1).sum(1) / nd
-    Rdata = scipy.sparse.dia_matrix(Rx).data
-
-    #- replicate for all spectra for the output file
-    Rdata = np.array([Rdata for i in range(opts.nspec)])
-
-
-#    print 'wavelenthGrid %s, sourceFlux %s'%(qsim.wavelengthGrid,qsim.sourceFlux)
-
-    #- Write brick output
     filename = 'brick-{}-{}.fits'.format(channel, opts.brickname)
     filepath = os.path.join(opts.outdir, filename)
     if os.path.exists(filepath):
@@ -291,33 +254,22 @@ for j, camera in enumerate(qsim.instrument.cameras):
 
     header = dict(BRICKNAM=opts.brickname, CHANNEL=channel)
     brick = desispec.io.Brick(filepath, mode='update', header=header)
-    brick.add_objects(noisyflux[channel][:,iiobs].astype(np.float32), obsivar[channel][:,iiobs].astype(np.float32),
-        obswave[iiobs].astype(np.float32), Rdata.astype(np.float32), fibermap, night, expid)
+    brick.add_objects(
+        noisyflux[channel], obsivar[channel],
+        cwave[channel], resolution[channel], fibermap, night, expid)
     brick.close()
 
     #- Append truth to the file
     #- Note: Resolution convolved true flux, not high resolution source flux;
     #-       This makes chi2 calculations easier
-    from astropy.io import fits
-
     if opts.outdir_truth is None : # add truth in same file
         fx = fits.open(filepath, mode='append')
-        header = desispec.io.fitsheader(header)
-        fx.append(fits.ImageHDU(trueflux[channel][:,iiobs].astype(np.float32), name='_TRUEFLUX', header=header))
-        if (channel == 'b'):
-            fx.append(fits.ImageHDU(qsim.wavelengthGrid.astype(np.float32), name='_SOURCEWAVE', header=header))
-            fx.append(fits.ImageHDU(srcfl['SOURCE'].astype(np.float32), name='_SOURCEFLUX', header=header))
-        fx.append(fits.BinTableHDU(meta.as_array(), name='_TRUTH'))
+        add_truth(fx, header, channel)
         fx.flush()
         fx.close()
-    else :
-        header = desispec.io.fitsheader(header)
+    else:
         hdulist = fits.HDUList([fits.PrimaryHDU(header=header)])
-        hdulist.append(fits.ImageHDU(trueflux[channel][:,iiobs].astype(np.float32), name='_TRUEFLUX', header=header))
-        if (channel == 'b'):
-            hdulist.append(fits.ImageHDU(qsim.wavelengthGrid.astype(np.float32), name='_SOURCEWAVE', header=header))
-            hdulist.append(fits.ImageHDU(srcfl['SOURCE'].astype(np.float32), name='_SOURCEFLUX', header=header))
-        hdulist.append(fits.BinTableHDU(meta.as_array(), name='_TRUTH'))
+        add_truth(hdulist, header, channel)
         filename = 'truth-brick-{}-{}.fits'.format(channel, opts.brickname)
         filepath = os.path.join(opts.outdir_truth, filename)
         hdulist.writeto(filepath,clobber=True)

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -44,6 +44,7 @@ parser.add_argument("--fibermap",type=str, help='input fibermap file')
 parser.add_argument("--nspec",type=int,default=5000,help='no. of spectra to be simulated, starting from first')
 parser.add_argument("--nstart", type=int, default=0,help='starting spectra # for simulation 0-4999')
 parser.add_argument("--spectrograph",type=int, default=None,help='Spectrograph no. 0-9')
+parser.add_argument("--config", type=str, default='desi', help='specsim configuration')
 parser.add_argument("--seed", type=int, default=0,  help="random seed")
 args = parser.parse_args()
 
@@ -140,8 +141,8 @@ print "Simulating spectra",args.nstart, "to", nmax
 
 print "************************************************"
 
-print "Initializing SpecSim"
-qsim = specsim.simulator.Simulator('desi')
+print "Initializing SpecSim with config '{0}'".format(args.config)
+qsim = specsim.simulator.Simulator(args.config)
 
 # Set simulation parameters from the simspec header.
 qsim.atmosphere.airmass = simspec.header['AIRMASS']

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -287,8 +287,9 @@ for j in xrange(args.nstart,nmax): # Exclusive
         # The factor of 25 here represents an average over 25 sky fibers.
         sky_ivar[j, i, :num_pixels] = 25.0 / sky_var
 
-        cframe_observedflux[j,i,:waveMaxbin[channel]]=results.obsflux[waveRange[channel]]*1.0e-17
-        cframe_ivar[j,i,:waveMaxbin[channel]]=np.clip(results.ivar[waveRange[channel]]*1.0e34, 1e-12, np.max(results.ivar[waveRange[channel]]*1.0e34))
+        assert output['observed_flux'].unit == u.erg / (u.cm**2 * u.s * u.Angstrom)
+        cframe_observedflux[j, i, :num_pixels] = output['observed_flux']
+        cframe_ivar[j, i, :num_pixels] = output['flux_inverse_variance']
 
         frame_rand_noise[j,i,:waveMaxbin[channel]]=np.random.normal(np.zeros(waveMaxbin[channel]),np.ones(waveMaxbin[channel])/np.sqrt(nivar[j,i,:waveMaxbin[channel]]),waveMaxbin[channel])
 

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -23,7 +23,6 @@ import scipy.interpolate
 import sys
 import desispec
 import desisim.io
-import specsim.config
 import specsim.simulator
 import astropy.units as u
 from desispec.resolution import Resolution
@@ -137,29 +136,19 @@ print "Simulating spectra",args.nstart, "to", nmax
 
 print "************************************************"
 
-# Run Simulation for first Spectrum
 print "Initializing SpecSim"
-config = specsim.config.load_config('desi')
-
-# Match the simulation to the wavelength coverage of the input spectra.
-config.wavelength_grid.min = wavelengths[0]
-config.wavelength_grid.max = wavelengths[-1]
-config.update()
-
-# Initialize the quick simulator.
-qsim = specsim.simulator.Simulator(config)
+qsim = specsim.simulator.Simulator('desi')
 
 # Set simulation parameters from the simspec header.
 qsim.atmosphere.airmass = simspec.header['AIRMASS']
 qsim.instrument.exposure_time = simspec.header['EXPTIME'] * u.s
 
-qsim.downsampling = 5
-fluxunits = 1e-17 * u.erg / (u.s * u.cm ** 2 * u.Angstrom)
-
 #- simulate a fake object 0 just to get wavelength grids etc setup
 results=qsim.simulate()
 observedWavelengths=results.wave
 origin_wavelength=qsim.wavelengthGrid
+
+assert np.array_equal(origin_wavelength, qsim.simulated['wavelength'])
 
 # Get the camera ranges and resolution from the specsim instrument model.
 waveLimits=dict()
@@ -173,6 +162,9 @@ for i,camera in enumerate(qsim.instrument.cameras):
     waveRange[channel],=np.where((observedWavelengths>=waveLimits[channel][0])&(observedWavelengths<=waveLimits[channel][1]))
     waveMaxbin[channel],=waveRange[channel].shape
     waves[channel]=observedWavelengths[waveRange[channel]]
+
+    assert np.array_equal(waves[channel], camera.output_wavelength.value)
+
     # Interpolate the RMS resolution from the simulation grid to the output grid.
     interpolator = scipy.interpolate.interp1d(
         origin_wavelength, qsim.cameras[i].sigmaWavelength,
@@ -270,6 +262,7 @@ for i, channel in enumerate( ['b', 'r', 'z'] ):
     resolution_data[channel] = _calc_resolution_data(sigma_vs_wave[channel], waves[channel], nspec)
 
 # Now repeat the simulation for all spectra
+fluxunits = 1e-17 * u.erg / (u.s * u.cm ** 2 * u.Angstrom)
 for j in xrange(args.nstart,nmax): # Exclusive
     print "\rSimulating spectrum %d,  object type=%s"%(j,objtype[j]),
     sys.stdout.flush()
@@ -279,14 +272,19 @@ for j in xrange(args.nstart,nmax): # Exclusive
     qsim.source.update_out()
     results=qsim.simulate()
 
-    for i,channel in enumerate(['b','r','z']):
-        nobj[j,i,:waveMaxbin[channel]]=results.nobj[waveRange[channel],i]
+    for i,channel in enumerate('brz'):
 
-        nsky[j,i,:waveMaxbin[channel]]=results.nsky[waveRange[channel],i]
+        output = qsim.camera_output[i]
+        num_pixels = len(output)
+        nobj[j, i, :num_pixels] = output['num_source_electrons']
+        nsky[j, i, :num_pixels] = output['num_sky_electrons']
 
-        nivar[j,i,:waveMaxbin[channel]]=1/((results.nobj[waveRange[channel],i])+(results.nsky[waveRange[channel],i])+(results.rdnoise[waveRange[channel],i])**2.0+(results.dknoise[waveRange[channel],i])**2.0)
-
-        sky_ivar[j,i,:waveMaxbin[channel]]=25*1/((results.nsky[waveRange[channel],i])+(results.rdnoise[waveRange[channel],i])**2.0+(results.dknoise[waveRange[channel],i])**2.0)
+        sky_var = (
+            output['num_sky_electrons'] + output['num_dark_electrons'] +
+            output['read_noise_electrons'] ** 2)
+        sky_ivar[j, i, :num_pixels] = 1.0 / sky_var
+        nivar[j, i, :num_pixels] = 1.0 / (
+            sky_var + output['num_source_electrons'])
 
         cframe_observedflux[j,i,:waveMaxbin[channel]]=results.obsflux[waveRange[channel]]*1.0e-17
         cframe_ivar[j,i,:waveMaxbin[channel]]=np.clip(results.ivar[waveRange[channel]]*1.0e34, 1e-12, np.max(results.ivar[waveRange[channel]]*1.0e34))

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -150,9 +150,6 @@ qsim.instrument.exposure_time = simspec.header['EXPTIME'] * u.s
 #- simulate a fake object 0 just to get wavelength grids etc setup
 results=qsim.simulate()
 observedWavelengths=results.wave
-origin_wavelength=qsim.wavelengthGrid
-
-assert np.array_equal(origin_wavelength, qsim.simulated['wavelength'])
 
 # Get the camera ranges and resolution from the specsim instrument model.
 waveLimits=dict()
@@ -169,27 +166,25 @@ for i,camera in enumerate(qsim.instrument.cameras):
 
     assert np.array_equal(waves[channel], camera.output_wavelength.value)
 
-    # Interpolate the RMS resolution from the simulation grid to the output grid.
-    interpolator = scipy.interpolate.interp1d(
-        origin_wavelength, qsim.cameras[i].sigmaWavelength,
-        kind='linear', copy=False, assume_sorted=True)
-    sigma_vs_wave[channel] = interpolator(waves[channel])
-
 maxbin=max(waveMaxbin['b'],waveMaxbin['r'],waveMaxbin['z'])
 
 #- Check if input simspec is for a continuum flat lamp instead of science
 #- This does not convolve to per-fiber resolution
 if simspec.flavor == 'flat':
     print "Simulating flat lamp exposure"
-    for channel in ('b', 'r', 'z'):
-
-        ii = (waveLimits[channel][0] <= observedWavelengths) & (observedWavelengths <= waveLimits[channel][1])
-        wave = observedWavelengths[ii]
+    for i,camera in enumerate(qsim.instrument.cameras):
+        channel = camera.name
+        assert camera.output_wavelength.unit == u.Angstrom
+        wave = camera.output_wavelength.value
+        num_pixels = len(wave)
         dw = np.gradient(simspec.wave[channel])
-        meanspec = resample_flux(wave, simspec.wave[channel], np.average(simspec.phot[channel]/dw, axis=0))
-        fiberflat = random_state.normal(loc=0.0, scale=1.0/np.sqrt(meanspec), size=(nspec, len(wave)))
-        ivar = np.tile(1.0/meanspec, nspec).reshape(nspec, len(meanspec))
-        mask = np.zeros((simspec.nspec, len(wave)))
+        meanspec = resample_flux(
+            wave, simspec.wave[channel],
+            np.average(simspec.phot[channel]/dw, axis=0))
+        fiberflat = random_state.normal(
+            scale=1.0 / np.sqrt(meanspec), size=(nspec, num_pixels))
+        ivar = np.tile(1.0 / meanspec, [nspec, 1])
+        mask = np.zeros((simspec.nspec, num_pixels))
 
         for kk in range((args.nspec+args.nstart-1)/500+1):
             camera = channel+str(kk)

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -44,7 +44,11 @@ parser.add_argument("--fibermap",type=str, help='input fibermap file')
 parser.add_argument("--nspec",type=int,default=5000,help='no. of spectra to be simulated, starting from first')
 parser.add_argument("--nstart", type=int, default=0,help='starting spectra # for simulation 0-4999')
 parser.add_argument("--spectrograph",type=int, default=None,help='Spectrograph no. 0-9')
+parser.add_argument("--seed", type=int, default=0,  help="random seed")
 args = parser.parse_args()
+
+# Initialize random number generator to use.
+random_state = np.random.RandomState(args.seed)
 
 # Derive spectrograph number from nstart if needed
 if args.spectrograph is None:
@@ -183,7 +187,7 @@ if simspec.flavor == 'flat':
         wave = observedWavelengths[ii]
         dw = np.gradient(simspec.wave[channel])
         meanspec = resample_flux(wave, simspec.wave[channel], np.average(simspec.phot[channel]/dw, axis=0))
-        fiberflat = np.random.normal(loc=0.0, scale=1.0/np.sqrt(meanspec), size=(nspec, len(wave)))
+        fiberflat = random_state.normal(loc=0.0, scale=1.0/np.sqrt(meanspec), size=(nspec, len(wave)))
         ivar = np.tile(1.0/meanspec, nspec).reshape(nspec, len(meanspec))
         mask = np.zeros((simspec.nspec, len(wave)))
 
@@ -214,8 +218,6 @@ cframe_ivar=np.zeros((nmax,3,maxbin))    # inverse variance of calibrated object
 frame_rand_noise=np.zeros((nmax,3,maxbin))     # random Gaussian noise to nobj+nsky
 sky_rand_noise=np.zeros((nmax,3,maxbin))  # random Gaussian noise to sky only
 cframe_rand_noise=np.zeros((nmax,3,maxbin))  # random Gaussian noise to calibrated flux
-
-np.random.seed(0)
 
 #construct resolution matrix from sigma_vs_wave.
 
@@ -270,35 +272,36 @@ for j in xrange(args.nstart,nmax): # Exclusive
         'Quickgen source {0}'.format(j), objtype[j].lower(),
         wavelengths * u.Angstrom, spectra[j, :] * fluxunits)
     qsim.source.update_out()
-    results=qsim.simulate()
+    qsim.simulate()
+    qsim.generate_random_noise(random_state)
 
     for i, output in enumerate(qsim.camera_output):
 
+        # Extract the simulation results needed to create our uncalibrated
+        # frame output file.
         num_pixels = len(output)
         nobj[j, i, :num_pixels] = output['num_source_electrons']
         nsky[j, i, :num_pixels] = output['num_sky_electrons']
+        nivar[j, i, :num_pixels] = 1.0 / output['variance_electrons']
 
-        sky_var = (
-            output['num_sky_electrons'] + output['num_dark_electrons'] +
-            output['read_noise_electrons'] ** 2)
-        nivar[j, i, :num_pixels] = 1.0 / (
-            sky_var + output['num_source_electrons'])
-        # The factor of 25 here represents an average over 25 sky fibers.
-        sky_ivar[j, i, :num_pixels] = 25.0 / sky_var
-
+        # Get results for our flux-calibrated output file.
         assert output['observed_flux'].unit == u.erg / (u.cm**2 * u.s * u.Angstrom)
         cframe_observedflux[j, i, :num_pixels] = output['observed_flux']
         cframe_ivar[j, i, :num_pixels] = output['flux_inverse_variance']
 
-        frame_rand_noise[j, i, :num_pixels] = np.random.normal(
-            scale=1.0 / np.sqrt(nivar[j, i, :num_pixels]), size=num_pixels)
-        sky_rand_noise[j, i, :num_pixels] = np.random.normal(
-            scale=1.0 / np.sqrt(sky_ivar[j,i,:num_pixels]),size=num_pixels)
-
         # Use the same noise realization in the cframe and frame, without any
         # additional noise from sky subtraction for now.
+        frame_rand_noise[j, i, :num_pixels] = output['random_noise_electrons']
         cframe_rand_noise[j, i, :num_pixels] = (
-            output['flux_calibration'] * frame_rand_noise[j, i, :num_pixels])
+            output['flux_calibration'] * output['random_noise_electrons'])
+
+        # The sky output file represents a model fit to ~40 sky fibers.
+        # We reduce the variance by a factor of 25 to account for this and
+        # give the sky an independent (Gaussian) noise realization.
+        sky_ivar[j, i, :num_pixels] = 25.0 / (
+            output['variance_electrons'] - output['num_source_electrons'])
+        sky_rand_noise[j, i, :num_pixels] = random_state.normal(
+            scale=1.0 / np.sqrt(sky_ivar[j,i,:num_pixels]),size=num_pixels)
 
 
 print

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -140,18 +140,20 @@ print "************************************************"
 # Run Simulation for first Spectrum
 print "Initializing SpecSim"
 config = specsim.config.load_config('desi')
-config.atmosphere.airmass = simspec.header['AIRMASS']
-config.instrument.constants.exposure_time = '{0} s'.format(simspec.header['EXPTIME'])
-config.simulator.downsampling = 5
 
-# Set the simulation wavelength grid.
-config.wavelength_grid.min = 3569.
-config.wavelength_grid.max = 9834.
-config.wavelength_grid.step = 0.1
+# Match the simulation to the wavelength coverage of the input spectra.
+config.wavelength_grid.min = wavelengths[0]
+config.wavelength_grid.max = wavelengths[-1]
 config.update()
 
-#- Initialize the quick simulator.
-qsim=specsim.simulator.Simulator(config)
+# Initialize the quick simulator.
+qsim = specsim.simulator.Simulator(config)
+
+# Set simulation parameters from the simspec header.
+qsim.atmosphere.airmass = simspec.header['AIRMASS']
+qsim.instrument.exposure_time = simspec.header['EXPTIME'] * u.s
+
+qsim.downsampling = 5
 fluxunits = 1e-17 * u.erg / (u.s * u.cm ** 2 * u.Angstrom)
 
 #- simulate a fake object 0 just to get wavelength grids etc setup

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -147,26 +147,14 @@ qsim = specsim.simulator.Simulator('desi')
 qsim.atmosphere.airmass = simspec.header['AIRMASS']
 qsim.instrument.exposure_time = simspec.header['EXPTIME'] * u.s
 
-#- simulate a fake object 0 just to get wavelength grids etc setup
-results=qsim.simulate()
-observedWavelengths=results.wave
-
-# Get the camera ranges and resolution from the specsim instrument model.
-waveLimits=dict()
-waveRange=dict()
-waveMaxbin=dict()
+# Get the camera output pixels from the specsim instrument model.
+maxbin = 0
 waves=dict()
-sigma_vs_wave = dict()
 for i,camera in enumerate(qsim.instrument.cameras):
     channel = camera.name
-    waveLimits[channel] = (camera.wavelength_min.value, camera.wavelength_max.value)
-    waveRange[channel],=np.where((observedWavelengths>=waveLimits[channel][0])&(observedWavelengths<=waveLimits[channel][1]))
-    waveMaxbin[channel],=waveRange[channel].shape
-    waves[channel]=observedWavelengths[waveRange[channel]]
-
-    assert np.array_equal(waves[channel], camera.output_wavelength.value)
-
-maxbin=max(waveMaxbin['b'],waveMaxbin['r'],waveMaxbin['z'])
+    assert camera.output_wavelength.unit == u.Angstrom
+    waves[channel] = camera.output_wavelength.value
+    maxbin = max(maxbin, len(waves[channel]))
 
 #- Check if input simspec is for a continuum flat lamp instead of science
 #- This does not convolve to per-fiber resolution
@@ -175,11 +163,10 @@ if simspec.flavor == 'flat':
     for i,camera in enumerate(qsim.instrument.cameras):
         channel = camera.name
         assert camera.output_wavelength.unit == u.Angstrom
-        wave = camera.output_wavelength.value
-        num_pixels = len(wave)
+        num_pixels = len(waves[channel])
         dw = np.gradient(simspec.wave[channel])
         meanspec = resample_flux(
-            wave, simspec.wave[channel],
+            waves[channel], simspec.wave[channel],
             np.average(simspec.phot[channel]/dw, axis=0))
         fiberflat = random_state.normal(
             scale=1.0 / np.sqrt(meanspec), size=(nspec, num_pixels))
@@ -195,7 +182,9 @@ if simspec.flavor == 'flat':
             if (args.spectrograph <= kk):
                 print "writing files for channel:",channel,", spectrograph:",kk, ", spectra:", start,'to',end
 
-            ff = FiberFlat(wave, fiberflat[start:end,:], ivar[start:end,:], mask[start:end,:], meanspec)
+            ff = FiberFlat(
+                waves[channel], fiberflat[start:end,:],
+                ivar[start:end,:], mask[start:end,:], meanspec)
             write_fiberflat(outfile, ff)
     filePath=os.path.join(prod_Dir,'calib2d',NIGHT)
     print "Wrote files to", filePath
@@ -214,41 +203,6 @@ frame_rand_noise=np.zeros((nmax,3,maxbin))     # random Gaussian noise to nobj+n
 sky_rand_noise=np.zeros((nmax,3,maxbin))  # random Gaussian noise to sky only
 cframe_rand_noise=np.zeros((nmax,3,maxbin))  # random Gaussian noise to calibrated flux
 
-#construct resolution matrix from sigma_vs_wave.
-
-#- Resolution data from gaussian sigmas
-def _calc_resolution_data(sigma, wavelengths, nspec):
-    """
-    Return resolution matrix data
-
-    Args:
-        sigma : 1D array of sigmas in Angstroms
-        wavelengths : 1D array of equally spaced wavelengths in Angstroms
-
-    TODO: check this.  Replace with desisim.resolution.Resolution.
-    """
-    ndiag = 21
-    offsets = np.arange(-ndiag//2+1,ndiag//2+1,1.0)
-    nwave = len(wavelengths)
-    dw = np.gradient(wavelengths)
-
-    resolution_data = np.zeros((ndiag, nwave))
-    for i in range(nwave):
-        x = offsets * dw[i] / sigma[i]
-        dx = dw[i] / sigma[i]
-
-        edges = np.concatenate([x-dx/2, x[-1:]+dx/2])
-        assert len(edges) == len(x)+1
-
-        y = scipy.special.erf(edges)
-        resolution_data[:, i] = (y[1:] - y[:-1])/2
-
-    #- Convert this to [nspec, ndiag, nwave]
-    result = np.zeros((nspec, ndiag, nwave))
-    for i in range(nspec):
-        result[i] = resolution_data
-
-    return result
 
 #-------------------------------------------------------------------------
 
@@ -311,7 +265,7 @@ armName={"b":0,"r":1,"z":2}
 #3. flux calibration vector file (x3)
 #4. cframe file
 
-for channel in ["b","r","z"]:
+for channel in 'brz':
 
     #Before writing, convert from counts/bin to counts/A (as in Pixsim output)
     #Quicksim Default:
@@ -319,14 +273,15 @@ for channel in ["b","r","z"]:
     #COUNTS_OBJ - object counts in 0.5 Ang bin
     #COUNTS_SKY - sky counts in 0.5 Ang bin
 
+    num_pixels = len(waves[channel])
     dwave=np.gradient(waves[channel])
-    nobj[:,armName[channel],:waveMaxbin[channel]]/=dwave
-    frame_rand_noise[:,armName[channel],:waveMaxbin[channel]]/=dwave
-    nivar[:,armName[channel],:waveMaxbin[channel]]*=dwave**2
+    nobj[:,armName[channel],:num_pixels]/=dwave
+    frame_rand_noise[:,armName[channel],:num_pixels]/=dwave
+    nivar[:,armName[channel],:num_pixels]*=dwave**2
 
-    nsky[:,armName[channel],:waveMaxbin[channel]]/=dwave
-    sky_rand_noise[:,armName[channel],:waveMaxbin[channel]]/=dwave
-    sky_ivar[:,armName[channel],:waveMaxbin[channel]]/=dwave**2
+    nsky[:,armName[channel],:num_pixels]/=dwave
+    sky_rand_noise[:,armName[channel],:num_pixels]/=dwave
+    sky_ivar[:,armName[channel],:num_pixels]/=dwave**2
 
 
 #### Now write the outputs in DESI standard file system.    None of the output file can have more than 500 spectra
@@ -341,16 +296,16 @@ for channel in ["b","r","z"]:
         if (args.spectrograph <= ii):
             camera = "{}{}".format(channel, ii)
             print "writing files for channel:",channel,", spectrograph:",ii, ", spectra:", start,'to',end
-
+            num_pixels = len(waves[channel])
 
 ######----------------frame file-----------------------------------
 
             framefileName=desispec.io.findfile("frame",NIGHT,EXPID,camera)
 
-            frame_flux=nobj[start:end,armName[channel],:waveMaxbin[channel]]+ \
-            nsky[start:end,armName[channel],:waveMaxbin[channel]] + \
-            frame_rand_noise[start:end,armName[channel],:waveMaxbin[channel]]
-            frame_ivar=nivar[start:end,armName[channel],:waveMaxbin[channel]]
+            frame_flux=nobj[start:end,armName[channel],:num_pixels]+ \
+            nsky[start:end,armName[channel],:num_pixels] + \
+            frame_rand_noise[start:end,armName[channel],:num_pixels]
+            frame_ivar=nivar[start:end,armName[channel],:num_pixels]
 
             sh1=frame_flux.shape[0]  # required for slicing the resolution metric, resolusion matrix has (nspec,ndiag,wave)
                                       # for example if nstart =400, nspec=150: two spectrographs:
@@ -366,11 +321,10 @@ for channel in ["b","r","z"]:
 
 ############--------------------------------------------------------
     #cframe file
-    #TODO : for sky input spectrum (all zero), quicksim output flux is also zero and also ivar. Need to fix!!
 
             cframeFileName=desispec.io.findfile("cframe",NIGHT,EXPID,camera)
-            cframeFlux=cframe_observedflux[start:end,armName[channel],:waveMaxbin[channel]]+cframe_rand_noise[start:end,armName[channel],:waveMaxbin[channel]]
-            cframeIvar=cframe_ivar[start:end,armName[channel],:waveMaxbin[channel]]
+            cframeFlux=cframe_observedflux[start:end,armName[channel],:num_pixels]+cframe_rand_noise[start:end,armName[channel],:num_pixels]
+            cframeIvar=cframe_ivar[start:end,armName[channel],:num_pixels]
 
             # write cframe file
             cframe = Frame(waves[channel], cframeFlux, cframeIvar, resolution_data=resol,spectrograph=ii)
@@ -380,9 +334,9 @@ for channel in ["b","r","z"]:
             #sky file
 
             skyfileName=desispec.io.findfile("sky",NIGHT,EXPID,camera)
-            skyflux=nsky[start:end,armName[channel],:waveMaxbin[channel]] + \
-            sky_rand_noise[start:end,armName[channel],:waveMaxbin[channel]]
-            skyivar=sky_ivar[start:end,armName[channel],:waveMaxbin[channel]]
+            skyflux=nsky[start:end,armName[channel],:num_pixels] + \
+            sky_rand_noise[start:end,armName[channel],:num_pixels]
+            skyivar=sky_ivar[start:end,armName[channel],:num_pixels]
             skymask=np.zeros(skyflux.shape, dtype=int)
 
             # write sky file
@@ -393,15 +347,15 @@ for channel in ["b","r","z"]:
              # calibration vector file
 
             calibVectorFile=desispec.io.findfile("calib",NIGHT,EXPID,camera)
-            flux = cframe_observedflux[start:end,armName[channel],:waveMaxbin[channel]]
-            phot = nobj[start:end,armName[channel],:waveMaxbin[channel]]
+            flux = cframe_observedflux[start:end,armName[channel],:num_pixels]
+            phot = nobj[start:end,armName[channel],:num_pixels]
             calibration = np.zeros_like(phot)
             jj = (flux>0)
             calibration[jj] = phot[jj] / flux[jj]
 
     #- TODO: what should calibivar be?
     #- For now, model it as the noise of combining ~10 spectra
-            calibivar=10/cframe_ivar[start:end,armName[channel],:waveMaxbin[channel]]
+            calibivar=10/cframe_ivar[start:end,armName[channel],:num_pixels]
             #mask=(1/calibivar>0).astype(long)??
             mask=np.zeros(calibration.shape, dtype=int)
 

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -272,9 +272,8 @@ for j in xrange(args.nstart,nmax): # Exclusive
     qsim.source.update_out()
     results=qsim.simulate()
 
-    for i,channel in enumerate('brz'):
+    for i, output in enumerate(qsim.camera_output):
 
-        output = qsim.camera_output[i]
         num_pixels = len(output)
         nobj[j, i, :num_pixels] = output['num_source_electrons']
         nsky[j, i, :num_pixels] = output['num_sky_electrons']
@@ -291,11 +290,15 @@ for j in xrange(args.nstart,nmax): # Exclusive
         cframe_observedflux[j, i, :num_pixels] = output['observed_flux']
         cframe_ivar[j, i, :num_pixels] = output['flux_inverse_variance']
 
-        frame_rand_noise[j,i,:waveMaxbin[channel]]=np.random.normal(np.zeros(waveMaxbin[channel]),np.ones(waveMaxbin[channel])/np.sqrt(nivar[j,i,:waveMaxbin[channel]]),waveMaxbin[channel])
+        frame_rand_noise[j, i, :num_pixels] = np.random.normal(
+            scale=1.0 / np.sqrt(nivar[j, i, :num_pixels]), size=num_pixels)
+        sky_rand_noise[j, i, :num_pixels] = np.random.normal(
+            scale=1.0 / np.sqrt(sky_ivar[j,i,:num_pixels]),size=num_pixels)
 
-        sky_rand_noise[j,i,:waveMaxbin[channel]]=np.random.normal(np.zeros(waveMaxbin[channel]),np.ones(waveMaxbin[channel])/np.sqrt(sky_ivar[j,i,:waveMaxbin[channel]]),waveMaxbin[channel])
-
-        cframe_rand_noise[j,i,:waveMaxbin[channel]]=np.random.normal(0.0,1.0/np.sqrt(cframe_ivar[j,i,:waveMaxbin[channel]]))
+        # Use the same noise realization in the cframe and frame, without any
+        # additional noise from sky subtraction for now.
+        cframe_rand_noise[j, i, :num_pixels] = (
+            output['flux_calibration'] * frame_rand_noise[j, i, :num_pixels])
 
 
 print

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -161,6 +161,26 @@ results=qsim.simulate()
 observedWavelengths=results.wave
 origin_wavelength=qsim.wavelengthGrid
 
+# Get the camera ranges and resolution from the specsim instrument model.
+waveLimits=dict()
+waveRange=dict()
+waveMaxbin=dict()
+waves=dict()
+sigma_vs_wave = dict()
+for i,camera in enumerate(qsim.instrument.cameras):
+    channel = camera.name
+    waveLimits[channel] = (camera.wavelength_min.value, camera.wavelength_max.value)
+    waveRange[channel],=np.where((observedWavelengths>=waveLimits[channel][0])&(observedWavelengths<=waveLimits[channel][1]))
+    waveMaxbin[channel],=waveRange[channel].shape
+    waves[channel]=observedWavelengths[waveRange[channel]]
+    # Interpolate the RMS resolution from the simulation grid to the output grid.
+    interpolator = scipy.interpolate.interp1d(
+        origin_wavelength, qsim.cameras[i].sigmaWavelength,
+        kind='linear', copy=False, assume_sorted=True)
+    sigma_vs_wave[channel] = interpolator(waves[channel])
+
+maxbin=max(waveMaxbin['b'],waveMaxbin['r'],waveMaxbin['z'])
+
 #- Check if input simspec is for a continuum flat lamp instead of science
 #- This does not convolve to per-fiber resolution
 if simspec.flavor == 'flat':
@@ -190,31 +210,6 @@ if simspec.flavor == 'flat':
     print "Wrote files to", filePath
 
     sys.exit(0)
-
-# Get the camera ranges and resolution from the specsim instrument model.
-waveLimits=dict()
-waveRange=dict()
-waveMaxbin=dict()
-waves=dict()
-sigma_vs_wave = dict()
-for i,camera in enumerate(qsim.instrument.cameras):
-    channel = camera.name
-    waveLimits[channel] = (camera.wavelength_min.value, camera.wavelength_max.value)
-    waveRange[channel],=np.where((observedWavelengths>=waveLimits[channel][0])&(observedWavelengths<=waveLimits[channel][1]))
-    waveMaxbin[channel],=waveRange[channel].shape
-    waves[channel]=observedWavelengths[waveRange[channel]]
-    # Interpolate the RMS resolution from the simulation grid to the output grid.
-    interpolator = scipy.interpolate.interp1d(
-        origin_wavelength, qsim.cameras[i].sigmaWavelength,
-        kind='linear', copy=False, assume_sorted=True)
-    sigma_vs_wave[channel] = interpolator(waves[channel])
-    '''
-    sigma_vs_wave[channel] = specsim.spectrum.WavelengthFunction(
-        origin_wavelength,
-        qsim.cameras[i].sigmaWavelength).getResampledValues(waves[channel])
-    '''
-
-maxbin=max(waveMaxbin['b'],waveMaxbin['r'],waveMaxbin['z'])
 
 # Now break the simulated outputs in three different ranges.
 

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -260,8 +260,11 @@ def _calc_resolution_data(sigma, wavelengths, nspec):
 # resolution data in format as desired for frame file
 nspec=args.nspec
 resolution_data = dict()
-for i, channel in enumerate( ['b', 'r', 'z'] ):
-    resolution_data[channel] = _calc_resolution_data(sigma_vs_wave[channel], waves[channel], nspec)
+for i, channel in enumerate('brz'):
+    resolution_matrix = Resolution(
+        qsim.instrument.cameras[i].get_output_resolution_matrix())
+    resolution_data[channel] = np.tile(
+        resolution_matrix.to_fits_array(), [nspec, 1, 1])
 
 # Now repeat the simulation for all spectra
 fluxunits = 1e-17 * u.erg / (u.s * u.cm ** 2 * u.Angstrom)

--- a/bin/quickgen
+++ b/bin/quickgen
@@ -282,9 +282,10 @@ for j in xrange(args.nstart,nmax): # Exclusive
         sky_var = (
             output['num_sky_electrons'] + output['num_dark_electrons'] +
             output['read_noise_electrons'] ** 2)
-        sky_ivar[j, i, :num_pixels] = 1.0 / sky_var
         nivar[j, i, :num_pixels] = 1.0 / (
             sky_var + output['num_source_electrons'])
+        # The factor of 25 here represents an average over 25 sky fibers.
+        sky_ivar[j, i, :num_pixels] = 25.0 / sky_var
 
         cframe_observedflux[j,i,:waveMaxbin[channel]]=results.obsflux[waveRange[channel]]*1.0e-17
         cframe_ivar[j,i,:waveMaxbin[channel]]=np.clip(results.ivar[waveRange[channel]]*1.0e34, 1e-12, np.max(results.ivar[waveRange[channel]]*1.0e34))


### PR DESCRIPTION
The changes here depend on specsim changes in desihub/specsim#35, which will be merged and tagged (as v0.4) before this PR is merged.

Both quickgen and quickbrick now have much cleaner and consistent interactions with specsim.

Externally visible changes to quickgen:
* Add `--seed` option for reproducible results with different seeds (was always seed=0 before).
* Same noise realization is used for frame and cframe files.
* Noise and ivar are based on individual camera statistics, not the coadd, which is most noticeable at the camera edges.
* Resolution is convolved with the output pixel size.
* Sky model output now has non-zero ivar and noise (after fixing desihub/specsim/#1).

Externally visible changes to quickbrick:
* Random numbers are now reproducible.
* Remove `--wavestep` option (was 0.2A by default, now 0.1A from `desi.yaml`)
* Remove `--downsampling` option (output pixels were 3 x 0.2A by default, now 0.5A from `desi.yaml`)
* Resolution matrix now written correctly to brick files (was using non-standard number of off-diagonals).

Externally visible changes to specsim that affect both scripts:
* The sky now has extinction applied.
* Source flux can now disperse onto the CCDs from just outside.
* Initializing a simulator no longer warns about non-standard FITS units.
