### PR TITLE
Cache specsim

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ env:
         - SPECLITE_VERSION=0.5
         - SPECSIM_VERSION=master
         - SPECTER_VERSION=0.6.0
-        - DESISPEC_VERSION=0.11.0
+        - DESISPEC_VERSION=master
         - DESITARGET_VERSION=0.7.0
         # - DESIMODEL_VERSION=trunk
         - DESI_LOGLEVEL=DEBUG

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,10 +47,10 @@ env:
         - DESIMODEL_DATA=branches/test-0.4.5
         - DESISIM_TESTDATA_VERSION=0.3.2
         - SPECLITE_VERSION=0.5
-        - SPECSIM_VERSION=v0.5
+        - SPECSIM_VERSION=master
         - SPECTER_VERSION=0.6.0
-        - DESISPEC_VERSION=0.10.0
-        - DESITARGET_VERSION=0.6.1
+        - DESISPEC_VERSION=0.11.0
+        - DESITARGET_VERSION=0.7.0
         # - DESIMODEL_VERSION=trunk
         - DESI_LOGLEVEL=DEBUG
         - MAIN_CMD='python setup.py'

--- a/py/desisim/scripts/quickgen.py
+++ b/py/desisim/scripts/quickgen.py
@@ -27,6 +27,7 @@ from desispec.fiberflat import FiberFlat
 from desispec.sky import SkyModel
 from desispec.fluxcalibration import FluxCalib
 from desispec.log import INFO
+from ..specsim import get_simulator
 
 def expand_args(args):
     hdr = fits.getheader(args.simspec)
@@ -168,7 +169,8 @@ def main(args=None):
     log.info("************************************************")
 
     log.info("Initializing SpecSim with config {}".format(args.config))
-    qsim = specsim.simulator.Simulator(args.config)
+    ### qsim = specsim.simulator.Simulator(args.config)
+    qsim = get_simulator(args.config)
 
     # explicitly set location on focal plane if needed to support airmass
     # variations when using specsim v0.5

--- a/py/desisim/specsim.py
+++ b/py/desisim/specsim.py
@@ -1,0 +1,50 @@
+'''
+DESI wrapper functions for external specsim classes
+'''
+
+from __future__ import absolute_import, division, print_function
+
+#- Cached simulators, keyed by config string
+_simulators = dict()
+
+#- Cached defaults after loading a new simulator, to be used to reset a
+#- simulator back to a reference state before returning it as a cached copy
+_simdefaults = dict()
+
+import desispec.log
+log = desispec.log.get_logger()
+
+def get_simulator(config='desi'):
+    '''
+    returns new or cached specsim.simulator.Simulator object
+    '''
+    if config in _simulators:
+        log.debug('Returning cached {} Simulator'.format(config))
+        qsim = _simulators[config]
+        defaults = _simdefaults[config]
+        qsim.source.focal_xy = defaults['focal_xy']
+        qsim.atmosphere.airmass = defaults['airmass']
+        qsim.observation.exposure_time = defaults['exposure_time']
+        qsim.atmosphere.moon.moon_phase = defaults['moon_phase']
+        qsim.atmosphere.moon.separation_angle = defaults['moon_angle']
+        qsim.atmosphere.moon.moon_zenith = defaults['moon_zenith']
+
+    else:
+        log.debug('Creating new {} Simulator'.format(config))
+        #- New config; create Simulator object
+        import specsim.simulator
+        qsim = specsim.simulator.Simulator(config)
+        #- Cache defaults to reset back to original state later
+        defaults = dict()
+        defaults['focal_xy'] = qsim.source.focal_xy
+        defaults['airmass'] = qsim.atmosphere.airmass
+        defaults['exposure_time'] = qsim.observation.exposure_time
+        defaults['moon_phase'] = qsim.atmosphere.moon.moon_phase
+        defaults['moon_angle'] = qsim.atmosphere.moon.separation_angle
+        defaults['moon_zenith'] = qsim.atmosphere.moon.moon_zenith
+
+        _simulators[config] = qsim
+        _simdefaults[config] = defaults
+
+    return qsim
+    

--- a/py/desisim/test/test_quickbrick.py
+++ b/py/desisim/test/test_quickbrick.py
@@ -22,7 +22,7 @@ class TestQuickBrick(unittest.TestCase):
             rmtree(self.testdir)
             
     #- Run basic test of quickbrick and check its outputs
-    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
+    ### @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
     def test_quickbrick(self):
         brickname = 'test1'
         nspec = 3
@@ -54,7 +54,7 @@ class TestQuickBrick(unittest.TestCase):
         brick.close()
 
     #- Test quickbrick with a bunch of options
-    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
+    ### @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
     def test_quickbrick_options(self):
         brickname = 'test2'
         nspec = 5
@@ -86,7 +86,7 @@ class TestQuickBrick(unittest.TestCase):
             self.assertLess(std, 0.2)                        
 
     #- Ensure that using --seed results in reproducible spectra
-    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
+    ### @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
     def test_quickbrick_seed(self):
         nspec = 2
         cmd = "quickbrick --seed 1 -b test1a --objtype BRIGHT_MIX -n {} --outdir {}".format(nspec, self.testdir)
