### PR TITLE
refactor stellar templates, issue #64

### DIFF
--- a/bin/newexp-desi
+++ b/bin/newexp-desi
@@ -7,7 +7,7 @@ newexp-desi arc/flat/dark/bright/bgs/mws/elg/lrg/qso [options]
 
 dark: a mix of elg, qso and lrg targets
 bright: a mix of BGS and MWS targetls
-or just MWS, BGS, ELG, LRG, QSO targets. NOTE: BGS and bright not yet implemented. 
+or just MWS, BGS, ELG, LRG, QSO targets.  
 
 Stephen Bailey, LBL
 Fall 2014

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -150,7 +150,7 @@ def write_simspec(meta, truth, expid, night, header=None, outfile=None):
     #- Add Metadata table HDU; use write_bintable to get units and comments
     if meta is not None:
         comments = dict(
-            OBJTYPE     = 'Object type (ELG, LRG, QSO, STD, STAR)',
+            OBJTYPE     = 'Object type (ELG, LRG, QSO, STD, STAR, MWS_STAR, BGS)',
             REDSHIFT    = 'true object redshift',
             TEMPLATEID  = 'input template ID',
             OIIFLUX     = '[OII] flux [erg/s/cm2]',
@@ -158,7 +158,7 @@ def write_simspec(meta, truth, expid, night, header=None, outfile=None):
         )
 
         units = dict(
-            # OBJTYPE     = 'Object type (ELG, LRG, QSO, STD, STAR)',
+            # OBJTYPE     = 'Object type (ELG, LRG, QSO, STD, STAR, MWS_STAR, BGS)',
             # REDSHIFT    = 'true object redshift',
             # TEMPLATEID  = 'input template ID',
             OIIFLUX      = 'erg/s/cm2',
@@ -423,7 +423,7 @@ def read_basis_templates(objtype, outwave=None, nspec=None, infile=None):
        wavelengths outwave.
 
     Args:
-      objtype (str): object type to read (e.g., ELG, LRG, QSO, STAR, FSTD, WD).
+      objtype (str): object type to read (e.g., ELG, LRG, QSO, STAR, FSTD, WD, MWS_STAR, BGS).
       outwave (numpy.array, optional): array of wavelength at which to sample
         the spectra.
       nspec (int, optional): number of templates to return
@@ -449,6 +449,8 @@ def read_basis_templates(objtype, outwave=None, nspec=None, infile=None):
 
     ltype = objtype.lower()
     if objtype == 'FSTD':
+        ltype = 'star'
+    if objtype == 'MWS_STAR':
         ltype = 'star'
 
     if infile is None:

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -212,19 +212,16 @@ def get_targets(nspec, flavor, tileid=None):
             fibermap['DESI_TARGET'][ii] = desi_mask.QSO
 
         elif objtype == 'STD':
-            from desisim.templates import STAR
-            star = STAR(wave=wave,FSTD=True)
-            rr = (16.0, 19.0)
-            gg = (16.0, 19.5)
-            simflux, wave1, meta = \
-                star.make_templates(nmodel=nobj, rmagrange=rr, gmagrange=gg)
+            from desisim.templates import FSTD
+            fstd = FSTD(wave=wave)
+            simflux, wave1, meta = fstd.make_templates(nmodel=nobj)
             fibermap['DESI_TARGET'][ii] = desi_mask.STD_FSTAR
 
         elif objtype == 'MWS_STAR':
-            from desisim.templates import STAR
-            star = STAR(wave=wave)
+            from desisim.templates import MWS_STAR
+            mwsstar = MWS_STAR(wave=wave)
             # todo: mag ranges for different flavors of STAR targets should be in desimodel
-            simflux, wave1, meta = star.make_templates(nmodel=nobj,rmagrange=(15.0,20.0))
+            simflux, wave1, meta = mwsstar.make_templates(nmodel=nobj,rmagrange=(15.0,20.0))
             fibermap['DESI_TARGET'][ii] = desi_mask.MWS_ANY
             fibermap['MWS_TARGET'][ii] = mws_mask.MWS_PLX  #- ???
 

--- a/py/desisim/test/test_templates.py
+++ b/py/desisim/test/test_templates.py
@@ -3,7 +3,7 @@ from __future__ import division
 import os
 import unittest
 import numpy as np
-from desisim.templates import ELG, LRG, QSO, STAR
+from desisim.templates import ELG, LRG, QSO, STAR, FSTD, MWS_STAR
 
 desimodel_data_available = 'DESIMODEL' in os.environ
 desi_templates_available = 'DESI_ROOT' in os.environ
@@ -26,7 +26,7 @@ class TestTemplates(unittest.TestCase):
     @unittest.skipUnless(desi_basis_templates_available, '$DESI_BASIS_TEMPLATES was not detected.')
     def test_simple(self):
         '''Confirm that creating templates works at all'''
-        for T in [ELG, LRG, QSO, STAR]:
+        for T in [ELG, LRG, QSO, STAR, FSTD, MWS_STAR]:
             template_factory = T(wave=self.wave)
             flux, wave, meta = template_factory.make_templates(self.nspec)
             self._check_output_size(flux, wave, meta)
@@ -60,13 +60,20 @@ class TestTemplates(unittest.TestCase):
         self.assertTrue('TEFF' in meta.dtype.names)
         self.assertTrue('FEH' in meta.dtype.names)
 
-        star = STAR(wave=self.wave, FSTD=True)
-        flux, wave, meta = star.make_templates(self.nspec)
+        fstd = FSTD(wave=self.wave)
+        flux, wave, meta = fstd.make_templates(self.nspec)
         self._check_output_size(flux, wave, meta)
         self.assertTrue('LOGG' in meta.dtype.names)
         self.assertTrue('TEFF' in meta.dtype.names)
         self.assertTrue('FEH' in meta.dtype.names)
 
+        mwsstar = MWS_STAR(wave=self.wave)
+        flux, wave, meta = mwsstar.make_templates(self.nspec)
+        self._check_output_size(flux, wave, meta)
+        self.assertTrue('LOGG' in meta.dtype.names)
+        self.assertTrue('TEFF' in meta.dtype.names)
+        self.assertTrue('FEH' in meta.dtype.names)
+        
         star = STAR(wave=self.wave, WD=True)
         flux, wave, meta = star.make_templates(self.nspec)
         self._check_output_size(flux, wave, meta)
@@ -77,7 +84,7 @@ class TestTemplates(unittest.TestCase):
     @unittest.skipUnless(desi_basis_templates_available, '$DESI_BASIS_TEMPLATES was not detected.')
     def test_random_seed(self):
         '''Test that random seed works to get the same results back'''
-        for T in [ELG, LRG, QSO, STAR]:
+        for T in [ELG, LRG, QSO, STAR, FSTD, MWS_STAR]:
             Tx = T(wave=self.wave)
             flux1, wave1, meta1 = Tx.make_templates(self.nspec, seed=1)
             flux2, wave2, meta2 = Tx.make_templates(self.nspec, seed=1)


### PR DESCRIPTION
Refactor STAR template class to make it easy to create multiple kinds of DESI stellar targets without proliferating arguments and if statements. There are now FSTD and MWS_STAR classes that inherit from the STAR class.  This is done "new class" style, I can change to the older style if preferred. Corresponding changes to target.py and io.py to use the new stellar template classes in newexp-desi for the mws, bgs and bright options.  The only remaining problem for bright sims is that spectre understands none of objtype=BGS, MWS_STAR or FSTD and uses the default for the throughput for all three.  That can only be right for the extended source or the stars, not both.  