### PR TITLE
remove lya absorption below lyman-lymit 

### DIFF
--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -1815,9 +1815,11 @@ class QSO():
 
             # Interpolate the Lya forest spectrum.
             if lyaforest:
-                no_forest = ( skewer_wave > self.lambda_lyalpha * (1 + redshift[ii]) ) | (skewer_wave <  self.lambda_lylimit* (1 + redshift[ii]))
+                no_forest = ( skewer_wave > self.lambda_lyalpha * (1 + redshift[ii]) )
                 skewer_flux[ii, no_forest] = 1.0
                 qso_skewer_flux = resample_flux(zwave[:, ii], skewer_wave, skewer_flux[ii, :])
+                w=zwave[:, ii]>self.lambda_lyalpha * (1 + redshift[ii])
+                qso_skewer_flux[w]=1.
 
             idx = np.where( (zQSO > redshift[ii]-self.z_wind/2) * (zQSO < redshift[ii]+self.z_wind/2) )[0]
             if len(idx) == 0:

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -1815,7 +1815,7 @@ class QSO():
 
             # Interpolate the Lya forest spectrum.
             if lyaforest:
-                no_forest = ( skewer_wave > self.lambda_lyalpha * (1 + redshift[ii]) ) & (skewer_wave <  self.lambda_lylimit* (1 + redshift[ii]))
+                no_forest = ( skewer_wave > self.lambda_lyalpha * (1 + redshift[ii]) ) | (skewer_wave <  self.lambda_lylimit* (1 + redshift[ii]))
                 skewer_flux[ii, no_forest] = 1.0
                 qso_skewer_flux = resample_flux(zwave[:, ii], skewer_wave, skewer_flux[ii, :])
 

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -1852,7 +1852,7 @@ class QSO():
                 # Lyman-limit based on the MFP, and the Lyman-alpha forest.
                 for kk in range(N_perz):
                     flux[kk, :] = np.dot(self.eigenflux.T, PCA_rand[:, kk]).flatten()
-                    if redshift[ii] > 2.39:
+                    if redshift[ii] > 2.39 and not lyaforest:
                          flux[kk, :pix912] *= np.exp(-phys_dist.value / mfp[ii])
                     if lyaforest:
                         flux[kk, :] *= qso_skewer_flux

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -1815,7 +1815,7 @@ class QSO():
 
             # Interpolate the Lya forest spectrum.
             if lyaforest:
-                no_forest = ( skewer_wave > self.lambda_lyalpha * (1 + redshift[ii]) )
+                no_forest = ( skewer_wave > self.lambda_lyalpha * (1 + redshift[ii]) ) & (skewer_wave <  self.lambda_lylimit* (1 + redshift[ii]))
                 skewer_flux[ii, no_forest] = 1.0
                 qso_skewer_flux = resample_flux(zwave[:, ii], skewer_wave, skewer_flux[ii, :])
 
@@ -1852,7 +1852,7 @@ class QSO():
                 # Lyman-limit based on the MFP, and the Lyman-alpha forest.
                 for kk in range(N_perz):
                     flux[kk, :] = np.dot(self.eigenflux.T, PCA_rand[:, kk]).flatten()
-                    if redshift[ii] > 2.39 and not lyaforest:
+                    if redshift[ii] > 2.39:
                          flux[kk, :pix912] *= np.exp(-phys_dist.value / mfp[ii])
                     if lyaforest:
                         flux[kk, :] *= qso_skewer_flux


### PR DESCRIPTION
This PR intends to address issue #235 by removing the lyman-alpha absorption below the lyman-limit (which is already taken into account in the template).
