### PR TITLE
fix template fibermap mag; fix quickgen outputs

### DIFF
--- a/bin/newexp-desi
+++ b/bin/newexp-desi
@@ -66,7 +66,7 @@ if opts.night is None:
     opts.night = obs.get_night(utc=time.gmtime())
 
 opts.flavor = opts.flavor.lower()
-if opts.flavor not in ['arc','flat','dark','gray','grey','bright','bgs','mws','lrg','elg','qso']:
+if opts.flavor not in ['arc','flat','dark','gray','grey','bright','bgs','mws','lrg','elg','qso','std']:
     log.fatal('ERROR: unknown flavor {}'.format(opts.flavor))
     sys.exit(1)
 
@@ -79,7 +79,7 @@ if opts.exptime is None:
         opts.exptime = 10
     elif opts.flavor in ('bright', 'mws', 'bgs'):
         opts.exptime = 300
-    elif opts.flavor in ('dark', 'elg', 'lrg', 'qso', 'gray', 'grey'):
+    elif opts.flavor in ('dark', 'elg', 'lrg', 'qso', 'gray', 'grey', 'std'):
         opts.exptime = 1000
     else:
         print('Do not know the default exposure time for flavor' + opts.flavor)

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -733,7 +733,7 @@ def empty_metatable(nmodel=1, objtype='ELG', add_SNeIa=None):
     meta.add_column(Column(name='SEED', length=nmodel, dtype='int64',
                            data=np.zeros(nmodel)-1))
     meta.add_column(Column(name='REDSHIFT', length=nmodel, dtype='f4',
-                           data=np.zeros(nmodel)-1))
+                           data=np.zeros(nmodel)))
     meta.add_column(Column(name='MAG', length=nmodel, dtype='f4',
                            data=np.zeros(nmodel)-1))
     meta.add_column(Column(name='DECAM_FLUX', shape=(6,), length=nmodel, dtype='f4'))

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -369,10 +369,19 @@ def get_targets(nspec, flavor, tileid=None, seed=None, specmin=0):
         #    import pdb ; pdb.set_trace()
         
         # Pack in the photometry.  This needs updating!
-        grz = 22.5-2.5*np.log10(meta['DECAM_FLUX'].data.flatten()[[1, 2, 4]])
-        wise = 22.5-2.5*np.log10(meta['WISE_FLUX'].data.flatten()[[0, 1]])
-        fibermap['MAG'][ii, :6] = np.vstack(np.hstack([grz, wise])).T
+        # grz = 22.5-2.5*np.log10(meta['DECAM_FLUX'].data.flatten()[[1, 2, 4]])
+        # wise = 22.5-2.5*np.log10(meta['WISE_FLUX'].data.flatten()[[0, 1]])
+        # fibermap['MAG'][ii, :6] = np.vstack(np.hstack([grz, wise])).T
+        # fibermap['FILTER'][ii, :6] = ['DECAM_G', 'DECAM_R', 'DECAM_Z', 'WISE_W1', 'WISE_W2']
+
+        ugrizy = 22.5-2.5*np.log10(meta['DECAM_FLUX'].data)
+        wise = 22.5-2.5*np.log10(meta['WISE_FLUX'].data)
         fibermap['FILTER'][ii, :6] = ['DECAM_G', 'DECAM_R', 'DECAM_Z', 'WISE_W1', 'WISE_W2']
+        fibermap['MAG'][ii, 0] = ugrizy[:, 1]
+        fibermap['MAG'][ii, 1] = ugrizy[:, 2]
+        fibermap['MAG'][ii, 2] = ugrizy[:, 4]
+        fibermap['MAG'][ii, 3] = wise[:, 0]
+        fibermap['MAG'][ii, 4] = wise[:, 1]
 
     ## Only store the metadata table for non-sky spectra.
     #notsky = np.where(true_objtype != 'SKY')[0]

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -363,17 +363,6 @@ def get_targets(nspec, flavor, tileid=None, seed=None, specmin=0):
         truth['UNITS'] = '1e-17 erg/s/cm2/A'
         truth['META'][ii] = meta
 
