### PR TITLE
Fix bgs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ env:
         - SPECSIM_VERSION=v0.6
         - SPECTER_VERSION=0.6.0
         - DESISPEC_VERSION=0.12.0
-        - DESITARGET_VERSION=0.7.0
+        - DESITARGET_VERSION=0.8.1
         # - DESIMODEL_VERSION=trunk
         - DESI_LOGLEVEL=DEBUG
         - MAIN_CMD='python setup.py'

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,6 +8,8 @@ desisim change log
 * fixes tests for use with latest desitarget master
 * Refactor quickgen and quickbrick to reduce duplicated code (PR #184)
 * Refactor quickcat
+* Makes BGS compatible with desitarget master after
+  isBGS -> isBGS_faint vs. isBGS_bright
 
 0.16.0 (2016-11-10)
 -------------------

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -868,7 +868,7 @@ class BGS(GALAXY):
         if colorcuts_function is None:
             try:
                 from desitarget.cuts import isBGS_bright as colorcuts_function
-            else:
+            except:
                 from desitarget.cuts import isBGS as colorcuts_function
                 log.warn('You are using on old version of desitarget')
 

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -866,7 +866,11 @@ class BGS(GALAXY):
 
         """
         if colorcuts_function is None:
-            from desitarget.cuts import isBGS as colorcuts_function
+            try:
+                from desitarget.cuts import isBGS_bright as colorcuts_function
+            else:
+                from desitarget.cuts import isBGS as colorcuts_function
+                log.warn('You are using on old version of desitarget')
 
         super(BGS, self).__init__(objtype='BGS', minwave=minwave, maxwave=maxwave,
                                   cdelt=cdelt, wave=wave, colorcuts_function=colorcuts_function,


### PR DESCRIPTION
`desitarget.cuts.isBGS` was refactored into `isBGS_faint` and `isBGS_bright`, which broke `desisim.templates.BGS` that was looking for `isBGS`.  This PR fixes that while still supporting older versions of desitarget via try/except blocks around importing `isBGS_bright` vs. `isBGS`.