### PR TITLE
add integration test for quickgen

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,9 +5,9 @@ desisim change log
 0.15.1 (unreleased)
 -------------------
 
-* No changes yet
+* add integration test for quickgen
 
-0.15.0 (2016-10-14)
+0.15.0 (2016-10-20)
 -------------------
 
 * add moon phase, moon angle, and zenith angle to quickgen

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,35 +5,9 @@ desisim change log
 0.15.1 (unreleased)
 -------------------
 
-* add integration test for quickgen
+* Add integration test for quickgen
 
-0.15.0 (2016-10-20)
--------------------
-
-* add moon phase, moon angle, and zenith angle to quickgen
-* add a unit test for each moon property
-
-0.14.0 (2016-10-13)
--------------------
-
-* change $PRODNAME to $SPECPROD in quickgen
-* change print statement to log.info() in quickgen
-* change os.path.join to desispec.io.findfile in quickgen
-
-0.14.0 (2016-10-12)
--------------------
-
-* add keyword frameonly to quickgen
-* allow for only uncalibrated frame files to be output by quickgen
-
-0.14.0 (2016-10-12)
--------------------
-
-* add airmass unit test for quickgen
-* add exposure time unit test for quickgen
-* update how exposure time is set in quickgen with specsim v0.5
-
-0.14.0 (2016-09-28)
+0.15.0 (2016-10-14)
 -------------------
 
 * Fix some ``build_sphinx`` errors.

--- a/py/desisim/test/integration_test_quickgen.py
+++ b/py/desisim/test/integration_test_quickgen.py
@@ -112,7 +112,7 @@ def integration_test(night="20160726", nspec=25, clobber=False):
         skytestfile = desispec.io.findfile('sky', night, expid, camera) + 'test'
         calibfile = desispec.io.findfile('calib', night, expid, camera)
         calibtestfile = desispec.io.findfile('calib', night, expid, camera) + 'test'
-        stdstarsfile = desispec.io.findfile('stdstars', night, expid, camera, spectrograph=0)
+        stdstarsfile = desispec.io.findfile('stdstars', night, expid, spectrograph=0)
         cframetestfile = desispec.io.findfile('cframe', night, expid, camera) + 'test'
 
         # verify that quickgen output works for full pipeline
@@ -120,9 +120,11 @@ def integration_test(night="20160726", nspec=25, clobber=False):
         if pipe.runcmd(com, clobber=clobber) != 0:
             raise RuntimeError('desi_compute_sky failed for camera {}'.format(camera))
 
-        com = "desi_fit_stdstars --frames {} --skymodels {} --fiberflats {} --starmodels $DESI_BASIS_TEMPLATES/star_templates_v2.1.fits --outfile {}".format(framefile, skyfile, fiberflatfile, stdstarsfile)
-        if pipe.runcmd(com, clobber=clobber) != 0:
-            raise RuntimeError('desi_fit_stdstars failed for camera {}'.format(camera))
+        # only fit stdstars once
+        if camera == 'b0':
+            com = "desi_fit_stdstars --frames {} --skymodels {} --fiberflats {} --starmodels $DESI_BASIS_TEMPLATES/star_templates_v2.1.fits --outfile {}".format(framefile, skyfile, fiberflatfile, stdstarsfile)
+            if pipe.runcmd(com, clobber=clobber) != 0:
+                raise RuntimeError('desi_fit_stdstars failed for camera {}'.format(camera))
 
         com = "desi_compute_fluxcalibration --infile {} --fiberflat {} --sky {} --models {} --outfile {}".format(framefile, fiberflatfile, skyfile, stdstarsfile, calibtestfile)
         if pipe.runcmd(com, clobber=clobber) != 0:

