### PR TITLE
set z_wind=0 in lya_spectra

### DIFF
--- a/py/desisim/lya_spectra.py
+++ b/py/desisim/lya_spectra.py
@@ -76,7 +76,7 @@ def get_spectra(lyafile, nqso=None, wave=None, templateid=None, normfilter='sdss
     normfilt = load_filters(normfilter)
 
     if qso is None:
-        qso = QSO(normfilter=normfilter, wave=wave)
+        qso = QSO(normfilter=normfilter, wave=wave,z_wind=0)
 
     wave = qso.wave
     flux = np.zeros([nqso, len(wave)], dtype='f4')

--- a/py/desisim/lya_spectra.py
+++ b/py/desisim/lya_spectra.py
@@ -76,7 +76,7 @@ def get_spectra(lyafile, nqso=None, wave=None, templateid=None, normfilter='sdss
     normfilt = load_filters(normfilter)
 
     if qso is None:
-        qso = QSO(normfilter=normfilter, wave=wave,z_wind=0)
+        qso = QSO(normfilter=normfilter, wave=wave)
 
     wave = qso.wave
     flux = np.zeros([nqso, len(wave)], dtype='f4')

--- a/py/desisim/qso_template/desi_qso_templ.py
+++ b/py/desisim/qso_template/desi_qso_templ.py
@@ -187,7 +187,7 @@ def desi_qso_templates(z_wind=0.2, zmnx=(0.4,4.), outfil=None, N_perz=500,
     Parameters
     ----------
     z_wind : float, optional
-      Window for sampling
+      Window for sampling PCAs
     zmnx : tuple, optional
       Min/max for generation
     N_perz : int, optional
@@ -275,7 +275,7 @@ def desi_qso_templates(z_wind=0.2, zmnx=(0.4,4.), outfil=None, N_perz=500,
             z0 = np.array([redshift])
         else:
             z0 = redshift.copy()
-        z1 = z0 + z_wind
+        z1 = z0.copy() #+ z_wind
 
 
     pca_list = ['PCA0', 'PCA1', 'PCA2', 'PCA3']


### PR DESCRIPTION
I'm opening this PR to fix a "feature" in lya_spectra which resulted in simulated quasars with different redshifts than what's specified in the input files. This is a minimalist fix of [issue 227](https://github.com/desihub/desisim/issues/227). 

The only change is:
 * set z_wind = 0 when constructing the qso object