### PR TITLE
quickbrick tests and bug fixes

### DIFF
--- a/py/desisim/scripts/quickbrick.py
+++ b/py/desisim/scripts/quickbrick.py
@@ -233,10 +233,6 @@ def main(args):
     meta.add_column(Column(true_objtype, dtype=(str, 10), name='TRUE_OBJTYPE'))
     meta.add_column(Column(targetids, name='TARGETID'))
 
-    # @sbailey asks: What was this supposed to do for OBJTYPE vs. TRUE_OBJTYPE?
-    # Now add fixed-up OBJTYPE to the template meta table
-    # meta.add_column(Column(true_objtype, dtype=(str, 10), name='OBJTYPE'))
-
     # Rename REDSHIFT -> TRUEZ anticipating later table joins with zbest.Z
     meta.rename_column('REDSHIFT', 'TRUEZ')
 

--- a/py/desisim/test/test_quickbrick.py
+++ b/py/desisim/test/test_quickbrick.py
@@ -1,0 +1,117 @@
+from __future__ import absolute_import, division, print_function
+
+import unittest
+from uuid import uuid1
+from shutil import rmtree
+import os
+
+import numpy as np
+from astropy.io import fits
+from desisim.scripts import quickbrick
+import desispec.io
+
+class TestQuickBrick(unittest.TestCase):
+    
+    #- Pick random test directory
+    def setUp(self):
+        self.testdir = 'test-{uuid}'.format(uuid=uuid1())
+
+    #- Cleanup test files if they exist
+    def tearDown(self):
+        if os.path.exists(self.testdir):
+            rmtree(self.testdir)
+            
+    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
+    def test_quickbrick(self):
+        brickname = 'test1'
+        nspec = 3
+        cmd = "quickbrick -b {} --objtype ELG -n {} --outdir {}".format(brickname, nspec, self.testdir)
+        args = quickbrick.parse(cmd.split()[1:])
+        results = quickbrick.main(args)
+        #- Do the bricks exist?
+        for channel in ['z', 'r', 'b']:
+            brickfile = '{}/brick-{}-{}.fits'.format(self.testdir, channel, brickname)
+            self.assertTrue(os.path.exists(brickfile))
+            
+        #- Check one of them for correct dimensionality of contents
+        brickfile = '{}/brick-b-{}.fits'.format(self.testdir, brickname)
+        with fits.open(brickfile) as fx:
+            self.assertEqual(fx['FLUX'].shape[0], nspec)
+            self.assertEqual(fx['FLUX'].shape, fx['IVAR'].shape)
+            self.assertEqual(fx['FLUX'].shape[1], fx['WAVELENGTH'].shape[0])
+            self.assertEqual(fx['FLUX'].shape[0], fx['RESOLUTION'].shape[0])
+            self.assertEqual(fx['FLUX'].shape[1], fx['RESOLUTION'].shape[2])
+            self.assertEqual(len(fx['FIBERMAP'].data), nspec)
+            self.assertEqual(fx['_TRUEFLUX'].shape, fx['FLUX'].shape)
+            self.assertTrue(np.all(fx['_TRUTH'].data['OBJTYPE'] == 'ELG'))
+        
+        #- Make sure that desispec I/O functions can read it
+        frame = desispec.io.read_frame(brickfile)
+        self.assertEqual(frame.flux.shape[0], nspec)
+        brick = desispec.io.Brick(brickfile)
+        self.assertEqual(brick.get_num_spectra(), nspec)
+        brick.close()
+
+    #- Test quickbrick with a bunch of options
+    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
+    def test_quickbrick_options(self):
+        brickname = 'test2'
+        nspec = 3
+        cmd = "quickbrick -b {} --objtype BGS -n {} --outdir {}".format(brickname, nspec, self.testdir)
+        cmd = cmd + " --airmass 1.5 --verbose --zrange-bgs 0.1 0.2"
+        cmd = cmd + " --moon-phase 0.1 --moon-angle 30 --moon-zenith 20"
+        args = quickbrick.parse(cmd.split()[1:])
+        results = quickbrick.main(args)
+        brickfile = '{}/brick-b-{}.fits'.format(self.testdir, brickname)
+        truth = fits.getdata(brickfile, '_TRUTH')        
+        z = truth['TRUEZ']
+        self.assertTrue(np.all((0.1 <= z) & (z <= 0.2)))
+
+    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
+    def test_quickbrick_seed(self):
+        nspec = 2
+        cmd = "quickbrick --seed 1 -b test1 --objtype BRIGHT_MIX -n {} --outdir {}".format(nspec, self.testdir)
+        quickbrick.main(quickbrick.parse(cmd.split()[1:]))
+        cmd = "quickbrick --seed 1 -b test2 --objtype BRIGHT_MIX -n {} --outdir {}".format(nspec, self.testdir)
+        quickbrick.main(quickbrick.parse(cmd.split()[1:]))
+        
+        f1 = desispec.io.read_frame('{}/brick-b-test1.fits'.format(self.testdir))
+        f2 = desispec.io.read_frame('{}/brick-b-test2.fits'.format(self.testdir))
+        self.assertTrue(np.all(f1.flux == f2.flux))
+        self.assertTrue(np.all(f1.ivar == f2.ivar))
+
+        t1 = fits.getdata('{}/brick-b-test1.fits'.format(self.testdir), '_TRUTH')
+        t2 = fits.getdata('{}/brick-b-test2.fits'.format(self.testdir), '_TRUTH')
+        self.assertTrue(np.all(t1['TRUE_OBJTYPE'] == t2['TRUE_OBJTYPE']))
+        self.assertTrue(np.all(t1['TRUEZ'] == t2['TRUEZ']))
+
+    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
+    def test_quickbrick_moon(self):
+        nspec = 2
+        cmd = "quickbrick --seed 1 -b brightmoon --objtype BRIGHT_MIX -n {} --outdir {} --moon-phase 0.1".format(nspec, self.testdir)
+        quickbrick.main(quickbrick.parse(cmd.split()[1:]))
+        cmd = "quickbrick --seed 1 -b crescentmoon --objtype BRIGHT_MIX -n {} --outdir {} --moon-phase 0.9".format(nspec, self.testdir)
+        quickbrick.main(quickbrick.parse(cmd.split()[1:]))
+        
+        brickfile = '{}/brick-b-brightmoon.fits'.format(self.testdir)
+        brick1 = desispec.io.read_frame(brickfile)
+        brickfile = '{}/brick-b-crescentmoon.fits'.format(self.testdir)
+        brick2 = desispec.io.read_frame(brickfile)
+        #- brick1 has more moonlight thus larger errors thus smaller ivar
+        self.assertLess(np.median(brick1.ivar), np.median(brick2.ivar))
+
+    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
+    def test_quickbrick_exptime(self):
+        nspec = 2
+        cmd = "quickbrick --seed 1 -b test1 --exptime 100 --objtype DARK_MIX -n {} --outdir {}".format(nspec, self.testdir)
+        quickbrick.main(quickbrick.parse(cmd.split()[1:]))
+        cmd = "quickbrick --seed 1 -b test2 --exptime 1000 --objtype DARK_MIX -n {} --outdir {}".format(nspec, self.testdir)
+        quickbrick.main(quickbrick.parse(cmd.split()[1:]))
+        
+        f1 = desispec.io.read_frame('{}/brick-b-test1.fits'.format(self.testdir))
+        f2 = desispec.io.read_frame('{}/brick-b-test2.fits'.format(self.testdir))
+        #- test1 has shorter exposure time thus larger errors thus smaller ivar
+        self.assertLess(np.median(f1.ivar), np.median(f2.ivar))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR
 * adds tests for quickbrick
 * fixes #161 (updating how exposure time is set with specsim v0.5)
 * fixes #162 (quickbrick crash)
 * closes #96 (tests for quickgen and quickbrick)

It also fixes some bugs that weren't previously known and were caught by the new unit tests:
 * --seed option wasn't working
 * truth table output was corrupted using py3

However:
  * The tests won't work on Travis until desihub/specsim#43 is addressed to reduce the specsim memory footprint or another workaround is found.  I've flagged these with `@unittest.skipIf('TRAVIS_JOB_ID' in os.environ)` wrappers.  Note that this also impacts the quickgen tests -- you can run them on a laptop with sufficient memory, but not on Travis.  In the meantime, we also won't get accurate coverage reports on coveralls.io for these.
  * The tests are slow (2.5 minutes for just the quickbrick tests).  Although quicksim is fast for N>>1 spectra in a single shot, generating the templates on the fly is not, and quicksim has a fairly large overhead that we encounter multiple times when comparing things like "did making the moon brighter make the spectra noiser?"
  * I'm not sure what the original intent of OBJTYPE vs. TRUE_OBJTYPE was for the truth table.  What I have in there currently at least runs, but it may need further modification.

Related: apologies for the noise I generated on issue #161 where I kept typing "specsim" when I meant "desisim".  @dkirkby and I meant the same thing but I kept typing the wrong thing and misreading the right thing that he was typing...