-        #success = (np.sum(truth['FLUX'][ii], axis=1) > 0)*1
-        #fix = np.where(success == 0)[0]
-        #if len(fix) > 0:
-        #    import pdb ; pdb.set_trace()
-        
-        # Pack in the photometry.  This needs updating!
-        # grz = 22.5-2.5*np.log10(meta['DECAM_FLUX'].data.flatten()[[1, 2, 4]])
-        # wise = 22.5-2.5*np.log10(meta['WISE_FLUX'].data.flatten()[[0, 1]])
-        # fibermap['MAG'][ii, :6] = np.vstack(np.hstack([grz, wise])).T
-        # fibermap['FILTER'][ii, :6] = ['DECAM_G', 'DECAM_R', 'DECAM_Z', 'WISE_W1', 'WISE_W2']
-
         ugrizy = 22.5-2.5*np.log10(meta['DECAM_FLUX'].data)
         wise = 22.5-2.5*np.log10(meta['WISE_FLUX'].data)
         fibermap['FILTER'][ii, :6] = ['DECAM_G', 'DECAM_R', 'DECAM_Z', 'WISE_W1', 'WISE_W2']
@@ -382,11 +371,6 @@ def get_targets(nspec, flavor, tileid=None, seed=None, specmin=0):
         fibermap['MAG'][ii, 2] = ugrizy[:, 4]
         fibermap['MAG'][ii, 3] = wise[:, 0]
         fibermap['MAG'][ii, 4] = wise[:, 1]
-
-    ## Only store the metadata table for non-sky spectra.
-    #notsky = np.where(true_objtype != 'SKY')[0]
-    #if len(notsky) > 0:
-    #    truth['META'] = truth['META'][notsky]
 
     #- Load fiber -> positioner mapping and tile information
     fiberpos = desimodel.io.load_fiberpos()

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -336,8 +336,14 @@ def get_targets(nspec, flavor, tileid=None, seed=None, specmin=0):
         # For a "bad" QSO simulate a normal star without color cuts, which isn't
         # right. We need to apply the QSO color-cuts to the normal stars to pull
         # out the correct population of contaminating stars.
+        
+        # Note by @moustakas: we can now do this using desisim/#150, but we are
+        # going to need 'noisy' photometry (because the QSO color-cuts
+        # explicitly avoid the stellar locus).
         elif objtype == 'QSO_BAD':
             from desisim.templates import STAR
+            #from desitarget.cuts import isQSO
+            #star = STAR(wave=wave, colorcuts_function=isQSO)
             star = STAR(wave=wave)
             simflux, wave1, meta = star.make_templates(nmodel=nobj, seed=seed)
             fibermap['DESI_TARGET'][ii] = desi_mask.QSO

--- a/py/desisim/test/test_templates.py
+++ b/py/desisim/test/test_templates.py
@@ -141,7 +141,7 @@ class TestTemplates(unittest.TestCase):
             flux2, wave2, meta2 = Tx.make_templates(input_meta=meta1)
             badkeys = list()
             for key in meta1.colnames:
-                if key in ('DECAM_FLUX', 'WISE_FLUX', 'OIIFLUX'):
+                if key in ('DECAM_FLUX', 'WISE_FLUX', 'OIIFLUX', 'HBETAFLUX'):
                     if not np.allclose(meta1[key], meta2[key]):
                         badkeys.append(key)
                 else:


### PR DESCRIPTION
This PR fixes the MAG calculation for the simulated fibermap, which was broken as part of PR #132.  The previous flattening/slicing/stacking logic was wrong and the same magnitudes were replicated across multiple targets.  This was the core problem for the integration test failures.

Other changes that came long for the ride as a result of debugging this:
* adds exposure flavor "std" to newexp-desi to simulate a bunch of standards; useful for debugging
* several quickgen fixes:
  * include fibermap in frame, cframe output
  * include CAMERA header keyword
  * fiberflats are referenced to 1.0 not 0.0