@@ -111,7 +111,7 @@ class TestQuickBrick(unittest.TestCase):
         self.assertTrue(np.any(t1a['TRUEZ'] != t2['TRUEZ']))
 
     #- Test that brighter moon makes noisier spectra
-    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
+    ### @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
     def test_quickbrick_moon(self):
         nspec = 2
         cmd = "quickbrick --seed 1 -b brightmoon --objtype BRIGHT_MIX -n {} --outdir {} --moon-phase 0.1".format(nspec, self.testdir)
@@ -127,7 +127,7 @@ class TestQuickBrick(unittest.TestCase):
         self.assertLess(np.median(brick1.ivar), np.median(brick2.ivar))
 
     #- Test that shorter exposures make noisier spectra
-    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
+    ### @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickbrick/specsim test on Travis')
     def test_quickbrick_exptime(self):
         nspec = 2
         cmd = "quickbrick --seed 1 -b test1 --exptime 100 --objtype DARK_MIX -n {} --outdir {}".format(nspec, self.testdir)

--- a/py/desisim/test/test_quickgen.py
+++ b/py/desisim/test/test_quickgen.py
@@ -155,7 +155,7 @@ class TestQuickgen(unittest.TestCase):
         self.assertEqual(args.fibermap, fibermap)
 
     @unittest.skipUnless(desi_root_available, '$DESI_ROOT not set')
-    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
+    ### @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
     def test_quickgen(self):
         night = self.night
         expid = self.expid
@@ -220,7 +220,7 @@ class TestQuickgen(unittest.TestCase):
                 os.remove(skyfile)
                 os.remove(fluxcalibfile)
 
-    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
+    ### @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
     # test to see if same seed yields same spectrum
     def test_quickgen_seed(self):
 
@@ -266,7 +266,7 @@ class TestQuickgen(unittest.TestCase):
         self.assertTrue(s0[13].data['REDSHIFT'][0] == s1[13].data['REDSHIFT'][0])
         self.assertTrue(s0[13].data['REDSHIFT'][0] != s2[13].data['REDSHIFT'][0])
 
-    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
+    ### @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
     # test to see if increased airmass yields smaller ivar
     def test_quickgen_airmass(self):
 
@@ -293,7 +293,7 @@ class TestQuickgen(unittest.TestCase):
         cf1=desispec.io.read_frame(CFRAME101_PATH)
         self.assertLess(np.median(cf0.ivar),np.median(cf1.ivar))
 
-    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
+    ### @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
     # test to see if decreased exposure time yields smaller ivar
     def test_quickgen_exptime(self):
 
@@ -320,7 +320,7 @@ class TestQuickgen(unittest.TestCase):
         cf1=desispec.io.read_frame(CFRAME101_PATH)
         self.assertLess(np.median(cf0.ivar),np.median(cf1.ivar))
 
-    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
+    ### @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
     # test to see if full moon yields smaller ivar than new moon
     def test_quickgen_moonphase(self):
 
@@ -347,7 +347,7 @@ class TestQuickgen(unittest.TestCase):
         cf1=desispec.io.read_frame(CFRAME101_PATH)
         self.assertLess(np.median(cf0.ivar),np.median(cf1.ivar))
 
-    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
+    ### @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
     # test to see if moon angle of 0 yeilds smaller ivar than a moon angle of 180
     def test_quickgen_moonangle(self):
 
@@ -374,7 +374,7 @@ class TestQuickgen(unittest.TestCase):
         cf1=desispec.io.read_frame(CFRAME101_PATH)
         self.assertLess(np.median(cf0.ivar),np.median(cf1.ivar))
 
-    @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
+    ### @unittest.skipIf('TRAVIS_JOB_ID' in os.environ, 'Skipping memory hungry quickgen/specsim test on Travis')
     # test to see if moon zenith angle of 0 yeilds smaller ivar than moon zenith angle of 90
     def test_quickgen_moonzenith(self):
 


### PR DESCRIPTION
This PR makes the quickbrick and quickgen tests ~2x faster by caching the `specsim.simulator.Simulator` object instead of recreating it anew every time.  It also enables these tests on Travis using specsim master and desisim master, now that specsim fits within the memory limits of Travis (as a side effect, the tests were also faster due to that change, even before this caching).  After the next tag of specsim, we can update this to use that tag instead.

Since the cached `Simulator` object may have been altered by the previous test, the caching code also caches the state for a few key variables and puts them back to their original state before returning the cached object:
* qsim.source.focal_xy
* qsim.atmosphere.airmass
* qsim.observation.exposure_time
* qsim.atmosphere.moon.moon_phase
* qsim.atmosphere.moon.separation_angle
* qsim.atmosphere.moon.moon_zenith

Are there other variables that should also be reset?

The new `desisim.specsim` module could also be the namespace landing spot for other desi-specific wrappers to `specsim` to unify the common code from quickbrick and quickgen.  If having both `desisim.specsim` and `specsim` is confusing, please suggest an alternate name for desi-specific convenience wrappers of `specsim`.
