### PR TITLE
Cleanup

### DIFF
--- a/bin/newexp-desi
+++ b/bin/newexp-desi
@@ -19,7 +19,6 @@ import numpy as np
 import optparse
 import random
 import time
-import multiprocessing
 import string
 
 from desisim import obs, io

--- a/bin/newexp-desi
+++ b/bin/newexp-desi
@@ -32,7 +32,7 @@ parser = optparse.OptionParser(
     epilog = "See $SPECTER_DIR/doc/datamodel.md for input format details"
     )
         
-parser.add_option("--flavor",   type=str,   help="arc/flat/dark/bright/bgs/mws/elg/lrg/qso", default='dark')
+parser.add_option("--flavor",   type=str,   help="arc/flat/dark/gray/bright/bgs/mws/elg/lrg/qso", default='dark')
 parser.add_option("--tileid",   type=int,   help="tile id")
 parser.add_option("--expid",    type=int,   help="exposure id")
 parser.add_option("--exptime",  type=int,   help="exposure time in seconds, default for arc = 5s, flat = 10s, dark/elg/lrg/qso=1000s, bright/bgs/mws=300s ")
@@ -64,8 +64,9 @@ if opts.expid is None:
 if opts.night is None:
     opts.night = obs.get_night(utc=time.gmtime())
 
-if string.lower(opts.flavor) not in ['arc','flat','dark','bright','bgs','mws','lrg','elg','qso']:
-    print(opts.flavor + ': unknown flavor')
+opts.flavor = opts.flavor.lower()
+if opts.flavor not in ['arc','flat','dark','gray','grey','bright','bgs','mws','lrg','elg','qso']:
+    log.fatal('ERROR: unknown flavor {}'.format(opts.flavor))
     sys.exit(1)
 
     
@@ -75,12 +76,12 @@ if opts.exptime is None:
         opts.exptime = 5
     elif opts.flavor == 'flat':
         opts.exptime = 10
-    elif (opts.flavor == 'bright') or (string.lower(opts.flavor) == 'bgs') or (string.lower(opts.flavor) == 'mws'):
+    elif opts.flavor in ('bright', 'mws', 'bgs'):
         opts.exptime = 300
-    elif (opts.flavor == 'dark') or (string.lower(opts.flavor) == 'elg') or (string.lower(opts.flavor) == 'lrg') or (string.lower(opts.flavor) == 'qso'):
+    elif opts.flavor in ('dark', 'elg', 'lrg', 'qso', 'gray', 'grey'):
         opts.exptime = 1000
     else:
-        print('Do not know the default exposure time for flavor' + flavor)
+        print('Do not know the default exposure time for flavor' + opts.flavor)
         sys.exit(1)
     
     

