### PR TITLE
significant speed-up of desisim.templates for galaxies

### DIFF
--- a/bin/time-vdisp-cache
+++ b/bin/time-vdisp-cache
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import numpy as np
+import argparse
+
+from desisim.templates import ELG
+from desisim.io import empty_metatable, read_basis_templates
+
+def make_elg(nobj=50, seed=123, fracvdisp=(0.1, 40), no_cache=False):
+    
+    rand = np.random.RandomState(seed)
+
+    if no_cache:
+        vdisp = 10**rand.normal(1.9, 0.15, nobj)
+    else:
+        nvdisp = int(np.min((np.fix(nobj * fracvdisp[0]), fracvdisp[1], 1)))
+        vdisp = 10**rand.normal(1.9, 0.15, nvdisp)
+
+    meta = read_basis_templates('ELG', onlymeta=True)
+
+    input_meta = empty_metatable(nobj, objtype='ELG')
+    input_meta['TEMPLATEID'] = rand.choice(meta['TEMPLATEID'], nobj)
+    input_meta['REDSHIFT'] = rand.uniform(0.8, 1.2, nobj)
+    input_meta['MAG'] = rand.uniform(21, 23, nobj)
+    input_meta['SEED'] = rand.randint(2**32, size=nobj)
+    input_meta['VDISP'] = rand.choice(vdisp, nobj)
+
+    ELG().make_templates(input_meta=input_meta, nocolorcuts=True)
+    #ELG().make_templates(nmodel=nobj, seed=seed, nocolorcuts=True)
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-n', '--nobj', type=int, help='Number of spectra to simulate.')
+    parser.add_argument('--no-cache', action='store_true', help='Do not cache the velocity dispersion (slow!)')
+
+    args = parser.parse_args()
+    make_elg(args.nobj, no_cache=args.no_cache)

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,6 +8,8 @@ desisim change log
 * Fixed a number of documentation errors (`PR #224`_).
 * Removed unneeded Travis scripts in ``etc/``.
 * Fixed N^2 scaling of ``QSO.make_templates``
