### PR TITLE
fix obs.get_next_tileid() for UPPERCASE program in desi-tiles.fits

### DIFF
--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -458,13 +458,13 @@ def get_night(t=None, utc=None):
     
 #- I'm not really sure this is a good idea.
 #- I'm sure I will want to change the schema later...
-def update_obslog(obstype='science', program='dark', expid=None, dateobs=None,
+def update_obslog(obstype='science', program='DARK', expid=None, dateobs=None,
     tileid=-1, ra=None, dec=None):
     """
     Update obslog with a new exposure
     
     obstype : 'arc', 'flat', 'bias', 'test', 'science', ...
-    program : 'dark', 'gray', 'bright', 'calib'
+    program : 'DARK', 'GRAY', 'BRIGHT', 'CALIB'
     expid   : integer exposure ID, default from get_next_expid()
     dateobs : time.struct_time tuple; default time.localtime()
     tileid  : integer TileID, default -1, i.e. not a DESI tile
@@ -487,7 +487,7 @@ def update_obslog(obstype='science', program='dark', expid=None, dateobs=None,
         dateobs DATETIME,                   -- seconds since Unix Epoch (1970)
         night TEXT,                         -- YEARMMDD
         obstype TEXT DEFAULT "science",
-        program TEXT DEFAULT "dark",
+        program TEXT DEFAULT "DARK",
         tileid INTEGER DEFAULT -1,
         ra REAL DEFAULT 0.0,
         dec REAL DEFAULT 0.0
@@ -516,7 +516,7 @@ def update_obslog(obstype='science', program='dark', expid=None, dateobs=None,
     INSERT OR REPLACE INTO obslog(expid,dateobs,night,obstype,program,tileid,ra,dec)
     VALUES (?,?,?,?,?,?,?,?)
     """
-    db.execute(insert, (expid, time.mktime(dateobs), night, obstype.upper(), program, tileid, ra, dec))
+    db.execute(insert, (expid, time.mktime(dateobs), night, obstype.upper(), program.upper(), tileid, ra, dec))
     db.commit()
     
     return expid, dateobs

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -332,9 +332,9 @@ def get_next_tileid(program='dark'):
     Note: simultaneous calls will return the same tileid;
           it does *not* reserve the tileid
     """
-    program = program.lower()
-    if program not in ('dark', 'gray', 'grey', 'bright',
-                       'elg', 'lrg', 'qso', 'lya', 'bgs', 'mws'):
+    program = program.upper()
+    if program not in ('DARK', 'GRAY', 'GREY', 'BRIGHT',
+                       'ELG', 'LRG', 'QSO', 'LYA', 'BGS', 'MWS'):
         return -1
     
     #- Read DESI tiling and trim to just tiles in DESI footprint
@@ -342,6 +342,9 @@ def get_next_tileid(program='dark'):
 
     #- HACK: update tilelist to include PROGRAM, etc.
     if 'PROGRAM' not in tiles.colnames:
+        log.error('You are using an out-of-date desi-tiles.fits file from desimodel')        
+        log.error('please update your copy of desimodel/data')        
+        log.warning('proceeding anyway with a workaround for now...')
         tiles['PASS'] -= min(tiles['PASS'])  #- standardize to starting at 0 not 1
     
         brighttiles = tiles[tiles['PASS'] <= 2].copy()
@@ -352,11 +355,9 @@ def get_next_tileid(program='dark'):
 
         program_col = table.Column(name='PROGRAM', length=len(tiles), dtype='S6')
         tiles.add_column(program_col)
-        tiles['PROGRAM'][tiles['PASS'] <= 3] = 'dark'
-        tiles['PROGRAM'][tiles['PASS'] == 4] = 'gray'
-        tiles['PROGRAM'][tiles['PASS'] >= 5] = 'bright'
-    else:
-        log.error('It looks like desimodel has updated the tile format; update this code')        
+        tiles['PROGRAM'][tiles['PASS'] <= 3] = 'DARK'
+        tiles['PROGRAM'][tiles['PASS'] == 4] = 'GRAY'
+        tiles['PROGRAM'][tiles['PASS'] >= 5] = 'BRIGHT'
 
     #- If obslog doesn't exist yet, start at tile 0
     dbfile = io.simdir()+'/etc/obslog.sqlite'

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -320,9 +320,8 @@ def specter_objtype(desitype):
         return results[0]
     else:
         return results
-        
 
-def get_next_tileid(program='dark'):
+def get_next_tileid(program='DARK'):
     """
     Return tileid of next tile to observe
     

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -175,7 +175,8 @@ def get_targets_parallel(nspec, flavor, tileid=None, nproc=None, seed=None):
 
         return fibermap, truth
 
-def simspec_truth(truth, wave=None, seed=None):
+#- Work in progress; don't use yet.
+def _simspec_truth(truth, wave=None, seed=None):
     from astropy import table
     #- Get DESI wavelength coverage
     if wave is None:
@@ -423,7 +424,7 @@ def get_targets(nspec, flavor, tileid=None, seed=None, specmin=0):
 
 #-------------------------------------------------------------------------
 #- Currently unused, but keep around for now
-def _sample_nz(objtype, n):
+def sample_nz(objtype, n):
     """
     Given `objtype` = 'LRG', 'ELG', 'QSO', 'STAR', 'STD'
     return array of `n` redshifts that properly sample n(z)

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -175,6 +175,86 @@ def get_targets_parallel(nspec, flavor, tileid=None, nproc=None, seed=None):
 
         return fibermap, truth
 
+def simspec_truth(truth, wave=None, seed=None):
+    from astropy import table
+    #- Get DESI wavelength coverage
+    if wave is None:
+        wavemin = desimodel.io.load_throughput('b').wavemin
+        wavemax = desimodel.io.load_throughput('z').wavemax
+        dw = 0.2
+        wave = np.arange(round(wavemin, 1), wavemax, dw)
+
+    truetype = truth['TRUETYPE']
+    subtype = truth['TRUESUBTYPE']
+    isGAL = (truetype == 'GALAXY')
+    isQSO = (truetype == 'QSO')
+    isSTAR = (truetype == 'STAR')
+
+    isLRG = isGAL & (subtype == 'LRG')
+    isELG = isGAL & (subtype == 'ELG')
+    isBGS = isGAL & (subtype == 'BGS')
+    isMWS = isSTAR & (subtype == 'MWS')
+    isSTD = isSTAR & (subtype == 'FSTD')
+
+    isFakeQSO = isSTAR & (subtype == 'FAKE_QSO')
+    isFakeELG = isSTAR & (subtype == 'FAKE_ELG')
+    isFakeLRG = isSTAR & (subtype == 'FAKE_LRG')
+
+    #- did we cover all options?
+    x = isLRG | isELG | isBGS | isQSO | isMWS | isSTD
+    x |= isFakeQSO | isFakeELG | isFakeLRG
+    if np.any(~x):
+        unknown = set(zip(truetype[~x], subtype[~x]))
+        message = 'Unknown objtype types {}'.format(unknown)
+        log.fatal(message)
+        raise ValueError(message)
+
+    def make_templates(truth, template_class, wave, seed):
+        nobj = len(truth)
+        tx = template_class(wave=wave)
+        print('generating {} {} targets'.format(nobj, tx.objtype))
+        simflux, _x, meta = tx.make_templates(nmodel=nobj, seed=seed)
+        meta.add_column(table.Column(name='TARGETID', data=truth['TARGETID']))
+        return simflux, meta
+
+    from desisim.templates import LRG, ELG, QSO, BGS, MWS_STAR, FSTD
+
+    results = list()
+    if np.any(isLRG):
+        results.append( make_templates(truth[isLRG], LRG, wave, seed) )
+    if np.any(isELG):
+        results.append( make_templates(truth[isELG], ELG, wave, seed) )
+    if np.any(isQSO):
+        results.append( make_templates(truth[isQSO], QSO, wave, seed) )
+    if np.any(isBGS):
+        results.append( make_templates(truth[isBGS], BGS, wave, seed) )
+    if np.any(isMWS):
+        results.append( make_templates(truth[isMWS], MWS, wave, seed) )
+    if np.any(isSTD):
+        results.append( make_templates(truth[isSTD], FSTD, wave, seed) )
+    if np.any(isFakeQSO):
+        log.warn('not applying QSO color cuts to Fake QSOs yet')
+        results.append( make_templates(truth[isFakeQSO], MWS_STAR, wave, seed) )
+    if np.any(isFakeELG):
+        log.warn('not applying ELG color cuts to Fake ELGs yet')
+        results.append( make_templates(truth[isFakeELG], MWS_STAR, wave, seed) )
+    if np.any(isFakeLRG):
+        log.warn('not applying LRG color cuts to Fake LRGs yet')
+        results.append( make_templates(truth[isFakeLRG], MWS_STAR, wave, seed) )
+
+    simflux = np.vstack([x[0] for x in results])
+    simmeta = table.vstack([x[1] for x in results])
+
+    #- Sort to match order of input truth
+    #- Is there a way to do this without 3 argsort calls?
+    ii = np.argsort(np.asarray(truth['TARGETID']))
+    jj = np.argsort(np.asarray(simmeta['TARGETID'])) 
+    kk = np.argsort(ii)   
+    simmeta = simmeta[jj[kk]]
+    simflux = simflux[jj[kk]]
+
+    return simflux, simmeta
+
 def get_targets(nspec, flavor, tileid=None, seed=None, specmin=0):
     """
     Returns:
@@ -343,7 +423,7 @@ def get_targets(nspec, flavor, tileid=None, seed=None, specmin=0):
 
 #-------------------------------------------------------------------------
 #- Currently unused, but keep around for now
-def sample_nz(objtype, n):
+def _sample_nz(objtype, n):
     """
     Given `objtype` = 'LRG', 'ELG', 'QSO', 'STAR', 'STD'
     return array of `n` redshifts that properly sample n(z)
@@ -379,205 +459,3 @@ def sample_nz(objtype, n):
     x = np.random.uniform(0.0, 1.0, size=n)
     return np.interp(x, cdf, zhi)
 
-class TargetTile(object):
-    """
-    Keeps the relevant information for targets on a tile.
-    Attributes:
-         The properties initialized in the __init__ procedure:
-         ra (float): array for the target's RA
-         dec (float): array for the target's dec
-         type (string): array for the type of target
-         id (int): array of unique IDs for each target
-         tile_ra (float): RA identifying the tile's center
-         tile_dec (float) : dec identifying the tile's center
-         tile_id (int): ID identifying the tile's ID
-         n_target (int): number of targets stored in the object
-         filename (string): original filename from which the info was loaded
-         x (float): array of positions on the focal plane, in mm
-         y (float): array of positions on the focal plane, in mm
-         fiber_id (int): array of fiber_id to which the target is assigned
-    """
-    def __init__(self, filename):
-
-        hdulist = fits.open(filename)
-        self.filename = filename
-        self.ra = hdulist[1].data['RA']
-        self.dec = hdulist[1].data['DEC']
-        self.type = hdulist[1].data['OBJTYPE']
-        self.id = np.int_(hdulist[1].data['TARGETID'])
-        self.tile_ra = hdulist[1].header['TILE_RA']
-        self.tile_dec = hdulist[1].header['TILE_DEC']
-        self.tile_id = hdulist[1].header['TILE_ID']
-        self.n = np.size(self.ra)
-        self.x, self.y = radec2xy(self.ra, self.dec, self.tile_ra, self.tile_dec)
-
-        # this is related to the fiber assignment
-        self.fiber = -1.0 * np.ones(self.n, dtype='i4')
-
-        # This section is related to the number of times a galaxy has been observed,
-        # the assigned redshift and the assigned type
-        self.n_observed = np.zeros(self.n, dtype='i4')
-        self.assigned_z = -1.0 * np.ones(self.n)
-        self.assigned_type =  np.chararray(self.n, itemsize=8)
-        self.assigned_type[:] = 'NONE'
-
-    def set_fiber(self, target_id, fiber_id):
-        """
-        Sets the field .fiber[] (in the target_id  location) to fiber_uid
-        Args:
-            target_id (int): the target_id expected to be in self.id to modify
-                 its corresponding .fiber[] field
-            fiber_id (int): the fiber_id to be stored for the corresponding target_id
-        """
-        loc = np.where(self.id==target_id)
-        if(np.size(loc)!=0):
-            loc = loc[0]
-            self.fiber[loc]  = fiber_id
-        else:
-            raise ValueError('The fiber with %d ID does not seem to exist'%(fibers_id))
-
-    def reset_fiber(self, target_id):
-        """
-        Resets the field .fiber[] (in the target_id  location) to fiber_uid
-        Args:
-            target_id (int): the target_id expected to be in self.id to modify
-                 its corresponding .fiber[] field
-        """
-        loc = np.where(self.id==target_id)
-        if(np.size(loc)!=0):
-            loc = loc[0]
-            self.fiber[loc]  = -1
-        else:
-            raise ValueError('The fiber with %d ID does not seem to exist'%(fibers_id))
-
-
-    def reset_all_fibers(self):
-        """
-        Resets the field .fiber[] for all fibers.
-        """
-        self.fiber = -1.0 * np.ones(self.n, dtype='i4')
-
-
-    def write_results_to_file(self, targets_file):
-        """
-        Writes the section associated with the results to a fits file
-        Args:
-            targets_file (string): the name of the corresponding targets file
-        """
-
-        results_file = targets_file.replace("Targets_Tile", "Results_Tile")
-        if(os.path.isfile(results_file)):
-            os.remove(results_file)
-
-        c0=fits.Column(name='TARGETID', format='K', array=self.id)
-        c1=fits.Column(name='NOBS', format='I', array=self.n_observed)
-        c2=fits.Column(name='ASSIGNEDTYPE', format='8A', array=self.assigned_type)
-        c3=fits.Column(name='ASSIGNEDZ', format='D', array=self.assigned_z)
-
-        cat=fits.ColDefs([c0,c1,c2,c3])
-        table_targetcat_hdu=fits.TableHDU.from_columns(cat)
-
-        table_targetcat_hdu.header['TILE_ID'] = self.tile_id
-        table_targetcat_hdu.header['TILE_RA'] = self.tile_ra
-        table_targetcat_hdu.header['TILE_DEC'] = self.tile_dec
-
-        hdu=fits.PrimaryHDU()
-        hdulist=fits.HDUList([hdu])
-        hdulist.append(table_targetcat_hdu)
-        hdulist.verify()
-        hdulist.writeto(results_file)
-
-    def load_results(self, targets_file):
-        """
-        Loads results from the FITS file to update the arrays n_observed, assigned_z
-        and assigned_type.
-        Args:
-            tile_file (string): filename with the target information
-        """
-        results_file = targets_file.replace("Targets_Tile", "Results_Tile")
-        try:
-            fin = fits.open(results_file)
-            self.n_observed = fin[1].data['NOBS']
-            self.assigned_z = fin[1].data['ASSIGNEDZ']
-            self.assigned_type =  fin[1].data['ASSIGNEDTYPE']
-        except Exception, e:
-            import traceback
-            print('ERROR in get_tiles')
-            traceback.print_exc()
-            raise e
-
-    def update_results(self, fibers):
-        """
-        Updates the results of each target in the tile given the
-        corresponding association with fibers.
-
-        Args:
-            fibers (object class FocalPlaneFibers): only updates the results if a target
-                is assigned to a fiber.
-        Note:
-            Right now this procedure only opdates by one the number of observations.
-            It should also updated the redshift and the assigned type (given some additional information!)
-        """
-        for i in range(fibers.n_fiber):
-            t = fibers.target[i]
-            if(t != -1):
-                if((t in self.id)):
-                    index = np.where(t in self.id)
-                    index = index[0]
-                    self.n_observed[index]  =  self.n_observed[index] + 1
-                    # these two have to be updated as well TOWRITE
-                    # self.assigned_z[index]
-                    # self.assigned_type[index]
-                else:
-                    raise ValueError('The target associated with fiber_id %d does not exist'%(fibers.id[i]))
-
-
-
-
-class TargetSurvey(object):
-    """
-    Keeps basic information for all the targets in all tiles.
-    Attributes:
-        The properties initialized in the __init__ procedure are:
-        type (string): array describing the type of target.
-        id (int): 1D array of unique IDs.
-        n_observed (int)
-        assigned_type (string): array describing the assigned type
-        assigned_z (float): number of times this target has been observed
-        tile_names (string): list of list keeping track of all the tiles where this target is present.
-    """
-    def __init__(self, filename_list):
-        n_file = np.size(filename_list)
-        for i_file in np.arange(n_file):
-            print('Adding %s to build TargetSurvey %d files to go'%(filename_list[i_file], n_file - i_file))
-            tmp = TargetTile(filename_list[i_file])
-            # The first file is a simple initialization
-            if(i_file==0):
-                self.type = tmp.type.copy()
-                self.id = tmp.id.copy()
-                self.n_observed = tmp.n_observed.copy()
-                self.assigned_type = tmp.assigned_type.copy()
-                self.assigned_z = tmp.assigned_z.copy()
-                self.tile_names= []
-                for i in np.arange(np.size(self.id)):
-                    self.tile_names.append([filename_list[i_file]])
-            else: # the other files have to take into account the overlap
-                mask = np.in1d(self.id, tmp.id)
-
-                if((len(self.tile_names)!=np.size(self.id))):
-                    raise ValueError('Building TargetSurvey the numer of items in the filenames is not the same as in the ids.')
-                for i in np.arange(np.size(self.id)):
-                    if(mask[i]==True):
-                        self.tile_names[i].append(filename_list[i_file])
-
-                mask = np.in1d(tmp.id, self.id, invert=True)
-                n_new = np.size(np.where(mask==True))
-                self.id = np.append(self.id, tmp.id[mask])
-                self.type = np.append(self.type, tmp.type[mask])
-                self.n_observed = np.append(self.n_observed, tmp.n_observed[mask])
-                self.assigned_type = np.append(self.assigned_type, tmp.assigned_type[mask])
-                self.assigned_z = np.append(self.assigned_z, tmp.assigned_z[mask])
-                for i in np.arange(n_new):
-                    self.tile_names.append([filename_list[i_file]])
-
-        self.n_targets = np.size(self.id)


### PR DESCRIPTION
We've updated desimodel/data/footprint/desi-tiles.fits to include the program for each tile, e.g. DARK, GRAY, BRIGHT.  `desisim.obs.get_next_field()` and `update_obslog()` had anticipated this, but using lowercase program names dark, gray, bright.  This PR fixes that.

Coming along for the ride is some work-in-progress for connecting truth table input to what is actually simulated, and removing some unused classes.

This PR is necessary to fix a broken integration test on master so I will self merge if there are no quick comments...