--- a/bin/pixsim-desi
+++ b/bin/pixsim-desi
@@ -81,7 +81,7 @@ for camera in opts.cameras:
     #- Simulate
     pixsim.simulate(opts.night, opts.expid, camera, verbose=opts.verbose,
         nspec=opts.nspec, ncpu=opts.ncpu, trimxy=opts.trimxy,
-        cosmics=opts.cosmics)
+        cosmics=opts.cosmics, wavemin=opts.wavemin, wavemax=opts.wavemax)
 
 #-------------------------------------------------------------------------
 # if opts.debug:

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -150,7 +150,7 @@ def write_simspec(meta, truth, expid, night, header=None, outfile=None):
     #- Add Metadata table HDU; use write_bintable to get units and comments
     if meta is not None:
         comments = dict(
-            OBJTYPE     = 'Object type (ELG, LRG, QSO, STD, STAR, MWS_STAR, BGS)',
+            OBJTYPE     = 'Object type (ELG,LRG,QSO,STD,STAR,MWS_STAR,BGS)',
             REDSHIFT    = 'true object redshift',
             TEMPLATEID  = 'input template ID',
             OIIFLUX     = '[OII] flux [erg/s/cm2]',

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -489,7 +489,7 @@ def read_basis_templates(objtype, outwave=None, nspec=None, infile=None):
         meta = meta[these]
 
     # Optionally resample the templates at specific wavelengths.  Use
-    #multiprocessing to speed this up.
+    # multiprocessing to speed this up.
     if outwave is None:
         outflux = flux # Do I really need to copy these variables!
         outwave = wave

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -1,5 +1,7 @@
 #- Utility functions related to simulating observations for DESI
 
+from __future__ import absolute_import, division, print_function
+
 import os, sys
 import numpy as np
 import yaml
@@ -13,7 +15,10 @@ import desimodel.io
 import desispec.io
 from desispec.interpolation import resample_flux
 
-from targets import get_targets
+from desispec.log import get_logger
+log = get_logger()
+
+from .targets import get_targets
 from . import io
 
 def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
@@ -58,7 +63,8 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
         night = str(night)  #- just in case we got an integer instead of string
         dateobs = time.strptime(night+':22', '%Y%m%d:%H')
     
-    params = desimodel.io.load_desiparams()    
+    params = desimodel.io.load_desiparams()
+    flavor = flavor.lower()
     if flavor == 'arc':
         infile = os.getenv('DESI_ROOT')+'/spectro/templates/calib/v0.2/arc-lines-average.fits'
         d = fits.getdata(infile, 1)
@@ -112,10 +118,14 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
             exptime = params['exptime']
     
         #- Load sky [Magic knowledge of units 1e-17 erg/s/cm2/A/arcsec2]
-        if flavor.lower() in ('bright', 'bgs', 'mws'):
+        if flavor in ('bright', 'bgs', 'mws'):
             skyfile = os.getenv('DESIMODEL')+'/data/spectra/spec-sky-bright.dat'
+        elif flavor in ('gray', 'grey'):
+            skyfile = os.getenv('DESIMODEL')+'/data/spectra/spec-sky-grey.dat'
         else:
             skyfile = os.getenv('DESIMODEL')+'/data/spectra/spec-sky.dat'
+
+        log.info('skyfile '+skyfile)
 
         skywave, skyflux = np.loadtxt(skyfile, unpack=True)
         skyflux = np.interp(wave, skywave, skyflux)
@@ -128,8 +138,8 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
         
             #- Project flux to photons
             phot = thru.photons(wave[ii], flux[:,ii], units=truth['UNITS'],
-                    objtype=truth['OBJTYPE'], exptime=exptime,
-                    airmass=airmass)
+                    objtype=specter_objtype(truth['OBJTYPE']),
+                    exptime=exptime, airmass=airmass)
                 
             truth['PHOT_'+channel] = phot
             truth['WAVE_'+channel] = wave[ii]
@@ -177,7 +187,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
     #- ISO 8601 DATE-OBS year-mm-ddThh:mm:ss
     fiberfile = desispec.io.findfile('fibermap', night, expid)
     desispec.io.write_fibermap(fiberfile, fibermap, header=hdr)
-    print fiberfile
+    log.info('Wrote '+fiberfile)
     
     #- Write simspec; expand fibermap header
     hdr['AIRMASS'] = (airmass, 'Airmass at middle of exposure')
@@ -185,7 +195,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
     hdr['DATE-OBS'] = (time.strftime('%FT%T', dateobs), 'Start of exposure')
 
     simfile = io.write_simspec(meta, truth, expid, night, header=hdr)
-    print(simfile)
+    log.info('Wrote '+simfile)
 
     #- Update obslog that we succeeded with this exposure
     update_obslog(flavor, expid, dateobs, tileid)
@@ -197,6 +207,36 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
         del os.environ['DESI_SPECTRO_DATA']
     
     return fibermap, truth
