### PR TITLE
fix N^2 scaling of QSO.make_templates

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,6 +7,7 @@ desisim change log
 
 * Fixed a number of documentation errors (`PR #224`_).
 * Removed unneeded Travis scripts in ``etc/``.
+* Fixed N^2 scaling of ``QSO.make_templates``
 
 .. _`PR #224`: https://github.com/desihub/desisim/pull/224
 

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -1702,7 +1702,7 @@ class QSO():
 
             _, final_flux, redshifts = dqt.desi_qso_templates(
                 z_wind=self.z_wind, N_perz=N_perz, rstate=templaterand,
-                redshift=redshift, rebin_wave=zwave, no_write=True, cosmo=cosmo, ipad=15)
+                redshift=redshift[ii], rebin_wave=zwave, no_write=True, cosmo=cosmo, ipad=15)
 
             
             restflux = final_flux.T


### PR DESCRIPTION
This PR contributes the 4-character fix to solve the `QSO.make_templates` scaling problem reported in #219.  The core problem was that it was looping over redshifts but then calling `desi_qso_templ.desi_qso_templates` with the full redshift array every time, thus it was generating N^2 QSOs while only picking N of them.