### PR TITLE
Wave in vacuum

### DIFF
--- a/etc/travis_env_common.sh
+++ b/etc/travis_env_common.sh
@@ -54,7 +54,7 @@ $PIP_INSTALL speclite
 
 # DESI_ROOT and DESI_BASIS_TEMPLATES with test data
 export DESISIM=$PWD
-testdata_version=0.2
+testdata_version=0.3
 cd ./data
 wget https://github.com/desihub/desisim-testdata/archive/$testdata_version.zip
 unzip $testdata_version.zip

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -72,7 +72,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
     if flavor == 'arc':
         infile = os.getenv('DESI_ROOT')+'/spectro/templates/calib/v0.3/arc-lines-average-in-vacuum.fits'
         d = fits.getdata(infile, 1)
-        wave = d['AIRWAVE']
+        wave = d['VACUUM_WAVE']
         phot = d['ELECTRONS']
         
         truth = dict(WAVE=wave)

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -70,7 +70,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
     params = desimodel.io.load_desiparams()
     flavor = flavor.lower()
     if flavor == 'arc':
-        infile = os.getenv('DESI_ROOT')+'/spectro/templates/calib/v0.2/arc-lines-average.fits'
+        infile = os.getenv('DESI_ROOT')+'/spectro/templates/calib/v0.3/arc-lines-average-in-vacuum.fits'
         d = fits.getdata(infile, 1)
         wave = d['AIRWAVE']
         phot = d['ELECTRONS']
@@ -86,7 +86,7 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None, \
             truth['PHOT_'+channel] = np.tile(phot[ii], nspec).reshape(nspec, len(ii))
 
     elif flavor == 'flat':
-        infile = os.getenv('DESI_ROOT')+'/spectro/templates/calib/v0.2/flat-3100K-quartz-iodine.fits'
+        infile = os.getenv('DESI_ROOT')+'/spectro/templates/calib/v0.3/flat-3100K-quartz-iodine.fits'
         flux = fits.getdata(infile, 0)
         hdr = fits.getheader(infile, 0)
         wave = desispec.io.util.header2wave(hdr)


### PR DESCRIPTION
This PR for using an arc lamp emission line spectrum with wavelength in vacuum.
The template is at NERSC in /project/projectdirs/desi/spectro/templates/calib/v0.3
The hardcoded path in py/desisim/obs.py has been modified, we will need to remove this hardcoded path  in the future (the change is made in branch teststand).

This change from air to vacuum wavelength is needed to be consistent with the master version of desispec and specex, and the definitions of wavelength in the DESI target templates.