+
+#- Mapping of DESI objtype to things specter knows about
+def specter_objtype(desitype):
+    '''
+    Convert a list of DESI object types into ones that specter knows about
+    '''
+    intype = np.atleast_1d(desitype)
+    desi2specter = dict(
+        STAR='STAR', STD='STAR', STD_FSTAR='STAR', FSTD='STAR', MWS_STAR='STAR',
+        LRG='LRG', ELG='ELG', QSO='QSO', QSO_BAD='STAR',
+        BGS='LRG', # !!!
+        SKY='SKY'
+    )
+    
+    unknown_types = set(intype) - set(desi2specter.keys())
+    if len(unknown_types) > 0:
+        raise ValueError('Unknown input objtypes {}'.format(unknown_types))
+    
+    results = np.zeros(len(intype), dtype='S8')
+    for objtype in desi2specter:
+        ii = (intype == objtype)
+        results[ii] = desi2specter[objtype]
+        
+    assert np.count_nonzero(results == '') == 0
+    
+    if isinstance(desitype, (str, unicode)):
+        return results[0]
+    else:
+        return results
+        
 
 def get_next_tileid():
     """

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -18,7 +18,7 @@ from desispec.interpolation import resample_flux
 from desispec.log import get_logger
 log = get_logger()
 
-from .targets import get_targets
+from .targets import get_targets_parallel
 from . import io
 
 def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
@@ -108,7 +108,8 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
             truth['PHOT_'+channel] = phot
         
     else: # checked that flavor is valid in newexp-desi
-        fibermap, truth = get_targets(nspec, flavor, tileid=tileid)
+        log.debug('Generating {} targets'.format(nspec))
+        fibermap, truth = get_targets_parallel(nspec, flavor, tileid=tileid)
             
         flux = truth['FLUX']
         wave = truth['WAVE']
@@ -131,6 +132,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
         skyflux = np.interp(wave, skywave, skyflux)
         truth['SKYFLUX'] = skyflux
 
+        log.debug('Calculating flux -> photons')
         for channel in ('B', 'R', 'Z'):
             thru = desimodel.io.load_throughput(channel)
         

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -77,6 +77,8 @@ def sample_objtype(nobj, flavor):
         true_objtype  +=  ['STD']*nsci
     elif (flavor == 'BGS'):
         true_objtype  +=  ['BGS']*nsci
+    elif (flavor in ('GRAY', 'GREY')):
+        true_objtype += ['ELG',] * nsci
     elif (flavor == 'BRIGHT'):
         #- BGS galaxies and MWS stars
         ntgt = float(tgt['nobs_BG'] + tgt['nobs_MWS'])

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -13,6 +13,8 @@ import yaml
 
 from desimodel.focalplane import FocalPlane
 import desimodel.io
+from desispec.log import get_logger
+log = get_logger()
 
 from desispec import brick
 from desispec.io.fibermap import empty_fibermap
@@ -123,6 +125,42 @@ def sample_objtype(nobj, flavor):
     true_objtype = np.array(true_objtype)
 
     return true_objtype, target_objtype
+
+#- multiprocessing needs one arg, not multiple args
+def _wrap_get_targets(args):
+    nspec, flavor, tileid = args
+    return get_targets(nspec, flavor, tileid)
+    
+def get_targets_parallel(nspec, flavor, tileid=None, nproc=None):
+    import multiprocessing as mp
+    if nproc is None:
+        nproc = mp.cpu_count() // 2
+    
+    #- don't bother with parallelism if there aren't many targets
+    if nspec < 5*nproc:
+        log.debug('Not Parallelizing get_targets for only {} targets'.format(nspec))
+        return get_targets(nspec, flavor, tileid)
+    else:
+        log.debug('Parallelizing get_targets using {} cores'.format(nproc))
+        args = list()
+        n = nspec // nproc
+        for i in range(0, nspec, n):
+            if i+n < nspec:
+                args.append( (n, flavor, tileid) )
+            else:
+                args.append( (nspec-i, flavor, tileid) )
+                
+        pool = mp.Pool(nproc)
+        results = pool.map(_wrap_get_targets, args)
+        fibermaps, truthtables = zip(*results)
+        fibermap = np.concatenate(fibermaps)
+
+        truth = truthtables[0]
+        for key in truth.keys():
+            if key not in ('UNITS', 'WAVE'):
+                truth[key] = np.concatenate([t[key] for t in truthtables])
+
+        return fibermap, truth
 
 def get_targets(nspec, flavor, tileid=None):
     """

--- a/py/desisim/test/test_obs.py
+++ b/py/desisim/test/test_obs.py
@@ -125,6 +125,13 @@ class TestObs(unittest.TestCase):
         c = obs.get_next_tileid()
         self.assertNotEqual(a, c)
 
+    def test_specter_objtype(self):
+        self.assertEqual(obs.specter_objtype('MWS_STAR'), 'STAR')
+        self.assertEqual(obs.specter_objtype(['MWS_STAR',])[0], 'STAR')
+        a = np.array(['STAR', 'MWS_STAR', 'QSO_BAD', 'FSTD', 'QSO', 'ELG'])
+        b = np.array(['STAR', 'STAR', 'STAR', 'STAR', 'QSO', 'ELG'])
+        self.assertTrue(np.all(obs.specter_objtype(a) == b))
+
     def test_get_next_expid(self):
         a = obs.get_next_expid()
         b = obs.get_next_expid()

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -73,6 +73,20 @@ class TestPixsim(unittest.TestCase):
         self.assertTrue(os.path.exists(io.findfile('simpix', night, expid, camera)))
         self.assertTrue(os.path.exists(io.findfile('pix', night, expid, camera)))
 
