### PR TITLE
added unit tests to quickgen and updated exposure time

### DIFF
--- a/py/desisim/scripts/quickgen.py
+++ b/py/desisim/scripts/quickgen.py
@@ -369,13 +369,13 @@ def main(args=None):
 
             # Get results for our flux-calibrated output file.
             assert output['observed_flux'].unit == u.erg / (u.cm**2 * u.s * u.Angstrom)
-            cframe_observedflux[j, i, :num_pixels] = output['observed_flux']
-            cframe_ivar[j, i, :num_pixels] = output['flux_inverse_variance']
+            cframe_observedflux[j, i, :num_pixels] = 1e17 * output['observed_flux']
+            cframe_ivar[j, i, :num_pixels] = 1e-34 * output['flux_inverse_variance']
 
             # Use the same noise realization in the cframe and frame, without any
             # additional noise from sky subtraction for now.
             frame_rand_noise[j, i, :num_pixels] = output['random_noise_electrons']
-            cframe_rand_noise[j, i, :num_pixels] = (
+            cframe_rand_noise[j, i, :num_pixels] = 1e17 * (
                 output['flux_calibration'] * output['random_noise_electrons'])
 
             # The sky output file represents a model fit to ~40 sky fibers.

--- a/py/desisim/scripts/quickgen.py
+++ b/py/desisim/scripts/quickgen.py
@@ -165,6 +165,11 @@ def main(args=None):
     print("Initializing SpecSim with config '{0}'".format(args.config))
     qsim = specsim.simulator.Simulator(args.config)
 
+    # explicitly set location on focal plane if needed to support airmass
+    # variations when using specsim v0.5
+    if qsim.source.focal_xy is None:
+        qsim.source.focal_xy = (u.Quantity(0, 'mm'), u.Quantity(100, 'mm'))
+
     # Set simulation parameters from the simspec header.
     qsim.atmosphere.airmass = simspec.header['AIRMASS']
     qsim.observation.exposure_time = simspec.header['EXPTIME'] * u.s

--- a/py/desisim/scripts/quickgen.py
+++ b/py/desisim/scripts/quickgen.py
@@ -167,7 +167,7 @@ def main(args=None):
 
     # Set simulation parameters from the simspec header.
     qsim.atmosphere.airmass = simspec.header['AIRMASS']
-    qsim.instrument.exposure_time = simspec.header['EXPTIME'] * u.s
+    qsim.observation.exposure_time = simspec.header['EXPTIME'] * u.s
 
     # Get the camera output pixels from the specsim instrument model.
     maxbin = 0

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -358,7 +358,9 @@ def get_targets(nspec, flavor, tileid=None, seed=None, specmin=0):
             # todo: mag ranges for different flavors of STAR targets should be in desimodel
             simflux, wave1, meta = mwsstar.make_templates(nmodel=nobj,rmagrange=(15.0,20.0), seed=seed)
             fibermap['DESI_TARGET'][ii] = desi_mask.MWS_ANY
-            fibermap['MWS_TARGET'][ii] = mws_mask.MWS_PLX  #- ???
+            #- MWS bit names changed after desitarget 0.6.0 so use number
+            #- instead of name for now (bit 0 = mask 1 = MWS_MAIN currently)
+            fibermap['MWS_TARGET'][ii] = 1
 
         else:
             raise ValueError('Unable to simulate OBJTYPE={}'.format(objtype))

--- a/py/desisim/test/test_quickgen.py
+++ b/py/desisim/test/test_quickgen.py
@@ -5,6 +5,7 @@ import unittest, os
 from uuid import uuid1
 from shutil import rmtree
 
+import numpy as np
 import desispec.io
 from desisim import io
 from desisim import obs
@@ -222,49 +223,55 @@ class TestQuickgen(unittest.TestCase):
     # test to see if increased airmass yields smaller ivar
     def test_quickgen_airmass(self):
 
+        CFRAME100_PATH = os.path.join(os.environ['HOME'],'desi_test_io','spectro','sim','test-quickgen','test-quickgen','exposures','20150105','00000100','cframe-r0-00000100.fits')
+        CFRAME101_PATH = os.path.join(os.environ['HOME'],'desi_test_io','spectro','sim','test-quickgen','test-quickgen','exposures','20150105','00000101','cframe-r0-00000101.fits')
+
         # generate exposures of varying airmass
         night=self.night
         obs.new_exposure('dark', night=night, expid=100, nspec=1, airmass=1.5)
-        simspec0 = io.findfile('simspec', self.night, 100)
-        fibermap0 = desispec.io.findfile('fibermap', self.night, 100)
+        simspec0 = io.findfile('simspec', night, 100)
+        fibermap0 = desispec.io.findfile('fibermap', night, 100)
         opts0 = ['--simspec', simspec0, '--fibermap', fibermap0]
 
         obs.new_exposure('dark', night=night, expid=101, nspec=1, airmass=1.0)
-        simspec1 = io.findfile('simspec', self.night, 101)
-        fibermap1 = desispec.io.findfile('fibermap', self.night, 101)
+        simspec1 = io.findfile('simspec', night, 101)
+        fibermap1 = desispec.io.findfile('fibermap', night, 101)
         opts1 = ['--simspec', simspec1, '--fibermap', fibermap1]
 
         # generate quickgen output for each airmass
         desisim.scripts.quickgen.main(opts0)
         desisim.scripts.quickgen.main(opts1)
 
-        cf0=desispec.io.readframe('cframe-r0-00000100.fits')
-        cf1=desispec.io.readframe('cframe-r0-00000101.fits')
-        self.assertLess(np.median(cf0.ivar), np.median(cf1.ivar))
+        cf0=desispec.io.read_frame(CFRAME100_PATH)
+        cf1=desispec.io.read_frame(CFRAME101_PATH)
+        self.assertLess(np.median(cf0.ivar),np.median(cf1.ivar))
 
     @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
     # test to see if decreased exposure time yields smaller ivar
     def test_quickgen_exptime(self):
 
+        CFRAME100_PATH = os.path.join(os.environ['HOME'],'desi_test_io','spectro','sim','test-quickgen','test-quickgen','exposures','20150105','00000100','cframe-r0-00000100.fits')
+        CFRAME101_PATH = os.path.join(os.environ['HOME'],'desi_test_io','spectro','sim','test-quickgen','test-quickgen','exposures','20150105','00000101','cframe-r0-00000101.fits')
+
         # generate exposures of varying exposure times
         night=self.night
         obs.new_exposure('dark', exptime=100, night=night, expid=100, nspec=1)
-        simspec0 = io.findfile('simspec', self.night, 100)
-        fibermap0 = desispec.io.findfile('fibermap', self.night, 100)
+        simspec0 = io.findfile('simspec', night, 100)
+        fibermap0 = desispec.io.findfile('fibermap', night, 100)
         opts0 = ['--simspec', simspec0, '--fibermap', fibermap0]
 
         obs.new_exposure('dark', exptime=1000, night=night, expid=101, nspec=1)
-        simspec1 = io.findfile('simspec', self.night, 101)
-        fibermap1 = desispec.io.findfile('fibermap', self.night, 101)
+        simspec1 = io.findfile('simspec', night, 101)
+        fibermap1 = desispec.io.findfile('fibermap', night, 101)
         opts1 = ['--simspec', simspec1, '--fibermap', fibermap1]
 
         # generate quickgen output for each exposure time
         desisim.scripts.quickgen.main(opts0)
         desisim.scripts.quickgen.main(opts1)
 
-        cf0=desispec.io.readframe('cframe-r0-00000100.fits')
-        cf1=desispec.io.readframe('cframe-r0-00000101.fits')
-        self.assertLess(np.median(cf0.ivar), np.median(cf1.ivar))
+        cf0=desispec.io.read_frame(CFRAME100_PATH)
+        cf1=desispec.io.read_frame(CFRAME101_PATH)
+        self.assertLess(np.median(cf0.ivar),np.median(cf1.ivar))
 
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':

--- a/py/desisim/test/test_quickgen.py
+++ b/py/desisim/test/test_quickgen.py
@@ -245,7 +245,7 @@ class TestQuickgen(unittest.TestCase):
         fibermap2 = desispec.io.findfile('fibermap', night, 102)
         opts2 = ['--simspec', simspec2, '--fibermap', fibermap2]
 
-        # generate quickgen output for each airmass
+        # generate quickgen output for each exposure
         desisim.scripts.quickgen.main(opts0)
         desisim.scripts.quickgen.main(opts1)
         desisim.scripts.quickgen.main(opts2)


### PR DESCRIPTION
This PR

- adds airmass unit test for quickgen
- adds exposure time unit test for quickgen
- updates how exposure time is set with specsim v0.5

Note: bright time vs. dark time unit test is not included since quickgen does not yet include a moon phase option as quickbrick does.