--- a/py/desisim/test/integration_test_quickgen.py
+++ b/py/desisim/test/integration_test_quickgen.py
@@ -1,0 +1,136 @@
+"""
+Run integration test using quickgen output for full pipeline
+
+python -m desisim.test.integration_test_quickgen
+"""
+import os
+from desisim import io
+import desispec.pipeline as pipe
+import desispec.log as logging
+
+desi_templates_available = 'DESI_ROOT' in os.environ
+desi_root_available = 'DESI_ROOT' in os.environ
+
+def check_env():
+    """
+    Check required environment variables; raise RuntimeException if missing
+    """
+    log = logging.get_logger()
+    #- template locations
+    missing_env = False
+    if 'DESI_BASIS_TEMPLATES' not in os.environ:
+        log.warning('missing $DESI_BASIS_TEMPLATES needed for simulating spectra'.format(name))
+        missing_env = True
+
+    if not os.path.isdir(os.getenv('DESI_BASIS_TEMPLATES')):
+        log.warning('missing $DESI_BASIS_TEMPLATES directory')
+        log.warning('e.g. see NERSC:/project/projectdirs/desi/spectro/templates/basis_templates/v1.0')
+        missing_env = True
+
+    for name in (
+        'DESI_SPECTRO_SIM', 'DESI_SPECTRO_REDUX', 'PIXPROD', 'SPECPROD', 'DESIMODEL'):
+        if name not in os.environ:
+            log.warning("missing ${0}".format(name))
+            missing_env = True
+
+    if missing_env:
+        log.warning("Why are these needed?")
+        log.warning("    Simulations written to $DESI_SPECTRO_SIM/$PIXPROD/")
+        log.warning("    Raw data read from $DESI_SPECTRO_DATA/")
+        log.warning("    Spectro pipeline output written to $DESI_SPECTRO_REDUX/$SPECPROD/")
+        log.warning("    Templates are read from $DESI_BASIS_TEMPLATES")
+
+    #- Wait until end to raise exception so that we report everything that
+    #- is missing before actually failing
+    if missing_env:
+        log.critical("missing env vars; exiting without running pipeline")
+        sys.exit(1)
+
+# Simulate raw data
+
+def sim(night, nspec=5, clobber=False):
+    """
+    Simulate data as part of the integration test.
+
+    Args:
+        night (str): YEARMMDD
+        nspec (int, optional): number of spectra to include
+        clobber (bool, optional): rerun steps even if outputs already exist
+        
+    Raises:
+        RuntimeError if any script fails
+    """
+    log = logging.get_logger()
+    output_dir = os.path.join('$DESI_SPECTRO_REDUX','calib2d')
+
+    # Create input fibermaps, spectra, and quickgen data
+
+    for expid, flavor in zip([0,1,2], ['flat', 'arc', 'dark']):
+
+        cmd = "newexp-desi --flavor {flavor} --nspec {nspec} --night {night} --expid {expid}".format(expid=expid, flavor=flavor, nspec=nspec, night=night)
+        simspec = io.findfile('simspec', night, expid)
+        fibermap = '{}/fibermap-{:08d}.fits'.format(os.path.dirname(simspec),expid)
+        if pipe.runcmd(cmd, clobber=clobber) != 0:
+            raise RuntimeError('newexp failed for {} exposure {}'.format(flavor, expid))
+
+        cmd = "quickgen --simspec {} --fibermap {}".format(simspec,fibermap)
+        if pipe.runcmd(cmd, clobber=clobber) != 0:
+            raise RuntimeError('quickgen failed for {} exposure {}'.format(flavor, expid))
+
+    return
+
+def integration_test(night="20160726", nspec=25, clobber=False):
+    """Run an integration test from raw data simulations through redshifts
+    
+    Args:
+        night (str, optional): YEARMMDD, defaults to current night
+        nspec (int, optional): number of spectra to include
+        clobber (bool, optional): rerun steps even if outputs already exist
+        
+    Raises:
+        RuntimeError if any script fails
+      
+    """
+    log = logging.get_logger()
+    log.setLevel(logging.DEBUG)
+
+    flat_expid = "00000000"
+    expid = "00000002"
+
+    # check for required environment variables
+    check_env()
+
+    # simulate inputs
+    sim(night, nspec=nspec, clobber=clobber)
+    simdir = os.path.join('$DESI_SPECTRO_SIM','exposures','20160726')
+    rawdir = os.path.join('$DESI_SPECTRO_REDUX','exposures','20160726')
+    flatdir = os.path.join('$DESI_SPECTRO_REDUX','calib2d','20160726')
+
+    # verify that quickgen output works for full pipeline
+    for camera in ['b0', 'r0', 'z0']:
+        com = "desi_compute_sky --infile {}/{}/frame-{}-{}.fits --fiberflat {}/fiberflat-{}-{}.fits --outfile {}/{}/sky-{}-{}_test.fits".format(rawdir,expid,camera,expid,flatdir,camera,flat_expid,rawdir,expid,camera,expid)
+        if pipe.runcmd(com, clobber=clobber) != 0:
+            raise RuntimeError('desi_compute_sky failed for camera {}'.format(camera))
+
+    for camera in ['b0', 'r0', 'z0']:
+        com = "desi_fit_stdstars --frames {}/{}/frame-{}-{}.fits --skymodels {}/{}/sky-{}-{}.fits --fiberflats {}/fiberflat-{}-{}.fits --starmodels $DESI_BASIS_TEMPLATES/star_templates_v2.1.fits --outfile {}/{}/stdstars-{}-{}.fits".format(rawdir,expid,camera,expid,rawdir,expid,camera,expid,flatdir,camera,flat_expid,rawdir,expid,camera,expid)
+        if pipe.runcmd(com, clobber=clobber) != 0:
+            raise RuntimeError('desi_fit_stdstars failed for camera {}'.format(camera))
+
+    for camera in ['b0', 'r0', 'z0']:
+        com = "desi_compute_fluxcalibration --infile {}/{}/frame-{}-{}.fits --fiberflat {}/fiberflat-{}-{}.fits --sky {}/{}/sky-{}-{}.fits --models {}/{}/stdstars-{}-{}.fits --outfile {}/{}/calib-{}-{}_test.fits".format(rawdir,expid,camera,expid,flatdir,camera,flat_expid,rawdir,expid,camera,expid,rawdir,expid,camera,expid,rawdir,expid,camera,expid)
+        if pipe.runcmd(com, clobber=clobber) != 0:
+            raise RuntimeError('desi_compute_fluxcalibration failed for camera {}'.format(camera))
+
+    for camera in ['b0', 'r0', 'z0']:
+        com = "desi_process_exposure --infile {}/{}/frame-{}-{}.fits --fiberflat {}/fiberflat-{}-{}.fits --sky {}/{}/sky-{}-{}.fits --calib {}/{}/calib-{}-{}.fits --outfile {}/{}/cframe-{}-{}_test.fits".format(rawdir,expid,camera,expid,flatdir,camera,flat_expid,rawdir,expid,camera,expid,rawdir,expid,camera,expid,rawdir,expid,camera,expid)
+        if pipe.runcmd(com, clobber=clobber) != 0:
+            raise RuntimeError('desi_process_exposure failed for camera {}'.format(camera))
+
+    com = "desi_make_bricks --night 20160726"
+    if pipe.runcmd(com, clobber=clobber) != 0:
+        raise RuntimeError('desi_make_bricks failed')
+
+if __name__ == '__main__':
+    integration_test()
+

