### PR TITLE
Get desisim working on ReadTheDocs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,2 @@
 setuptools
-numpy
-scipy
-astropy
-pyyaml
 git+https://github.com/desihub/desiutil.git@1.8.0#egg=desiutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,4 @@ numpy
 scipy
 astropy
 pyyaml
-speclite
-specsim
-svn+https://desi.lbl.gov/svn/code/desimodel/branches/pip-install#egg=desimodel
-git+https://github.com/desihub/desispec.git@0.8.0#egg=desispec
-git+https://github.com/desihub/desiutil.git@1.6.0#egg=desiutil
+git+https://github.com/desihub/desiutil.git@1.8.0#egg=desiutil


### PR DESCRIPTION
desisim should now build successfully on ReadTheDocs.  You can view the successful build of this branch at https://desisim.readthedocs.io/en/rtd-test/.