### PR TITLE
newexp different tileids in parallel

### DIFF
--- a/bin/newexp-desi
+++ b/bin/newexp-desi
@@ -87,7 +87,10 @@ if opts.exptime is None:
 
 #- Initialize random seeds
 if opts.seed is None:
-    opts.seed = opts.tileid
+    if opts.flavor in ['arc', 'flat'] or opts.tileid < 0:
+        opts.seed = opts.expid
+    else:
+        opts.seed = opts.tileid
 
 #- Set the random seed, even though we further propagate it into the
 #- underlying get_targets and make_templates code

--- a/py/desisim/scripts/pixsim.py
+++ b/py/desisim/scripts/pixsim.py
@@ -258,5 +258,5 @@ def main(args=None):
         preproc.main(preproc.parse(preproc_opts))
 
     if mpicomm.rank == 0:
-        log.info('Finished pixsim {}'.format(asctime()))
+        log.info('Finished pixsim {} expid {} at {}'.format(args.night, args.expid, asctime()))
 

--- a/py/desisim/test/test_batch.py
+++ b/py/desisim/test/test_batch.py
@@ -4,7 +4,7 @@ import unittest
 from desisim.batch import calc_nodes
 from desisim.batch.pixsim import batch_newexp, batch_pixsim
 
-class TestBlat(unittest.TestCase):
+class TestBatch(unittest.TestCase):
     
     def setUp(self):
         self.batchfile = 'batch-d4ae52ada252.sh'
@@ -12,6 +12,7 @@ class TestBlat(unittest.TestCase):
         self._DESI_SPECTRO_SIM = os.getenv('DESI_SPECTRO_SIM')
         os.environ['PIXPROD'] = 'test'
         os.environ['DESI_SPECTRO_SIM'] = '/test/dir'
+        os.environ['DESI_SPECTRO_DATA'] = '/test/dir/test'
 
     def tearDown(self):
         if os.path.exists(self.batchfile):


### PR DESCRIPTION
This PR fixes a bug in the newexp-desi data flow where the batch jobs generating different exposures in parallel were all grabbing the same tileid and thus the same targets instead of having a different tileid per exposures.

We'll need to do a deeper refactor later coordinated with fiber assignment and the survey simulations, but this is the minimally useful step to actually get N different tiles instead of N different views of the same tile.

It is still borderline for whether or not pixel simulations can finish within the debug queue 30 minute time limit; I'll work on that in a separate branch + PR.