### PR TITLE
update template set to v2.2

### DIFF
--- a/etc/travis_env_common.sh
+++ b/etc/travis_env_common.sh
@@ -54,7 +54,7 @@ $PIP_INSTALL speclite
 
 # DESI_ROOT and DESI_BASIS_TEMPLATES with test data
 export DESISIM=$PWD
-testdata_version=0.3
+testdata_version=0.3.1
 
 #cd ./data
 wget https://github.com/desihub/desisim-testdata/archive/$testdata_version.zip


### PR DESCRIPTION
This PR updates the desisim-testdata version to 0.3.1, which itself updates the basis template set to v2.2 (see https://github.com/desihub/desisim-testdata/pull/4).  The new templates are located on NERSC in 
```
/global/project/projectdirs/desi/spectro/templates/basis_templates/v2.2
```

This PR also closes #113 and #118.
