### PR TITLE
fixes zeff

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -11,6 +11,7 @@ desisim change log
   isBGS -> isBGS_faint vs. isBGS_bright
 * Refactor quickcat to include dependency on observing conditions
 * Update quicksurvey to use observing conditions from surveysim
+* Fixes use of previous zcatalog when updating catalog with new observations
 
 0.16.0 (2016-11-10)
 -------------------

--- a/py/desisim/quickcat.py
+++ b/py/desisim/quickcat.py
@@ -145,8 +145,9 @@ def get_redshift_efficiency(simtype, targets, truth, targets_in_tile, obsconditi
            'MOONFRAC': array of moonfraction values on a tile.
            'SEEING': array of FWHM seeing during spectroscopic observation on a tile.
            
-    Outputs:
-        p: array marking the probability to get this redshift right. This must have the size of targetid.
+    Outputs: tuple of arrays (observed, p) both with same length as targets
+        observed: boolean array of whether the target was observed in these tiles
+        p: probability to get this redshift right
     """
     targetid = targets['TARGETID']
     n = len(targetid)
@@ -234,16 +235,20 @@ def get_redshift_efficiency(simtype, targets, truth, targets_in_tile, obsconditi
     #- NOTE: this still isn't quite right since multiple observations will
     #- be simultaneously fit instead of just taking whichever individual one
     #- succeeds.
-    
-    # zeff_obs = get_zeff_obs(simtype, obsconditions)
-    # pfail = np.ones(n)
-    # for i, tileid in enumerate(obsconditions['TILEID']):
-    #     ii = np.in1d(targets['TARGETID'], targets_in_tile[tileid])
-    #     pfail[ii] *= (1-simulated_eff[ii]*zeff_obs[i])
-    #
-    # simulated_eff = (1-pfail)
+        
+    zeff_obs = get_zeff_obs(simtype, obsconditions)
+    pfail = np.ones(n)
+    observed = np.zeros(n, dtype=bool)
+    for i, tileid in enumerate(obsconditions['TILEID']):
+        ii = np.in1d(targets['TARGETID'], targets_in_tile[tileid])
+        if np.count_nonzero(ii) > 0:
+            tmp = (simulated_eff[ii]*zeff_obs[i]).clip(0, 1)
+            pfail[ii] *= (1-tmp)
+            observed[ii] = True
 
-    return simulated_eff
+    simulated_eff = (1-pfail)
+
+    return observed, simulated_eff
 
 # Efficiency model
 def eff_model(x, sigma, max_efficiency):
@@ -273,7 +278,7 @@ def reverse_dictionary(a):
                 b[k].append(i[0])            
     return b
 
-def get_observed_redshifts(targets, truth, targets_in_tile, obsconditions=None):
+def get_observed_redshifts(targets, truth, targets_in_tile, obsconditions):
     """
     Returns observed z, zerr, zwarn arrays given true object types and redshifts
 
@@ -303,7 +308,7 @@ def get_observed_redshifts(targets, truth, targets_in_tile, obsconditions=None):
     zwarn = np.zeros(len(truez), dtype=np.int32)
 
     objtypes = list(set(simtype))
-    n_tiles = len(obsconditions['TILEID'])
+    n_tiles = len(np.unique(obsconditions['TILEID']))
     
     if(n_tiles!=len(targets_in_tile)):
         raise ValueError('Number of obsconditions {} != len(targets_in_tile) {}'.format(n_tiles, len(targets_in_tile)))
@@ -426,36 +431,38 @@ def get_observed_redshifts(targets, truth, targets_in_tile, obsconditions=None):
                 zerr[ii] = _sigma_v[objtype] * (1+truez[ii]) / c
                 zout[ii] += np.random.normal(scale=zerr[ii])
 
+            # Set ZWARN flags for some targets
+            # the redshift efficiency only sets warning, but does not impact
+            # the redshift value and its error.
+            was_observed, goodz_prob = get_redshift_efficiency(
+                objtype, targets[ii], truth[ii], targets_in_tile,
+                obsconditions=obsconditions)
+        
+            assert len(was_observed) == n
+            assert len(goodz_prob) == n
+            r = np.random.random(len(was_observed))
+            zwarn[ii] = 4 * (r > goodz_prob) * was_observed
 
-            # the redshift efficiency only sets warning, but does not impact the redshift value and its error.
-            if (obsconditions is not None):
-                p_obs = get_redshift_efficiency(objtype, targets[ii], truth[ii], targets_in_tile, obsconditions=obsconditions)
-                z_eff = p_obs.copy()
-                r = np.random.random(n)
-                jj = r > z_eff
-                zwarn_type = np.zeros(n, dtype=np.int32)
-                zwarn_type[jj] = 4
-                zwarn[ii] = zwarn_type
-                
-                ### print('--- OBJTYPE', objtype, np.count_nonzero(jj), len(jj))                    
+            print('--- OBJTYPE', objtype, np.count_nonzero(zwarn[ii]), np.count_nonzero(was_observed))
 
-                # Add fraction of catastrophic failures (zwarn=0 but wrong z)
-                nzwarnzero = np.count_nonzero(zwarn[ii] == 0)
-                num_cata = np.random.poisson(_cata_fail_fraction[objtype] * nzwarnzero)
-                if (objtype == 'ELG'): zlim=[0.6,1.7]
-                elif (objtype == 'LRG'): zlim=[0.5,1.1]
-                elif (objtype == 'QSO'): zlim=[0.5,3.5]
-                if num_cata > 0:
-                    jj, = np.where(zwarn[ii]==0)
-                    index = np.random.choice(jj, size=num_cata, replace=False)
-                    zout[index] = np.random.uniform(zlim[0],zlim[1],len(index)) 
+            # Add fraction of catastrophic failures (zwarn=0 but wrong z)
+            nzwarnzero = np.count_nonzero(zwarn[ii][was_observed] == 0)
+            num_cata = np.random.poisson(_cata_fail_fraction[objtype] * nzwarnzero)
+            if (objtype == 'ELG'): zlim=[0.6,1.7]
+            elif (objtype == 'LRG'): zlim=[0.5,1.1]
+            elif (objtype == 'QSO'): zlim=[0.5,3.5]
+            if num_cata > 0:
+                #- tmp = boolean array for all targets, flagging only those
+                #- that are of this simtype and were observed this epoch
+                tmp = np.zeros(len(ii), dtype=bool)
+                tmp[ii] = was_observed
+                kk, = np.where((zwarn==0) & tmp)
+                index = np.random.choice(kk, size=num_cata, replace=False)
+                assert np.all(np.in1d(index, np.where(ii)[0]))
+                assert np.all(zwarn[index] == 0)
+                        
+                zout[index] = np.random.uniform(zlim[0],zlim[1],len(index))
 
-            elif (obsconditions is None):
-                #- randomly select some objects to set zwarn
-                num_zwarn = int(_zwarn_fraction[objtype] * n)
-                if num_zwarn > 0:
-                    jj = np.random.choice(np.where(ii)[0], size=num_zwarn, replace=False)
-                    zwarn[jj] = 4
         else:
             msg = 'No redshift efficiency model for {}; using true z\n'.format(objtype) + \
                   'Known types are {}'.format(list(_sigma_v.keys()))

--- a/py/desisim/quickcat.py
+++ b/py/desisim/quickcat.py
@@ -533,7 +533,7 @@ def get_median_obsconditions(tileids):
         
     return obsconditions
 
-def quickcat(tilefiles, targets, truth, zcat=None, obsconditions=None, perfect=False, debug=False):
+def quickcat(tilefiles, targets, truth, zcat=None, obsconditions=None, perfect=False):
     """
     Generates quick output zcatalog
 
@@ -568,15 +568,6 @@ def quickcat(tilefiles, targets, truth, zcat=None, obsconditions=None, perfect=F
         ii = (fibassign['TARGETID'] != -1)  #- targets with assignments
         nobs.update(fibassign['TARGETID'][ii])
         targets_in_tile[tile_id] = fibassign['TARGETID'][ii]
-        
-#        print (targets_in_tile)
-
-    #- Count how many times each target was observed in previous zcatalog
-    #- NOTE: assumes that no tiles have been repeated
-    # if zcat is not None:
-    #     ### print('Counting targets from previous zobs')
-    #     for targetid, n in zip(zcat['TARGETID'], zcat['NUMOBS']):
-    #         nobs[targetid] += n
 
     #- Sort obsconditions to match order of tiles
     #- This might not be needed, but is fast for O(20k) tiles and may

--- a/py/desisim/test/test_quickcat.py
+++ b/py/desisim/test/test_quickcat.py
@@ -136,7 +136,7 @@ class TestQuickCat(unittest.TestCase):
         
         #- Observe the last tile again
         zcat3copy = zcat3.copy()
-        zcat4 = quickcat(self.tilefiles[3:4], self.targets, truth=self.truth, zcat=zcat3, debug=True)        
+        zcat4 = quickcat(self.tilefiles[3:4], self.targets, truth=self.truth, zcat=zcat3)
         self.assertTrue(np.all(zcat3copy == zcat3))  #- original unmodified
         self.assertTrue(np.all(zcat4['TARGETID'] == self.truth['TARGETID']))  #- order preserved
         self.assertTrue(np.all(zcat4['Z'] != self.truth['TRUEZ']))

--- a/py/desisim/test/test_quickcat.py
+++ b/py/desisim/test/test_quickcat.py
@@ -82,8 +82,11 @@ class TestQuickCat(unittest.TestCase):
         fiberassign['DEC'] = np.random.uniform(0,5, size=n)
         fiberassign.meta['EXTNAME'] = 'FIBER_ASSIGNMENTS'
         nx = cls.nspec // cls.ntiles
+        cls.targets_in_tile = dict()
         for i, filename in enumerate(cls.tilefiles):
-            fiberassign[i*nx:(i+1)*nx].write(filename)
+            subset = fiberassign[i*nx:(i+1)*nx]
+            subset.write(filename)
+            cls.targets_in_tile[cls.tileids[i]] = subset['TARGETID']
             hdulist = fits.open(filename, mode='update')
             hdr = hdulist[1].header
             hdr.set('TILEID', cls.tileids[i])
@@ -92,7 +95,8 @@ class TestQuickCat(unittest.TestCase):
         #- Also create a test of tile files that have multiple observations
         nx = cls.nspec // cls.ntiles
         for i, filename in enumerate(cls.tilefiles_multiobs):
-            fiberassign[0:(i+1)*nx].write(filename)
+            subset = fiberassign[0:(i+1)*nx]
+            subset.write(filename)
             hdulist = fits.open(filename, mode='update')
             hdr = hdulist[1].header
             hdr.set('TILEID', cls.tileids[i])
@@ -121,9 +125,34 @@ class TestQuickCat(unittest.TestCase):
         self.assertTrue(np.any(zcat2['ZWARN'] != 0))
 
         #- And add a second round of observations
-        zcat3 = quickcat(self.tilefiles[2:4], self.targets, truth=self.truth, zcat=zcat1)
+        zcat3 = quickcat(self.tilefiles[2:4], self.targets, truth=self.truth, zcat=zcat2)
         self.assertTrue(np.all(zcat3['TARGETID'] == self.truth['TARGETID']))
         self.assertTrue(np.all(zcat3['Z'] != self.truth['TRUEZ']))
+        
+        #- successful targets in the first round of observations shouldn't be updated
+        ii2 = np.in1d(zcat2['TARGETID'], zcat3['TARGETID']) & (zcat2['ZWARN'] == 0)
+        ii3 = np.in1d(zcat3['TARGETID'], zcat2['TARGETID'][ii2])
+        self.assertTrue(np.all(zcat2['Z'][ii2] == zcat3['Z'][ii3]))
+        
+        #- Observe the last tile again
+        zcat3copy = zcat3.copy()
+        zcat4 = quickcat(self.tilefiles[3:4], self.targets, truth=self.truth, zcat=zcat3, debug=True)        
+        self.assertTrue(np.all(zcat3copy == zcat3))  #- original unmodified
+        self.assertTrue(np.all(zcat4['TARGETID'] == self.truth['TARGETID']))  #- order preserved
+        self.assertTrue(np.all(zcat4['Z'] != self.truth['TRUEZ']))
+
+        #- Check that NUMOBS was incremented
+        i3 = np.in1d(zcat3['TARGETID'], self.targets_in_tile[self.tileids[3]])
+        i4 = np.in1d(zcat4['TARGETID'], self.targets_in_tile[self.tileids[3]])
+        self.assertTrue(np.all(zcat4['NUMOBS'][i4] == zcat3['NUMOBS'][i3]+1))
+
+        #- ZWARN==0 targets should be preserved, while ZWARN!=0 updated
+        nx = self.nspec // self.ntiles
+        z3 = zcat3[-nx:]
+        z4 = zcat4[-nx:]
+        ii = (z3['ZWARN'] != 0)
+        self.assertTrue(np.all(z3['Z'][ii] != z4['Z'][ii]))
+        self.assertTrue(np.all(z3['Z'][~ii] == z4['Z'][~ii]))
 
     def test_multiobs(self):
         # Earlier targets got more observations so should have higher efficiency


### PR DESCRIPTION
This PR fixes fixes a major issue impacting redshift efficiency with quickcat.  Previously it was replacing any previously observed targets with new redshifts with ZWARN=0, and only assigning ZWARN flags to the current epoch of observation (which would then get blown away by the next epoch).  This includes tests that would have caught the problem in the first place.

I'll get this PR going with Travis tests while finishing the last round of quicksurvey tests using this.