### PR TITLE
quicker quickcat maybe

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desisim change log
 0.17.2 (unreleased)
 -------------------
 
-* No changes yet
+* drops unused truth,targets columns to save memory in quicksurvey loop
 
 0.17.1 (2016-12-05)
 -------------------


### PR DESCRIPTION
This PR saves memory in quickcat by dropping some unused columns in the input catalogs; this might make it somewhat quicker.

It also fixes a bug when resuming quicksurvey at a given epoch after several epochs had previously been run (it reads in the previous MTL and zcat instead of treating them as None).