### PR TITLE
Lyaspeedup

### DIFF
--- a/py/desisim/qso_template/desi_qso_templ.py
+++ b/py/desisim/qso_template/desi_qso_templ.py
@@ -25,6 +25,8 @@ from desisim.qso_template import fit_boss_qsos as fbq
 from desiutil.stats import perc
 import desisim.io
 
+from desispec.interpolation import resample_flux
+
 from desispec.log import get_logger
 log = get_logger()
 
@@ -181,7 +183,7 @@ def desi_qso_templates(z_wind=0.2, zmnx=(0.4,4.), outfil=None, N_perz=500,
                        boss_pca_fil=None, wvmnx=(3500., 10000.),
                        rebin_wave=None, rstate=None,
                        sdss_pca_fil=None, no_write=False, redshift=None,
-                       seed=None, old_read=False, ipad=20):
+                       seed=None, old_read=False, ipad=20, cosmo=None):
     """ Generate QSO templates for DESI
 
     Rebins to input wavelength array (or log10 in wvmnx)
@@ -206,7 +208,8 @@ def desi_qso_templates(z_wind=0.2, zmnx=(0.4,4.), outfil=None, N_perz=500,
       Redshifts desired for the templates
     ipad : int, optional
       Padding for enabling enough models
-
+    cosmo: astropy.cosmology.core, optional
+       Cosmology inistantiation from astropy.cosmology.code
     Returns
     -------
     wave : ndarray
@@ -215,11 +218,13 @@ def desi_qso_templates(z_wind=0.2, zmnx=(0.4,4.), outfil=None, N_perz=500,
     z : ndarray
       Redshifts
     """
-    # Cosmology
-    from astropy import cosmology
-    from desispec.interpolation import resample_flux
-    cosmo = cosmology.core.FlatLambdaCDM(70., 0.3)
 
+
+    # Cosmology
+    if cosmo is None:
+        from astropy import cosmology
+        cosmo = cosmology.core.FlatLambdaCDM(70., 0.3)
+        
     if old_read:
         # PCA values
         if boss_pca_fil is None:
@@ -270,8 +275,12 @@ def desi_qso_templates(z_wind=0.2, zmnx=(0.4,4.), outfil=None, N_perz=500,
         z0 = np.arange(zmnx[0],zmnx[1],z_wind)
         z1 = z0 + z_wind
     else:
-        z0 = np.array([redshift])
-        z1 = z0
+        if np.isscalar(redshift):
+            z0 = np.array([redshift])
+            z1 = z0 
+        else:
+            z0 = redshift.copy()
+            z1 = z0 + z_wind
 
     pca_list = ['PCA0', 'PCA1', 'PCA2', 'PCA3']
     PCA_mean = np.zeros(4)

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -1704,6 +1704,7 @@ class QSO():
             mag = input_meta['MAG'].data
 
             meta = empty_metatable(nmodel, self.objtype)
+
         else:
             meta = empty_metatable(nmodel, self.objtype)
 
@@ -1733,12 +1734,13 @@ class QSO():
         from astropy import cosmology
         cosmo = cosmology.core.FlatLambdaCDM(70., 0.3)
 
+        templaterand = np.random.RandomState(templateseed)
 
         _, final_flux, redshifts = dqt.desi_qso_templates(
-            z_wind=self.z_wind, N_perz=N_perz, seed=templateseed,
-            redshift=redshift, rebin_wave=zwave, no_write=True, cosmo=cosmo, ipad=8)
+            z_wind=self.z_wind, N_perz=N_perz, rstate=templaterand,
+            redshift=redshift, rebin_wave=zwave, no_write=True, cosmo=cosmo, ipad=10)
 
-        templaterand = np.random.RandomState(templateseed)
+
 
         for ii in range(nmodel):
             log.debug('Simulating {} template {}/{}.'.format(self.objtype, ii+1, nmodel))

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -1728,13 +1728,22 @@ class QSO():
         zwave = self.wave # [observed-frame, Angstrom]
         outflux = np.zeros([nmodel, len(self.wave)]) # [erg/s/cm2/A]
 
+
+        # Cosmology
+        from astropy import cosmology
+        cosmo = cosmology.core.FlatLambdaCDM(70., 0.3)
+
+
+        _, final_flux, redshifts = dqt.desi_qso_templates(
+            z_wind=self.z_wind, N_perz=1, seed=templateseed,
+            redshift=redshift, rebin_wave=zwave, no_write=True, cosmo=cosmo, ipad=10)
+
+        templaterand = np.random.RandomState(templateseed)
+
         for ii in range(nmodel):
             log.debug('Simulating {} template {}/{}.'.format(self.objtype, ii+1, nmodel))
-            templaterand = np.random.RandomState(templateseed[ii])
 
-            _, final_flux, redshifts = dqt.desi_qso_templates(
-                z_wind=self.z_wind, N_perz=50, rstate=templaterand,
-                redshift=redshift[ii], rebin_wave=zwave, no_write=True)
+
             restflux = final_flux.T
             nmade = np.shape(restflux)[0]
 

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -1632,7 +1632,7 @@ class QSO():
 
     def make_templates(self, nmodel=100, zrange=(0.5, 4.0), rmagrange=(21.0, 23.0),
                        seed=None, redshift=None, mag=None, input_meta=None,
-                       nocolorcuts=False):
+                       nocolorcuts=False, N_perz=1):
         """Build Monte Carlo QSO spectra/templates.
 
         This function generates QSO spectra on-the-fly using PCA decomposition
@@ -1671,7 +1671,7 @@ class QSO():
             ignored.
           nocolorcuts (bool, optional): Do not apply the fiducial rzW1W2 color-cuts
             cuts (default False).
-
+          N_perz (int, optional): Number of templatex per redshift bin or redshift value.
         Returns:
           outflux (numpy.ndarray): Array [nmodel, npix] of observed-frame spectra (erg/s/cm2/A).
           wave (numpy.ndarray): Observed-frame [npix] wavelength array (Angstrom).
@@ -1735,8 +1735,8 @@ class QSO():
 
 
         _, final_flux, redshifts = dqt.desi_qso_templates(
-            z_wind=self.z_wind, N_perz=1, seed=templateseed,
-            redshift=redshift, rebin_wave=zwave, no_write=True, cosmo=cosmo, ipad=10)
+            z_wind=self.z_wind, N_perz=N_perz, seed=templateseed,
+            redshift=redshift, rebin_wave=zwave, no_write=True, cosmo=cosmo, ipad=8)
 
         templaterand = np.random.RandomState(templateseed)
 


### PR DESCRIPTION
Solves #207.

I did some benchmarking using this script (called `tt.py`)

```python
import desisim.lya_spectra
import argparse
parser = argparse.ArgumentParser()

parser.add_argument("nqso", type=int)
args = parser.parse_args()
print(args.nqso)
a, b, c = desisim.lya_spectra.get_spectra("/global/homes/f/forero/mocks/simpleSpec_0.fits.gz", nqso=args.nqso)
```

Using the old version I got
```bash
$time python tt.py 100

real	2m42.291s
user	16m30.520s
sys	1m23.836s

$time python tt.py 1000

real	26m7.781s
user	151m19.616s
sys	10m39.264s
```

Using the new version I get

```bash
$time python tt.py 100

real	0m23.315s
user	5m26.872s
sys	0m21.212s

$time python tt.py 1000

real	2m1.740s
user	50m55.360s
sys	3m11.264s
```
