### PR TITLE
fix quickgen for specsim v0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,11 +45,11 @@ env:
         # - SPHINX_VERSION=1.3
         # - DESIUTIL_VERSION=1.8.0
         - DESIUTIL_VERSION=1.9.3
-        - DESIMODEL_VERSION=0.5.0
-        - DESIMODEL_DATA=branches/test-0.5.0
+        - DESIMODEL_VERSION=0.6.0
+        - DESIMODEL_DATA=branches/test-0.6.0
         - DESISIM_TESTDATA_VERSION=0.3.3
         - SPECLITE_VERSION=0.5
-        - SPECSIM_VERSION=v0.6
+        - SPECSIM_VERSION=v0.8
         - SPECTER_VERSION=0.7.0
         - DESISPEC_VERSION=0.13.1
         - DESITARGET_VERSION=0.9.0

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desisim change log
 0.18.3 (unreleased)
 -------------------
 
-* No changes yet
+* Fix quickgen for specsim v0.8 (`PR #226`_).
+
+.. _`PR #226`: https://github.com/desihub/desisim/pull/226
 
 0.18.2 (2017-03-27)
 -------------------

--- a/py/desisim/specsim.py
+++ b/py/desisim/specsim.py
@@ -17,14 +17,15 @@ _simdefaults = dict()
 import desispec.log
 log = desispec.log.get_logger()
 
-def get_simulator(config='desi'):
+def get_simulator(config='desi', num_fibers=1):
     '''
     returns new or cached specsim.simulator.Simulator object
     '''
-    if config in _simulators:
+    key = (config, num_fibers)
+    if key in _simulators:
         log.debug('Returning cached {} Simulator'.format(config))
-        qsim = _simulators[config]
-        defaults = _simdefaults[config]
+        qsim = _simulators[key]
+        defaults = _simdefaults[key]
         qsim.source.focal_xy = defaults['focal_xy']
         qsim.atmosphere.airmass = defaults['airmass']
         qsim.observation.exposure_time = defaults['exposure_time']
@@ -36,7 +37,7 @@ def get_simulator(config='desi'):
         log.debug('Creating new {} Simulator'.format(config))
         #- New config; create Simulator object
         import specsim.simulator
-        qsim = specsim.simulator.Simulator(config)
+        qsim = specsim.simulator.Simulator(config, num_fibers)
         #- Cache defaults to reset back to original state later
         defaults = dict()
         defaults['focal_xy'] = qsim.source.focal_xy
@@ -46,7 +47,7 @@ def get_simulator(config='desi'):
         defaults['moon_angle'] = qsim.atmosphere.moon.separation_angle
         defaults['moon_zenith'] = qsim.atmosphere.moon.moon_zenith
 
-        _simulators[config] = qsim
-        _simdefaults[config] = defaults
+        _simulators[key] = qsim
+        _simdefaults[key] = defaults
 
     return qsim


### PR DESCRIPTION
specsim v0.8 broke quickgen because the Simulator outputs are now 2D arrays of multiple fibers instead of 1D arrays for a single fiber.  This PR provides the minimal fix to work around that, at the cost that quickgen now requires specsim v0.8 (i.e. it won't work with specsim v0.7 anymore).

A deeper refactor from @dkirkby will upgrade quickgen to do multi-fiber simulations taking into account their location on the focal plane; this PR is not that.

Another side effect of v0.8 was revealing a previously silent bug in `obs.new_exposure` where the EXPTIME header keyword was not being set for arcs and flats.  This PR fixes that.

Lastly, it also switches to using the `desisim.specsim.get_simulator()` wrapper to get a `Simulator` object; this lets the quickgen tests run much faster because they can re-use a pre-existing `Simulator` instead of having to recreate one N>>1 times while testing different interface options.