+* Speed up desisim.templates.GALAXY by factor of 8-12 by caching velocity
+  dispersions (PR #229)
 
 .. _`PR #224`: https://github.com/desihub/desisim/pull/224
 

--- a/etc/time-vdisp-cache
+++ b/etc/time-vdisp-cache
@@ -1,5 +1,12 @@
 #!/usr/bin/env python
 
+"""Simple script to time the impact of using a subset of velocity dispersion
+values.  To compare the "before and after" run with:
+
+% time python time-vdisp-cache -n 100
+% time python time-vdisp-cache -n 100 --no-cache
+
+"""
 import numpy as np
 import argparse
 
@@ -13,7 +20,8 @@ def make_elg(nobj=50, seed=123, fracvdisp=(0.1, 40), no_cache=False):
     if no_cache:
         vdisp = 10**rand.normal(1.9, 0.15, nobj)
     else:
-        nvdisp = int(np.min((np.fix(nobj * fracvdisp[0]), fracvdisp[1], 1)))
+        nvdisp = int(np.max( (np.min( (np.fix(nobj * fracvdisp[0]), fracvdisp[1]) ), 1) ))
+        print(nvdisp)
         vdisp = 10**rand.normal(1.9, 0.15, nvdisp)
 
     meta = read_basis_templates('ELG', onlymeta=True)

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -25,7 +25,7 @@ import desimodel.io
 from desispec.image import Image
 import desispec.io.util
 
-from desispec.log import get_logger
+from desiutil.log import get_logger
 log = get_logger()
 
 from desisim.util import spline_medfilt2d

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -371,8 +371,11 @@ class GALAXY(object):
     def lineratios(self, nobj, oiiihbrange=(-0.5, 0.2), oiidoublet_meansig=(0.73, 0.05),
                    agnlike=False, rand=None):
         """Get the correct number and distribution of the forbidden and [OII] 3726/3729
-           doublet emission-line ratios.  Note that the agnlike option is not
-           yet supported.
+        doublet emission-line ratios.  Note that the agnlike option is not yet
+        supported.
+
+        Supporting oiiihbrange needs a different (fast) approach.  Suppressing
+        the code below for now until it's needed.
 
         """
         if agnlike:
@@ -386,20 +389,27 @@ class GALAXY(object):
         else:
             oiidoublet = np.repeat(oiidoublet_meansig[0], nobj)
 
-        oiihbeta = np.zeros(nobj)
-        niihbeta = np.zeros(nobj)
-        siihbeta = np.zeros(nobj)
-        oiiihbeta = np.zeros(nobj)-99
-        need = np.where(oiiihbeta==-99)[0]
-        while len(need) > 0:
-            samp = EMSpectrum().forbidmog.sample(len(need), random_state=rand)
-            oiiihbeta[need] = samp[:,0]
-            oiihbeta[need] = samp[:,1]
-            niihbeta[need] = samp[:,2]
-            siihbeta[need] = samp[:,3]
-            oiiihbeta[oiiihbeta<oiiihbrange[0]] = -99
-            oiiihbeta[oiiihbeta>oiiihbrange[1]] = -99
+        samp = EMSpectrum().forbidmog.sample(len(need), random_state=rand)
+        oiiihbeta = samp[:, 0]
+        oiihbeta = samp[:, 1]
+        niihbeta = samp[:, 2]
+        siihbeta = samp[:, 3]
+
+        if False:
+            oiihbeta = np.zeros(nobj)
+            niihbeta = np.zeros(nobj)
+            siihbeta = np.zeros(nobj)
+            oiiihbeta = np.zeros(nobj)-99
             need = np.where(oiiihbeta==-99)[0]
+            while len(need) > 0:
+                samp = EMSpectrum().forbidmog.sample(len(need), random_state=rand)
+                oiiihbeta[need] = samp[:,0]
+                oiihbeta[need] = samp[:,1]
+                niihbeta[need] = samp[:,2]
+                siihbeta[need] = samp[:,3]
+                oiiihbeta[oiiihbeta<oiiihbrange[0]] = -99
+                oiiihbeta[oiiihbeta>oiiihbrange[1]] = -99
+                need = np.where(oiiihbeta==-99)[0]
 
         return oiidoublet, oiihbeta, niihbeta, siihbeta, oiiihbeta
 

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -389,7 +389,7 @@ class GALAXY(object):
         else:
             oiidoublet = np.repeat(oiidoublet_meansig[0], nobj)
 
-        samp = EMSpectrum().forbidmog.sample(len(need), random_state=rand)
+        samp = EMSpectrum().forbidmog.sample(nobj, random_state=rand)
         oiiihbeta = samp[:, 0]
         oiihbeta = samp[:, 1]
         niihbeta = samp[:, 2]

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -344,15 +344,6 @@ class GALAXY(object):
         self.normfilt = filters.load_filters(self.normfilter)
         self.decamwise = filters.load_filters('decam2014-*', 'wise2010-W1', 'wise2010-W2')
 
-    def vdispblur(self, flux, vdisp=150.0):
-        """Convolve an input spectrum with the velocity dispersion."""
-        from desisim import pixelsplines as pxs
-
-        sigma = 1.0 + (self.basewave * vdisp / LIGHT)
-        blurflux = pxs.gauss_blur_matrix(self.pixbound, sigma) * flux
-
-        return blurflux
-
     def _blurmatrix(self, vdisp):
         from desisim import pixelsplines as pxs
 
@@ -553,7 +544,8 @@ class GALAXY(object):
 
             if vdisp is None:
                 # Limit the number of unique velocity dispersion values.
-                nvdisp = np.max((np.min((np.round(nmodel * self.fracvdisp[0]), self.fracvdisp[1])), 1)).astype(int)
+                nvdisp = np.max( ( np.min(
+                    ( np.round(nmodel * self.fracvdisp[0]), self.fracvdisp[1] ) ), 1 ) ).astype(int)
                 if logvdisp_meansig[1] > 0:
                     vvdisp = 10**rand.normal(logvdisp_meansig[0], logvdisp_meansig[1], nvdisp)
                 else:

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -567,7 +567,7 @@ class GALAXY(object):
 
             if vdisp is None:
                 # Limit the number of unique velocity dispersion values.
-                nvdisp = np.min((np.fix(nmodel * self.fracvdisp[0]), self.fracvdisp[1], 1))
+                nvdisp = np.max((np.min((np.round(nmodel * self.fracvdisp[0]), self.fracvdisp[1])), 1)).astype(int)
                 if logvdisp_meansig[1] > 0:
                     vvdisp = 10**rand.normal(logvdisp_meansig[0], logvdisp_meansig[1], nvdisp)
                 else:

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -389,27 +389,13 @@ class GALAXY(object):
         else:
             oiidoublet = np.repeat(oiidoublet_meansig[0], nobj)
 
+        # Sample from the MoG.  This is not strictly correct because it ignores
+        # the prior on [OIII]/Hbeta, but let's revisit that later.
         samp = EMSpectrum().forbidmog.sample(nobj, random_state=rand)
         oiiihbeta = samp[:, 0]
         oiihbeta = samp[:, 1]
         niihbeta = samp[:, 2]
         siihbeta = samp[:, 3]
-
-        if False:
-            oiihbeta = np.zeros(nobj)
-            niihbeta = np.zeros(nobj)
-            siihbeta = np.zeros(nobj)
-            oiiihbeta = np.zeros(nobj)-99
-            need = np.where(oiiihbeta==-99)[0]
-            while len(need) > 0:
-                samp = EMSpectrum().forbidmog.sample(len(need), random_state=rand)
-                oiiihbeta[need] = samp[:,0]
-                oiihbeta[need] = samp[:,1]
-                niihbeta[need] = samp[:,2]
-                siihbeta[need] = samp[:,3]
-                oiiihbeta[oiiihbeta<oiiihbrange[0]] = -99
-                oiiihbeta[oiiihbeta>oiiihbrange[1]] = -99
-                need = np.where(oiiihbeta==-99)[0]
 
         return oiidoublet, oiihbeta, niihbeta, siihbeta, oiiihbeta
 

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -12,7 +12,7 @@ import sys
 import numpy as np
 
 from desisim.io import empty_metatable
-from desispec.log import get_logger
+from desiutil.log import get_logger
 log = get_logger()
 
 LIGHT = 2.99792458E5  #- speed of light in km/s

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -550,8 +550,8 @@ class GALAXY(object):
 
             if vdisp is None:
                 # Limit the number of unique velocity dispersion values.
-                nvdisp = np.max( ( np.min(
-                    ( np.round(nmodel * self.fracvdisp[0]), self.fracvdisp[1] ) ), 1 ) ).astype(int)
+                nvdisp = int(np.max( ( np.min(
+                    ( np.round(nmodel * self.fracvdisp[0]), self.fracvdisp[1] ) ), 1 ) ))
                 if logvdisp_meansig[1] > 0:
                     vvdisp = 10**rand.normal(logvdisp_meansig[0], logvdisp_meansig[1], nvdisp)
                 else:


### PR DESCRIPTION
This PR addresses #209 by using a smaller subset of unique, ungridded velocity dispersions (10% of the number of spectra being generated or 40, whichever is smaller) when generating galaxy (ELG, LRG, BGS) templates.  

I wasn't sure where to put it, but I added a small timing script to `desisim/bin/time-vdisp-cache` which compares the performance of the code with and without the incorporated changes (see below).  Building 100 templates is now a factor of ~12(!) faster with the new code vs the old code.  

The other change was to allow the [OIII]/H-beta line-ratio to meander outside of the prior range specified by the `oiiihbeta` optional input, which saved another ~20% of time.  This is a minor issue that's in the weeds for the current state of the code and can be revisited at a future time.

(Tests are still running but submitted this now.)