--- a/py/desisim/test/integration_test_quickgen.py
+++ b/py/desisim/test/integration_test_quickgen.py
@@ -4,6 +4,7 @@ Run integration test using quickgen output for full pipeline
 python -m desisim.test.integration_test_quickgen
 """
 import os
+import sys
 from desisim import io
 import desispec.pipeline as pipe
 import desispec.log as logging

--- a/py/desisim/test/integration_test_quickgen.py
+++ b/py/desisim/test/integration_test_quickgen.py
@@ -5,7 +5,8 @@ python -m desisim.test.integration_test_quickgen
 """
 import os
 import sys
-from desisim import io
+import desisim.io
+import desispec.io
 import desispec.pipeline as pipe
 import desispec.log as logging
 
@@ -49,7 +50,7 @@ def check_env():
 
 # Simulate raw data
 
-def sim(night, nspec=5, clobber=False):
+def sim(night, nspec=25, clobber=False):
     """
     Simulate data as part of the integration test.
 
@@ -69,8 +70,8 @@ def sim(night, nspec=5, clobber=False):
     for expid, flavor in zip([0,1,2], ['flat', 'arc', 'dark']):
 
         cmd = "newexp-desi --flavor {flavor} --nspec {nspec} --night {night} --expid {expid}".format(expid=expid, flavor=flavor, nspec=nspec, night=night)
-        simspec = io.findfile('simspec', night, expid)
-        fibermap = '{}/fibermap-{:08d}.fits'.format(os.path.dirname(simspec),expid)
+        simspec = desisim.io.findfile('simspec', night, expid)
+        fibermap = '{}/fibermap-{:08d}.fits'.format(os.path.dirname(simspec),expid) 
         if pipe.runcmd(cmd, clobber=clobber) != 0:
             raise RuntimeError('newexp failed for {} exposure {}'.format(flavor, expid))
 
@@ -95,40 +96,43 @@ def integration_test(night="20160726", nspec=25, clobber=False):
     log = logging.get_logger()
     log.setLevel(logging.DEBUG)
 
-    flat_expid = "00000000"
-    expid = "00000002"
+    flat_expid = 00000000
+    expid = 00000002
 
-    # check for required environment variables
+    # check for required environment variables and simulate inputs
     check_env()
-
-    # simulate inputs
     sim(night, nspec=nspec, clobber=clobber)
-    simdir = os.path.join('$DESI_SPECTRO_SIM','exposures','20160726')
-    rawdir = os.path.join('$DESI_SPECTRO_REDUX','exposures','20160726')
-    flatdir = os.path.join('$DESI_SPECTRO_REDUX','calib2d','20160726')
 
-    # verify that quickgen output works for full pipeline
     for camera in ['b0', 'r0', 'z0']:
-        com = "desi_compute_sky --infile {}/{}/frame-{}-{}.fits --fiberflat {}/fiberflat-{}-{}.fits --outfile {}/{}/sky-{}-{}_test.fits".format(rawdir,expid,camera,expid,flatdir,camera,flat_expid,rawdir,expid,camera,expid)
+
+        # find all necessary input and output files
+        framefile = desispec.io.findfile('frame', night, expid, camera)
+        fiberflatfile = desispec.io.findfile('fiberflat', night, flat_expid, camera)
+        skyfile = desispec.io.findfile('sky', night, expid, camera)
+        skytestfile = desispec.io.findfile('sky', night, expid, camera) + 'test'
+        calibfile = desispec.io.findfile('calib', night, expid, camera)
+        calibtestfile = desispec.io.findfile('calib', night, expid, camera) + 'test'
+        stdstarsfile = desispec.io.findfile('stdstars', night, expid, camera, spectrograph=0)
+        cframetestfile = desispec.io.findfile('cframe', night, expid, camera) + 'test'
+
+        # verify that quickgen output works for full pipeline
+        com = "desi_compute_sky --infile {} --fiberflat {} --outfile {}".format(framefile, fiberflatfile, skytestfile)
         if pipe.runcmd(com, clobber=clobber) != 0:
             raise RuntimeError('desi_compute_sky failed for camera {}'.format(camera))
 
-    for camera in ['b0', 'r0', 'z0']:
-        com = "desi_fit_stdstars --frames {}/{}/frame-{}-{}.fits --skymodels {}/{}/sky-{}-{}.fits --fiberflats {}/fiberflat-{}-{}.fits --starmodels $DESI_BASIS_TEMPLATES/star_templates_v2.1.fits --outfile {}/{}/stdstars-{}-{}.fits".format(rawdir,expid,camera,expid,rawdir,expid,camera,expid,flatdir,camera,flat_expid,rawdir,expid,camera,expid)
+        com = "desi_fit_stdstars --frames {} --skymodels {} --fiberflats {} --starmodels $DESI_BASIS_TEMPLATES/star_templates_v2.1.fits --outfile {}".format(framefile, skyfile, fiberflatfile, stdstarsfile)
         if pipe.runcmd(com, clobber=clobber) != 0:
             raise RuntimeError('desi_fit_stdstars failed for camera {}'.format(camera))
 
-    for camera in ['b0', 'r0', 'z0']:
-        com = "desi_compute_fluxcalibration --infile {}/{}/frame-{}-{}.fits --fiberflat {}/fiberflat-{}-{}.fits --sky {}/{}/sky-{}-{}.fits --models {}/{}/stdstars-{}-{}.fits --outfile {}/{}/calib-{}-{}_test.fits".format(rawdir,expid,camera,expid,flatdir,camera,flat_expid,rawdir,expid,camera,expid,rawdir,expid,camera,expid,rawdir,expid,camera,expid)
+        com = "desi_compute_fluxcalibration --infile {} --fiberflat {} --sky {} --models {} --outfile {}".format(framefile, fiberflatfile, skyfile, stdstarsfile, calibtestfile)
         if pipe.runcmd(com, clobber=clobber) != 0:
             raise RuntimeError('desi_compute_fluxcalibration failed for camera {}'.format(camera))
 
-    for camera in ['b0', 'r0', 'z0']:
-        com = "desi_process_exposure --infile {}/{}/frame-{}-{}.fits --fiberflat {}/fiberflat-{}-{}.fits --sky {}/{}/sky-{}-{}.fits --calib {}/{}/calib-{}-{}.fits --outfile {}/{}/cframe-{}-{}_test.fits".format(rawdir,expid,camera,expid,flatdir,camera,flat_expid,rawdir,expid,camera,expid,rawdir,expid,camera,expid,rawdir,expid,camera,expid)
+        com = "desi_process_exposure --infile {} --fiberflat {} --sky {} --calib {} --outfile {}".format(framefile, fiberflatfile, skyfile, calibfile, cframetestfile)
         if pipe.runcmd(com, clobber=clobber) != 0:
             raise RuntimeError('desi_process_exposure failed for camera {}'.format(camera))
 
-    com = "desi_make_bricks --night 20160726"
+    com = "desi_make_bricks --night {}".format(night)
     if pipe.runcmd(com, clobber=clobber) != 0:
         raise RuntimeError('desi_make_bricks failed')
 

--- a/py/desisim/test/integration_test_quickgen.py
+++ b/py/desisim/test/integration_test_quickgen.py
@@ -96,8 +96,8 @@ def integration_test(night="20160726", nspec=25, clobber=False):
     log = logging.get_logger()
     log.setLevel(logging.DEBUG)
 
-    flat_expid = 00000000
-    expid = 00000002
+    flat_expid = 0
+    expid = 2
 
     # check for required environment variables and simulate inputs
     check_env()


### PR DESCRIPTION
This PR

- Provides an integration test for quickgen which verifies that quickgen output can be used as input for the full pipeline.

The integration test:

- Checks that all necessary environment variables are set.
- Generates 25 spectra flat, arc, and dark exposures via newexp-desi, then simulates this data using quickgen.
- Uses quickgen frame and fiberflat files as input for desi_compute_sky.
- Uses quickgen frame, fiberflat, and sky files, and star templates as input for desi_fit_stdstars.
- Uses quickgen frame, fiberflat, and sky files, and stdstars file generated by previous step as input for desi_compute_fluxcalibration.
- Uses quickgen frame, fiberflat, sky, and calib files as input for desi_process_exposure.
- Runs desi_make_bricks.

Note: desi_process_exposure fails due to 32 bit vs. 64 bit wavelength arrays generated by desispec.io.frame vs. desispec.io.fluxcalibration. Changing fluxcalib.wave to fluxcalib.wave.astype('f4') in line 91 of desispec.io.fluxcalibration seems to solve this issue.