### PR TITLE
fix tiles vs. obsconditions bug; add start_epoch option

### DIFF
--- a/bin/quicksurvey
+++ b/bin/quicksurvey
@@ -13,7 +13,8 @@ parser.add_argument("--targets_dir","-T",help="Path to the targets.fits file", t
 parser.add_argument("--fiberassign_exec", "-f", help="Executable file for fiberassign", type=str, required=True)
 parser.add_argument("--epochs_dir","-E",help="Path to the directory with the epochs files ", type=str, required=False)
 parser.add_argument("--template_fiberassign","-t",help="File containing template for fiberassign", type=str, required=True)
-parser.add_argument("--n_epochs","-N",help="Number of epochs to run", type=int, default=None)
+parser.add_argument("--n_epochs","-N",help="Total number of epochs", type=int, default=None)
+parser.add_argument("--start_epoch",help="Epoch to start with (0-indexed)", type=int, default=0)
 parser.add_argument("--obsconditions",help="obslist_all.fits file from surveysim", type=str, required=False)
 parser.add_argument("--fiberassign_dates",help="file with list of dates to run fiberassign", type=str, required=False)
 
@@ -24,6 +25,7 @@ setup = qs.SimSetup(output_path = args.output_dir,
                     fiberassign_exec = args.fiberassign_exec, 
                     epochs_path = args.epochs_dir, 
                     template_fiberassign = args.template_fiberassign, 
+                    start_epoch = args.start_epoch,
                     n_epochs = args.n_epochs,
                     obsconditions = args.obsconditions,
                     fiberassign_dates = args.fiberassign_dates,


### PR DESCRIPTION
This PR fixes a crash-inducing quicksurvey bug that happened when the fiberassign output tiles do not match the observing conditions tiles from surveysim.  This can occur when the input target catalog is a subset of the overall footprint and fiberassign doesn't output a tile file for tiles that don't have any targets.  This update now gracefully handles that and proceeds with the tiles that are covered.

This PR also adds a `quicksurvey --start_epoch {n}` option to be able to restart where we left off from a previous run.  This should be useful for debugging and chaining together smaller jobs.

It also outputs more timestamps for debugging why quickcat isn't so quick.