+    @unittest.skipUnless(desimodel_data_available, 'The desimodel data/ directory was not detected.')
+    @unittest.skipUnless(desi_root_available, '$DESI_ROOT not set')
+    def test_pixsim_waveminmax(self):
+        night = '20150105'
+        expid = 123
+        camera = 'r0'
+        obs.new_exposure('arc', night=night, expid=expid, nspec=3)
+        pixsim.simulate(night, expid, camera, nspec=3, trimxy=True,
+            wavemin=6000, wavemax=6100)
+
+        self.assertTrue(os.path.exists(io.findfile('simspec', night, expid)))
+        simspec = io.read_simspec(io.findfile('simspec', night, expid))
+        self.assertTrue(os.path.exists(io.findfile('simpix', night, expid, camera)))
+        self.assertTrue(os.path.exists(io.findfile('pix', night, expid, camera)))
     @unittest.skipUnless(desi_templates_available, 'The DESI templates directory ($DESI_ROOT/spectro/templates) was not detected.')
     @unittest.skipUnless(desimodel_data_available, '$DESIMODEL/data not available')
     def test_pixsim_cosmics(self):

--- a/py/desisim/test/test_targets.py
+++ b/py/desisim/test/test_targets.py
@@ -4,17 +4,14 @@ import numpy as np
 
 import desisim.targets
 
-desimodel_data_available = 'DESIMODEL' in os.environ
-
 class TestObs(unittest.TestCase):
 
-    @unittest.skipUnless(desimodel_data_available, 'The desimodel data/ directory was not detected.')
     def test_sample_nz(self):
         n = 5
         for objtype in ['LRG', 'ELG', 'QSO', 'STAR', 'STD']:
             z = desisim.targets.sample_nz(objtype, n)
             self.assertEqual(len(z), n)
-
+    
     def test_get_targets(self):
         n = 5
         for flavor in ['DARK', 'BRIGHT', 'LRG', 'ELG', 'QSO', 'BGS', 'MWS']:
@@ -26,6 +23,22 @@ class TestObs(unittest.TestCase):
             for n in [5,10,50]:
                 for i in range(10):
                     truetype, targettype = desisim.targets.sample_objtype(n, flavor)
+
+    def test_parallel(self):
+        import multiprocessing as mp
+        nproc = mp.cpu_count() // 2
+        for n in [nproc, 5*nproc, 5*nproc+3]:
+            fibermap, truth = desisim.targets.get_targets_parallel(n, 'DARK')
+            if n != len(fibermap):
+                #--- DEBUG ---
+                import IPython
+                IPython.embed()
+                #--- DEBUG ---
+                
+            self.assertEqual(n, len(fibermap))
+            for key in truth.keys():
+                if key not in ('UNITS', 'WAVE'):
+                    self.assertEqual(n, truth[key].shape[0])
 
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':

--- a/py/desisim/test/test_targets.py
+++ b/py/desisim/test/test_targets.py
@@ -22,7 +22,7 @@ class TestObs(unittest.TestCase):
             fibermap, truth = desisim.targets.get_targets(n, flavor.lower())
             
     def test_sample_objtype(self):
-        for flavor in ['DARK', 'BRIGHT', 'LRG', 'ELG', 'QSO', 'BGS', 'MWS']:
+        for flavor in ['DARK', 'GRAY', 'BRIGHT', 'LRG', 'ELG', 'QSO', 'BGS', 'MWS']:
             for n in [5,10,50]:
                 for i in range(10):
                     truetype, targettype = desisim.targets.sample_objtype(n, flavor)


### PR DESCRIPTION
Some cleanup features and fixes:
* adds gray/grey flavor to simulate ELGs with gray sky conditions
* fixes pixsim wavemin/wavemax options
* converts DESI-specific objtypes into specter objtypes before calculating throughput
  * e.g. STAR, STD_FSTAR, and MWS_STAR all map onto "STAR" for specter
* adds get_targets_parallel() for faster template generation
* converts some print statements into logger calls
