### PR TITLE
add rand seeds for batch pixsim

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ desisim change log
 -------------------
 
 * desi_qa_zfind: fixed --reduxdir option; improved plots
+* desisim.batch.pixsim functions propagate random seeds for reproducibility
 
 0.12.0 (2016-07-14)
 -------------------

--- a/py/desisim/batch/pixsim.py
+++ b/py/desisim/batch/pixsim.py
@@ -109,9 +109,9 @@ def batch_newexp(batchfile, flavors, nspec=5000, night=None, expids=None,
         fx.write('mkdir -p $DESI_SPECTRO_SIM/$PIXPROD/{}\n'.format(night))
         fx.write('\n')
         
-        for i, expid, flavor, tileid in zip(range(nexp), expids, flavors, tileids):
+        for expid, flavor, tileid, seed in zip(expids, flavors, tileids, seeds):
             fx.write(cmd.format(nspec=nspec, night=night, expid=expid,
-                flavor=flavor, tileid=tileid, seed=seeds[i])+' &\n')
+                flavor=flavor, tileid=tileid, seed=seeds)+' &\n')
             
         fx.write('\nwait\n')
         fx.write('\necho Done at `date`\n')
@@ -180,10 +180,10 @@ def batch_pixsim(batchfile, flavors, nspec=5000, night=None, expids=None,
 
         fx.write('\necho Starting at `date`\n')
 
-        for i, expid, flavor in zip(range(nexp), expids, flavors):
+        for expid, flavor, seed in zip(expids, flavors, seeds):
             fx.write('\n#- Exposure {} ({})\n'.format(expid, flavor))
                 
-            cx = cmd.format(night=night, expid=expid, nspectrographs=nspectrographs, seed=seeds[i])
+            cx = cmd.format(night=night, expid=expid, nspectrographs=nspectrographs, seed=seed)
             fx.write(cx + ' &\n')
         
         fx.write('\nwait\n')


### PR DESCRIPTION
Adds propagation of random seeds to the `desisim.batch.pixsim` utility functions for batch generation of pixel-level simulations.  This is needed for before/after testing during the python3 migration (and is good to have anyway).

Note: the FITS header CHECKSUM and DATASUM headers include the timestamp of when they were generated, thus causing the sha1sum of the files to differ, even though the data and headers are otherwise identical.  To work around this, I compared the fits files from two batch newexp+pixsim runs using `fitsdiff` commands like:
```
fitsdiff -k CHECKSUM,DATASUM 20160818a/pix-r0-00000003.fits 20160818b/pix-r0-00000003.fits

 fitsdiff: 1.1.1
 a: 20160818a/pix-r0-00000003.fits
 b: 20160818b/pix-r0-00000003.fits
 Keyword(s) not to be compared:
  CHECKSUM DATASUM
 Maximum number of different data values to be reported: 10
 Data comparison level: 0.0

No differences found.
```