### PR TITLE
fix tests and code related to flavor=science

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,19 +2,17 @@
 desisim change log
 ==================
 
-0.19.1 (unreleased)
--------------------
-
-* No changes yet
-
-0.19.0 (2017-06-05)
+0.19.0 (unreleased)
 -------------------
 
 * Changed refs to ``desispec.brick`` to its new location at :mod:`desiutil.brick` (`PR #241`_).
 * Refactor and speed-up of QSO templates; add Lya forest on-the-fly (`PR #234`_).
+* "FLAVOR" keyword is arc/flat/science but not dark/bright/bgs/mws/etc to match
+  desispec usage (`PR #243`_).
 
 .. _`PR #234`: https://github.com/desihub/desisim/pull/234
-.. _`PR #241`: https://github.com/desihub/desisim/pull/241  
+.. _`PR #241`: https://github.com/desihub/desisim/pull/241
+.. _`PR #243`: https://github.com/desihub/desisim/pull/243
 
 0.18.3 (2017-04-13)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,7 +2,12 @@
 desisim change log
 ==================
 
-0.18.4 (unreleased)
+0.19.1 (unreleased)
+-------------------
+
+* No changes yet
+
+0.19.0 (2017-06-05)
 -------------------
 
 * Changed refs to ``desispec.brick`` to its new location at :mod:`desiutil.brick` (`PR #241`_).

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -281,10 +281,16 @@ def new_exposure(flavor, nspec=5000, night=None, expid=None, tileid=None,
         NIGHT = (night, 'Night of observation YEARMMDD'),
         EXPID = (expid, 'DESI exposure ID'),
         TILEID = (tileid, 'DESI tile ID'),
-        FLAVOR = (flavor, 'Flavor [arc, flat, science, ...]'),
         TELRA = (telera, 'Telescope pointing RA [degrees]'),
         TELDEC = (teledec, 'Telescope pointing dec [degrees]'),
         )
+    if flavor in ('arc', 'flat'):
+        hdr['FLAVOR'] = (flavor, 'Flavor [arc, flat, science, ...]')
+        hdr['PROGRAM'] = 'calib'
+    else:
+        hdr['FLAVOR'] = ('science', 'Flavor [arc, flat, science, ...]')
+        hdr['PROGRAM'] = flavor
+        
     #- ISO 8601 DATE-OBS year-mm-ddThh:mm:ss
     fiberfile = desispec.io.findfile('fibermap', night, expid)
     desispec.io.write_fibermap(fiberfile, fibermap, header=hdr)

--- a/py/desisim/scripts/quickgen.py
+++ b/py/desisim/scripts/quickgen.py
@@ -687,7 +687,8 @@ def main(args):
                     # must create desispec.Frame object
                     frame=Frame(waves[channel], frame_flux, frame_ivar,\
                         resolution_data=resol, spectrograph=ii, \
-                        fibermap=fibermap[start:end], meta=dict(CAMERA=camera) )
+                        fibermap=fibermap[start:end], \
+                        meta=dict(CAMERA=camera, FLAVOR=simspec.flavor) )
                     desispec.io.write_frame(framefileName, frame)
 
                     framefilePath=desispec.io.findfile("frame",NIGHT,EXPID,camera)
@@ -704,7 +705,8 @@ def main(args):
                     # must create desispec.Frame object
                     cframe = Frame(waves[channel], cframeFlux, cframeIvar, \
                         resolution_data=resol, spectrograph=ii,
-                        fibermap=fibermap[start:end], meta=dict(CAMERA=camera) )
+                        fibermap=fibermap[start:end],
+                        meta=dict(CAMERA=camera, FLAVOR=simspec.flavor) )
                     desispec.io.frame.write_frame(cframeFileName,cframe)
 
                     cframefilePath=desispec.io.findfile("cframe",NIGHT,EXPID,camera)

--- a/py/desisim/scripts/quickgen.py
+++ b/py/desisim/scripts/quickgen.py
@@ -410,9 +410,13 @@ def main(args):
     if args.simspec is None:
         object_type = objtype
         flavor = None
+    elif simspec.flavor == 'science':
+        object_type = None
+        flavor = simspec.header['PROGRAM']
     else:
         object_type = None
         flavor = simspec.flavor
+        log.warn('Maybe using an outdated simspec file with flavor={}'.format(flavor))
 
     # Set airmass and exptime
     if args.simspec:

--- a/py/desisim/test/test_obs.py
+++ b/py/desisim/test/test_obs.py
@@ -56,7 +56,10 @@ class TestObs(unittest.TestCase):
             simspecfile = io.findfile('simspec', night, expid=expid)
             self.assertTrue(os.path.exists(simspecfile))
             simspec = io.read_simspec(simspecfile)
-            self.assertEqual(simspec.flavor, flavor)
+            if flavor in ('arc', 'flat'):
+                self.assertEqual(simspec.flavor, flavor)
+            else:
+                self.assertEqual(simspec.flavor, 'science')
 
             #- Check that photons are in a reasonable range
             for channel in ('b', 'r', 'z'):


### PR DESCRIPTION
This PR fixes some pieces of desisim that were broken by desihub/desispec#386 which became more picky about allowable exposure flavors when writing Frame objects.

The whole usage of "flavor" vs. "objtype" vs. "program" still needs to be cleaned up (see #97), but this at least gets us back to a working state on desisim + desispec master.