### PR TITLE
Make sure data directory really is part of the package.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -52,6 +53,3 @@ docs/_build/
 
 # PyBuilder
 target/
-
-# Binary output files.
-*.fits

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,14 +1,10 @@
 include LICENSE.rst
 include README.rst
+include requirements.txt
 
 graft bin
-graft data
 graft doc
-graft etc
-
-recursive-exclude etc travis*
 
 prune build
 prune dist
 prune htmlcov
-prune doc/_build

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,10 @@ from __future__ import absolute_import, division, print_function
 import glob
 import os
 import sys
+#
+# setuptools' sdist command ignores MANIFEST.in
+#
+from distutils.command.sdist import sdist as DistutilsSdist
 from setuptools import setup, find_packages
 #
 # DESI support code.
@@ -52,12 +56,16 @@ setup_keywords['zip_safe'] = False
 setup_keywords['use_2to3'] = True
 setup_keywords['packages'] = find_packages('py')
 setup_keywords['package_dir'] = {'':'py'}
-setup_keywords['cmdclass'] = {'version': DesiVersion,'test': DesiTest}
+setup_keywords['cmdclass'] = {'version': DesiVersion, 'test': DesiTest, 'sdist': DistutilsSdist}
 setup_keywords['test_suite']='{name}.test.test_suite'.format(**setup_keywords)
 #
 # Autogenerate command-line scripts.
 #
 # setup_keywords['entry_points'] = {'console_scripts':['desiInstall = desiutil.install.main:main']}
+#
+# Add internal data directories.
+#
+setup_keywords['package_data'] = {'desisim': ['data/*']}
 #
 # Run setup command.
 #


### PR DESCRIPTION
This PR ensures that the py/desisim/data directory will always be treated as a legitimate part of the package, even though it contains no .py files.