### PR TITLE
QA backend for cronjobs

### DIFF
--- a/bin/desi_qa_zfind
+++ b/bin/desi_qa_zfind
@@ -14,6 +14,8 @@ import sys
 
 import yaml
 #import pdb
+import matplotlib
+matplotlib.use('pdf')
 from matplotlib.backends.backend_pdf import PdfPages
 
 import desispec.io
@@ -39,6 +41,11 @@ def main():
         log = get_logger(DEBUG)
     else:
         log = get_logger()
+
+    import matplotlib.pyplot as plt
+    log.debug('matplotlib backend is {}'.format(plt.get_backend()))
+    log.debug('interactive backends {}'.format(matplotlib.rcsetup.interactive_bk))
+    log.debug('non-interactive backends {}'.format(matplotlib.rcsetup.non_interactive_bk))
 
     if args.night is None:
         log.critical('Missing required night argument.')

--- a/bin/desi_qa_zfind
+++ b/bin/desi_qa_zfind
@@ -15,7 +15,7 @@ import sys
 import yaml
 #import pdb
 import matplotlib
-matplotlib.use('pdf')
+matplotlib.use('agg')
 from matplotlib.backends.backend_pdf import PdfPages
 
 import desispec.io

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -8,7 +8,7 @@ Module to run high_level QA on a given DESI run
 from __future__ import print_function, absolute_import, division, unicode_literals
 
 import matplotlib
-matplotlib.use('Agg')
+# matplotlib.use('Agg')
 
 import numpy as np
 import sys, os, pdb, glob


### PR DESCRIPTION
Set the matplotlib backend within `desi_qa_zfind` rather than `desisim/spec_qa/redshifts.py`.  Use 'agg' instead of 'Agg'.  These appear to be needed for getting `desi_qa_zfind` to work within a cronjob at NERSC (though it is different from the desispec QA code that sets that backend within the plotting code rather than the wrapper script, so we may need to revisit this...)