### PR TITLE
Fix test failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,9 @@ env:
         - DESISIM_TESTDATA_VERSION=0.3.3
         - SPECLITE_VERSION=0.5
         - SPECSIM_VERSION=v0.6
-        - SPECTER_VERSION=0.6.0
-        - DESISPEC_VERSION=0.12.0
-        - DESITARGET_VERSION=0.8.1
+        - SPECTER_VERSION=0.7.0
+        - DESISPEC_VERSION=0.13.0
+        - DESITARGET_VERSION=0.9.0
         # - DESIMODEL_VERSION=trunk
         - DESI_LOGLEVEL=DEBUG
         - MAIN_CMD='python setup.py'

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,7 @@ env:
         - SPECLITE_VERSION=0.5
         - SPECSIM_VERSION=v0.6
         - SPECTER_VERSION=0.7.0
-        - DESISPEC_VERSION=master
-        # - DESISPEC_VERSION=0.13.1
+        - DESISPEC_VERSION=0.13.1
         - DESITARGET_VERSION=0.9.0
         # - DESIMODEL_VERSION=trunk
         - DESI_LOGLEVEL=DEBUG

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,8 @@ env:
         - SPECLITE_VERSION=0.5
         - SPECSIM_VERSION=v0.6
         - SPECTER_VERSION=0.7.0
-        - DESISPEC_VERSION=0.13.0
+        - DESISPEC_VERSION=master
+        # - DESISPEC_VERSION=0.13.1
         - DESITARGET_VERSION=0.9.0
         # - DESIMODEL_VERSION=trunk
         - DESI_LOGLEVEL=DEBUG

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ env:
         # These packages will always be installed.
         - PIP_DEPENDENCIES=""
         # These packages will only be installed if we really need them.
