### PR TITLE
QA zfind plot updates

### DIFF
--- a/bin/desi_qa_zfind
+++ b/bin/desi_qa_zfind
@@ -69,7 +69,7 @@ def main():
         
         brick_names = set(fibermap_data['BRICKNAME'])
         for brick in brick_names:
-            zbest_path=desispec.io.findfile('zbest',brickname=brick)
+            zbest_path=desispec.io.findfile('zbest',brickname=brick, specprod_dir=args.reduxdir)
             if os.path.exists(zbest_path):
                 log.debug('Found {}'.format(os.path.basename(zbest_path)))
                 zbest_files.append(zbest_path)

--- a/bin/desi_qa_zfind
+++ b/bin/desi_qa_zfind
@@ -23,6 +23,7 @@ from desispec.log import get_logger, DEBUG
 
 from desisim.spec_qa import redshifts as dsqa_z
 from desiutil.io import yamlify
+import desiutil.depend
 
 def main():
 
@@ -87,8 +88,13 @@ def main():
     simz_tab = dsqa_z.load_z(fibermap_files, zbest_files)
 
     # Meta data
-    meta = dict(SIMSPECV='9.999', SPECPROD=os.getenv('SPECPROD'))
-
+    meta = dict(
+        DESISIM = desiutil.depend.getdep(simz_tab.meta, 'desisim'),
+        SPECTER = desiutil.depend.getdep(simz_tab.meta, 'specter'),
+        SPECPROD = os.getenv('SPECPROD', 'unknown'),
+        PIXPROD = os.getenv('PIXPROD', 'unknown'),
+        )
+    
     # Run stats
     summ_dict = dsqa_z.summ_stats(simz_tab)
     if args.qafile is not None:
@@ -108,7 +114,7 @@ def main():
         dsqa_z.summ_fig(simz_tab, summ_dict, meta, pp=pp)
         for objtype in ['ELG','LRG', 'QSO_T', 'QSO_L']:
             dsqa_z.obj_fig(simz_tab, objtype, summ_dict, pp=pp)
-        log.info("closing")
+        log.info("closing QA figure file")
         # All done
         pp.close()
 

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desisim change log
 0.12.1 (unreleased)
 -------------------
 
-* no changes yet
+* desi_qa_zfind: fixed --reduxdir option; improved plots
 
 0.12.0 (2016-07-14)
 -------------------

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -906,8 +906,6 @@ def dz_summ(simz_tab, pp=None, pdict=None, min_count=20):
             # Hide overlapping x-axis labels except in the bottom right.
             if overlap and (col < ncols - 1):
                 axis.set_xticks(axis.get_xticks()[0:-overlap])
-                # plt.setp(
-                #     [axis.get_xticklabels()[-overlap:]], visible=False)
 
         figure.subplots_adjust(
             left=0.1, bottom=0.07, right=0.9, top=0.95,


### PR DESCRIPTION
Fixes fibermap OBJTYPE vs. simspec OBJTYPE usage so that fake QSO targets don't count in the QSO statistics.  This removes a vertical stripe at ztrue=0, but doesn't substantially change the interpretation of a large number of QSOs are failing redshift fitting.

Propagates desisim and specter versions to output figure instead of placeholder SIMSPECV=9.999.  Includes value of $SPECPROD and $PIXPROD, with a default of "unknown" if they aren't set. (separate to do: we should have pipeline include those in the file headers, and then get them from there instead relying upon whatever they are currently set to).

Misc plot ranges / axis tweaks.

![qaz](https://cloud.githubusercontent.com/assets/218471/16961305/bd058df6-4da1-11e6-89e8-6e72d282607f.png)

