### PR TITLE
Tiny one-line fix so that function from desisim.pixsim can be called.

### DIFF
--- a/py/desisim/scripts/pixsim.py
+++ b/py/desisim/scripts/pixsim.py
@@ -12,6 +12,7 @@ import desimodel.io
 import desispec.io
 
 import desisim
+import desisim.pixsim
 from desisim import obs, io
 from desispec.log import get_logger
 log = get_logger()

--- a/py/desisim/scripts/pixsim.py
+++ b/py/desisim/scripts/pixsim.py
@@ -265,3 +265,4 @@ def main(args=None):
     if mpicomm.rank == 0:
         log.info('Finished pixsim {} expid {} at {}'.format(args.night, args.expid, asctime()))
 
+


### PR DESCRIPTION
Without this line, I get an error running on python 2.7:

File "/home/kisner/software/desi27/lib/python2.7/site-packages/desisim-0.14.0.dev684-py2.7.egg/desisim/scripts/pixsim.py", line 232, in main
    image, rawpix, truepix = desisim.pixsim.simulate(
AttributeError: 'module' object has no attribute 'pixsim'

This line fixes the error.  I am not sure why this does not get triggered by the desispec integration test!