-        - PIP_ALL_DEPENDENCIES="speclite==${SPECLITE_VERSION} coveralls"
+        - PIP_ALL_DEPENDENCIES="speclite==${SPECLITE_VERSION} coveralls fitsio"
         # These pip packages need to be installed in a certain order, so we
         # do that separately from the astropy/ci-helpers scripts.
         - DESIHUB_PIP_DEPENDENCIES="desiutil=${DESIUTIL_VERSION}"

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -644,6 +644,9 @@ def read_basis_templates(objtype, subtype='', outwave=None, nspec=None,
         wave = fits.getdata(infile, 2)
 
         if (objtype.upper() == 'WD') and (subtype != ''):
+            if 'WDTYPE' not in meta.colnames:
+                raise RuntimeError('Please upgrade to basis_templates >=2.3 to get WDTYPE support')
+
             keep = np.where(meta['WDTYPE'] == subtype.upper())[0]
             if len(keep) == 0:
                 log.warning('Unrecognized white dwarf subtype {}!'.format(subtype))

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -107,8 +107,11 @@ def write_simspec(meta, truth, expid, night, header=None, outfile=None):
         outfile = '{}/simspec-{:08d}.fits'.format(outdir, expid)
 
     #- Primary HDU is just a header from the input
+    header = desispec.io.util.fitsheader(header)
+    if 'DOSVER' not in header:
+        header['DOSVER'] = 'SIM'
     hx = fits.HDUList()
-    hx.append(fits.PrimaryHDU(None, header=desispec.io.util.fitsheader(header)))
+    hx.append(fits.PrimaryHDU(None, header=header))
 
     #- Object flux HDU (might not exist, e.g. for an arc)
     if 'FLUX' in truth:

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -622,22 +622,20 @@ def read_basis_templates(objtype, subtype='', outwave=None, nspec=None,
     log.info('Reading {}'.format(infile))
 
     if objtype.upper() == 'QSO':
-        fx = fits.open(infile)
-        format_version = _qso_format_version(infile)
-        if format_version == 1:
-            flux = fx[0].data * 1E-17
-            hdr = fx[0].header
-            from desispec.io.util import header2wave
-            wave = header2wave(hdr)
-            meta = Table(fx[1].data)
-        elif format_version == 2:
-            flux = fx['SDSS_EIGEN'].data.copy()
-            wave = fx['SDSS_EIGEN_WAVE'].data.copy()
-            meta = Table([np.arange(flux.shape[0]),], names=['PCAVEC',])
-        else:
-            raise IOError('Unknown QSO basis template format version {}'.format(format_version))
-
-        fx.close()
+        with fits.open(infile) as fx:
+            format_version = _qso_format_version(infile)
+            if format_version == 1:
+                flux = fx[0].data * 1E-17
+                hdr = fx[0].header
+                from desispec.io.util import header2wave
+                wave = header2wave(hdr)
+                meta = Table(fx[1].data)
+            elif format_version == 2:
+                flux = fx['SDSS_EIGEN'].data.copy()
+                wave = fx['SDSS_EIGEN_WAVE'].data.copy()
+                meta = Table([np.arange(flux.shape[0]),], names=['PCAVEC',])
+            else:
+                raise IOError('Unknown QSO basis template format version {}'.format(format_version))
     else:
         flux, hdr = fits.getdata(infile, 0, header=True)
         meta = Table(fits.getdata(infile, 1))

--- a/py/desisim/lya_spectra.py
+++ b/py/desisim/lya_spectra.py
@@ -51,7 +51,7 @@ def get_spectra(lyafile, nqso=None, wave=None, templateid=None, normfilter='sdss
             nqso = len(h)-1
         templateid = np.arange(nqso)
     else:
-        templateid = np.array(templateid)
+        templateid = np.asarray(templateid)
         nqso = len(templateid)
 
     if rand is None:

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -346,6 +346,9 @@ def _project(args):
     try:
         psf, wave, phot, specmin = args
         nspec = phot.shape[0]
+        if phot.shape[-1] != wave.shape[-1]:
+            raise ValueError('phot.shape {} vs. wave.shape {} mismatch'.format(phot.shape, wave.shape))
+
         xyrange = psf.xyrange( [specmin, specmin+nspec], wave )
         img = psf.project(wave, phot, specmin=specmin, xyrange=xyrange)
         return (xyrange, img)
@@ -356,6 +359,7 @@ def _project(args):
             print('ERROR in _project', psf.wmin, psf.wmax, wave[0], wave[-1], phot.shape, specmin)
             traceback.print_exc()
             print('-'*60)
+
         raise e
 
 #- Move this into specter itself?

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -266,7 +266,7 @@ def simulate(camera, simspec, psf, fibers=None, nspec=None, ncpu=None,
 
     if preproc:
         log.debug('Running preprocessing at {}'.format(asctime()))
-        image = desispec.preproc.preproc(rawpix, header)
+        image = desispec.preproc.preproc(rawpix, header, primary_header=simspec.header)
     else:
         log.debug('Skipping preprocessing')
         image = Image(np.zeros(rawpix.shape), np.zeros(rawpix.shape), meta=header)

--- a/py/desisim/test/test_lya.py
+++ b/py/desisim/test/test_lya.py
@@ -35,6 +35,7 @@ class TestLya(unittest.TestCase):
         self.assertEqual(wave.shape[0], flux.shape[1])
         self.assertEqual(len(meta), self.nspec)
         templateid = [0,1,2]
+        nqso = len(templateid)
 
         flux, wave, meta = lya_spectra.get_spectra(self.infile, templateid=templateid,
                                                    wave=self.wave, seed=self.seed)

--- a/py/desisim/test/test_lya.py
+++ b/py/desisim/test/test_lya.py
@@ -34,6 +34,7 @@ class TestLya(unittest.TestCase):
         self.assertEqual(flux.shape[0], self.nspec)
         self.assertEqual(wave.shape[0], flux.shape[1])
         self.assertEqual(len(meta), self.nspec)
+        templateid = [0,1,2]
 
         flux, wave, meta = lya_spectra.get_spectra(self.infile, templateid=templateid,
                                                    wave=self.wave, seed=self.seed)


### PR DESCRIPTION
A variety of test failures had crept into desisim mostly due to non-backwards compatible changes in other packages.  These went unnoticed in desisim since the Travis tests were pinned to older versions.  These changes get desisim back into compatibility with the latest versions of desispec, desitarget, and specter.

desisim itself will be ready for a fresh tag after confirming that these tests pass on Travis and merging.