### PR TITLE
fix random seed usage with parallelism

### DIFF
--- a/bin/newexp-desi
+++ b/bin/newexp-desi
@@ -38,8 +38,7 @@ parser.add_option("--exptime",  type=int,   help="exposure time in seconds, defa
 parser.add_option("--night",    type=str,   help="YEARMMDD")
 parser.add_option("--nspec",    type=int,   help="Number of spectra to simulate [%default]", default=5000)
 parser.add_option("--airmass",  type=float, help="Airmass [%default]", default=1.0)
-parser.add_option("--randseed", type=int,   help="random number seed"
-                  )
+parser.add_option("--randseed", type=int,   help="random number seed")
 
 opts, args = parser.parse_args()
 
@@ -68,7 +67,7 @@ if opts.flavor not in ['arc','flat','dark','gray','grey','bright','bgs','mws','l
     log.fatal('ERROR: unknown flavor {}'.format(opts.flavor))
     sys.exit(1)
 
-    
+
 #- TODO: don't hardcode these default exposure times
 if opts.exptime is None:
     if opts.flavor == 'arc':
@@ -82,19 +81,21 @@ if opts.exptime is None:
     else:
         print('Do not know the default exposure time for flavor' + opts.flavor)
         sys.exit(1)
-    
-    
+
 #- Initialize random seeds
 if opts.randseed is None:
     opts.randseed = opts.tileid
-        
+
+#- Set the random seed, even though we further propagate it into the
+#- underlying get_targets and make_templates code
 random.seed(opts.randseed)
 np.random.seed(opts.randseed)
 
 #- Generate the new exposure
 obs.new_exposure(opts.flavor, nspec=opts.nspec, \
     night=opts.night, expid=opts.expid,         \
-    tileid=opts.tileid, airmass=opts.airmass, exptime=opts.exptime)
+    tileid=opts.tileid, airmass=opts.airmass, exptime=opts.exptime, \
+    randseed=opts.randseed)
 
 #-------------------------------------------------------------------------
 # if opts.debug:

--- a/bin/newexp-desi
+++ b/bin/newexp-desi
@@ -38,7 +38,7 @@ parser.add_option("--exptime",  type=int,   help="exposure time in seconds, defa
 parser.add_option("--night",    type=str,   help="YEARMMDD")
 parser.add_option("--nspec",    type=int,   help="Number of spectra to simulate [%default]", default=5000)
 parser.add_option("--airmass",  type=float, help="Airmass [%default]", default=1.0)
-parser.add_option("--randseed", type=int,   help="random number seed")
+parser.add_option("--seed", type=int,   help="random number seed")
 
 opts, args = parser.parse_args()
 
@@ -83,19 +83,19 @@ if opts.exptime is None:
         sys.exit(1)
 
 #- Initialize random seeds
-if opts.randseed is None:
-    opts.randseed = opts.tileid
+if opts.seed is None:
+    opts.seed = opts.tileid
 
 #- Set the random seed, even though we further propagate it into the
 #- underlying get_targets and make_templates code
-random.seed(opts.randseed)
-np.random.seed(opts.randseed)
+random.seed(opts.seed)
+np.random.seed(opts.seed)
 
 #- Generate the new exposure
 obs.new_exposure(opts.flavor, nspec=opts.nspec, \
     night=opts.night, expid=opts.expid,         \
     tileid=opts.tileid, airmass=opts.airmass, exptime=opts.exptime, \
-    randseed=opts.randseed)
+    seed=opts.seed)
 
 #-------------------------------------------------------------------------
 # if opts.debug:

--- a/bin/pixsim-desi
+++ b/bin/pixsim-desi
@@ -43,7 +43,7 @@ parser.add_option("--arms", type=str, help="spectrograph arms, e.g. b,r,z", defa
 parser.add_option("--cosmics", type=str, help="fits file with dark images with cosmics to add")
 parser.add_option("--verbose", action="store_true", help="print more stuff")
 parser.add_option("--trimxy", action="store_true", help="Trim image to fit spectra")
-parser.add_option("--randseed", type=int, help="random number seed")
+parser.add_option("--seed", type=int, help="random number seed")
 parser.add_option("--nspec", type=int, help="Number of spectra to simulate per camera [%default]", default=500)
 parser.add_option("--ncpu",  type=int, help="Number of cpu cores to use [%default]", default=multiprocessing.cpu_count() // 2)
 parser.add_option("--wavemin",  type=float, help="Minimum wavelength to simulate")
@@ -74,8 +74,8 @@ if opts.cameras is None:
 else:
     opts.cameras = opts.cameras.split(',')
 
-random.seed(opts.randseed)
-np.random.seed(opts.randseed)
+random.seed(opts.seed)
+np.random.seed(opts.seed)
 
 for camera in opts.cameras:
     #- Simulate

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -22,7 +22,7 @@ from .targets import get_targets_parallel
 from . import io
 
 def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
-    airmass=1.0, exptime=None, randseed=None):
+    airmass=1.0, exptime=None, seed=None):
     """
     Create a new exposure and output input simulation files.
     Does not generate pixel-level simulations or noisy spectra.
@@ -37,7 +37,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
         tileid : integer tile ID
         airmass : airmass, default 1.0
         exptime : exposure time in seconds
-        randseed : random seed
+        seed : random seed
 
     Writes:
         $DESI_SPECTRO_SIM/$PIXPROD/{night}/fibermap-{expid}.fits
@@ -115,7 +115,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
         
     else: # checked that flavor is valid in newexp-desi
         log.debug('Generating {} targets'.format(nspec))
-        fibermap, truth = get_targets_parallel(nspec, flavor, tileid=tileid, randseed=randseed)
+        fibermap, truth = get_targets_parallel(nspec, flavor, tileid=tileid, seed=seed)
 
         flux = truth['FLUX']
         wave = truth['WAVE']

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -22,23 +22,27 @@ from .targets import get_targets_parallel
 from . import io
 
 def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
-    airmass=1.0, exptime=None):
+    airmass=1.0, exptime=None, randseed=None):
     """
     Create a new exposure and output input simulation files.
     Does not generate pixel-level simulations or noisy spectra.
-    
+
     Args:
         flavor: 'arc', 'flat', 'bright', 'dark', 'bgs', 'mws', ...
-        nspec (optional): integer number of spectra to simulate
-        night (optional): YEARMMDD string
-        expid (optional): positive integer exposure ID
-        tileid (optional): tile ID
-        airmass (optional): airmass, default 1.0
-    
+
+    Options:
+        nspec : integer number of spectra to simulate
+        night : YEARMMDD string
+        expid : positive integer exposure ID
+        tileid : integer tile ID
+        airmass : airmass, default 1.0
+        exptime : exposure time in seconds
+        randseed : random seed
+
     Writes:
         $DESI_SPECTRO_SIM/$PIXPROD/{night}/fibermap-{expid}.fits
         $DESI_SPECTRO_SIM/$PIXPROD/{night}/simspec-{expid}.fits
-        
+
     Returns:
         fibermap numpy structured array
         truth dictionary
@@ -111,7 +115,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
         
     else: # checked that flavor is valid in newexp-desi
         log.debug('Generating {} targets'.format(nspec))
-        fibermap, truth = get_targets_parallel(nspec, flavor, tileid=tileid)
+        fibermap, truth = get_targets_parallel(nspec, flavor, tileid=tileid, randseed=randseed)
 
         flux = truth['FLUX']
         wave = truth['WAVE']

--- a/py/desisim/test/test_io.py
+++ b/py/desisim/test/test_io.py
@@ -119,7 +119,7 @@ class TestIO(unittest.TestCase):
         c3 = io.read_cosmics(infile, expid=1, shape=shape, jitter=False)
         self.assertTrue(np.any(c2.pix != c3.pix))
 
-    #- read_templates(wave, objtype, nspec=None, randseed=1, infile=None):
+    #- read_templates(wave, objtype, nspec=None, seed=1, infile=None):
     @unittest.skipUnless(desi_basis_templates_available, '$DESI_BASIS_TEMPLATES not set')
     def test_read_templates(self):
         wave = np.arange(7000, 7020)

--- a/py/desisim/test/test_targets.py
+++ b/py/desisim/test/test_targets.py
@@ -30,11 +30,36 @@ class TestObs(unittest.TestCase):
         for n in [5, 23, 15*nproc+7]:
             fibermap, truth = desisim.targets.get_targets_parallel(n, 'DARK')
             self.assertEqual(n, len(fibermap))
-            self.assertEqual(n, len(set(fibermap['FIBER'])))  #- unique FIBER
+            #- unique FIBER and TARGETID
+            self.assertEqual(n, len(set(fibermap['FIBER'])))
+            self.assertEqual(n, len(set(fibermap['TARGETID'])))
             self.assertTrue(np.all(fibermap['SPECTROID'] == fibermap['FIBER']//500))
             for key in truth.keys():
                 if key not in ('UNITS', 'WAVE'):
                     self.assertEqual(n, truth[key].shape[0])
+
+    def test_random(self):
+        nspec = 30
+        fibermap1, truth1 = desisim.targets.get_targets_parallel(nspec, 'DARK', randseed=1)
+        fibermap2a, truth2a = desisim.targets.get_targets_parallel(nspec, 'DARK', randseed=2)
+        fibermap2b, truth2b = desisim.targets.get_targets_parallel(nspec, 'DARK', randseed=2)
+
+        #- Check that 1 and 2a do not have the same spectra
+        self.assertTrue(np.all(fibermap1['TARGETID'] != fibermap2a['TARGETID']))
+        self.assertTrue(np.all(truth1['REDSHIFT'] != truth2a['REDSHIFT']))
+
+        #- Check 2a and 2b have the same spectra
+        self.assertTrue(np.all(fibermap2a['TARGETID'] == fibermap2b['TARGETID']))
+        self.assertTrue(np.all(truth2a['REDSHIFT'] == truth2b['REDSHIFT']))
+        self.assertTrue(np.all(truth2a['OIIFLUX'] == truth2b['OIIFLUX']))
+        self.assertTrue(np.all(truth2a['FLUX'] == truth2b['FLUX']))
+
+        #- Check for duplicates
+        for i in range(nspec-1):
+            if truth1['OBJTYPE'][i] != 'SKY':
+                for j in range(i+1, nspec):
+                    self.assertFalse(np.all(truth1['FLUX'][i] == truth1['FLUX'][j]),
+                        'Spectra {} and {} are identical'.format(i,j))
 
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':

--- a/py/desisim/test/test_targets.py
+++ b/py/desisim/test/test_targets.py
@@ -39,27 +39,28 @@ class TestObs(unittest.TestCase):
                     self.assertEqual(n, truth[key].shape[0])
 
     def test_random(self):
-        nspec = 30
-        fibermap1, truth1 = desisim.targets.get_targets_parallel(nspec, 'DARK', randseed=1)
-        fibermap2a, truth2a = desisim.targets.get_targets_parallel(nspec, 'DARK', randseed=2)
-        fibermap2b, truth2b = desisim.targets.get_targets_parallel(nspec, 'DARK', randseed=2)
+        for nspec in (15, 30):
+            fibermap1, truth1 = desisim.targets.get_targets_parallel(nspec, 'DARK', seed=nspec+1)
+            fibermap2a, truth2a = desisim.targets.get_targets_parallel(nspec, 'DARK', seed=nspec+2)
+            fibermap2b, truth2b = desisim.targets.get_targets_parallel(nspec, 'DARK', seed=nspec+2)
 
-        #- Check that 1 and 2a do not have the same spectra
-        self.assertTrue(np.all(fibermap1['TARGETID'] != fibermap2a['TARGETID']))
-        self.assertTrue(np.all(truth1['REDSHIFT'] != truth2a['REDSHIFT']))
+            #- Check that 1 and 2a do not have the same spectra
+            notsky = (fibermap1['OBJTYPE'] != 'SKY') & (fibermap2a['OBJTYPE'] != 'SKY')
+            self.assertTrue(np.all(truth1['REDSHIFT'][notsky] != truth2a['REDSHIFT'][notsky]))
+            self.assertTrue(np.all(fibermap1['TARGETID'] != fibermap2a['TARGETID']))
 
-        #- Check 2a and 2b have the same spectra
-        self.assertTrue(np.all(fibermap2a['TARGETID'] == fibermap2b['TARGETID']))
-        self.assertTrue(np.all(truth2a['REDSHIFT'] == truth2b['REDSHIFT']))
-        self.assertTrue(np.all(truth2a['OIIFLUX'] == truth2b['OIIFLUX']))
-        self.assertTrue(np.all(truth2a['FLUX'] == truth2b['FLUX']))
+            #- Check 2a and 2b have the same spectra
+            self.assertTrue(np.all(truth2a['REDSHIFT'][notsky] == truth2b['REDSHIFT'][notsky]))
+            self.assertTrue(np.all(fibermap2a['TARGETID'] == fibermap2b['TARGETID']))
+            self.assertTrue(np.all(truth2a['OIIFLUX'] == truth2b['OIIFLUX']))
+            self.assertTrue(np.all(truth2a['FLUX'] == truth2b['FLUX']))
 
-        #- Check for duplicates
-        for i in range(nspec-1):
-            if truth1['OBJTYPE'][i] != 'SKY':
-                for j in range(i+1, nspec):
-                    self.assertFalse(np.all(truth1['FLUX'][i] == truth1['FLUX'][j]),
-                        'Spectra {} and {} are identical'.format(i,j))
+            #- Check for duplicates
+            for i in range(nspec-1):
+                if truth1['OBJTYPE'][i] != 'SKY':
+                    for j in range(i+1, nspec):
+                        self.assertFalse(np.all(truth1['FLUX'][i] == truth1['FLUX'][j]),
+                            'Spectra {} and {} are identical'.format(i,j))
 
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes a critical bug in the random number seed propagation in get_targets_parallel() that was causing different spectra to receive the same TARGETID.  Tests have been added to verify that different seeds result in different TARGETIDs and different spectra, and to verify that the same seed results in the same TARGETIDs and identical spectra.

Assigning to @tskisner, though if @moustakas is in front of a computer right now I'd appreciate a review from him as well since he faced similar issues getting the random number seed propagation correct in the templates code.