### PR TITLE
simulating desi spectra notebook tutorial

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desisim change log
 0.19.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Adds tutorial on simulating spectra (`PR #244`_).
+
+.. _`PR #244`: https://github.com/desihub/desisim/pull/244
 
 0.19.0 (2017-06-15)
 -------------------

--- a/doc/nb/simulating-desi-spectra.ipynb
+++ b/doc/nb/simulating-desi-spectra.ipynb
@@ -6,10 +6,13 @@
    "source": [
     "# Simulating DESI Spectra\n",
     "\n",
-    "The goal of this notebook is to demonstrate how to generate some simple DESI spectra using the *quickgen* utility.  For simplicity we will only generate 1D spectra and skip the more computationally intensive (yet still instructive!) step of extracting 1D spectra from simulated 2D spectra (i.e., so-called \"pixel-level simulations\").\n",
+    "The goal of this notebook is to demonstrate how to generate some simple DESI spectra using the `quickgen` utility.  For simplicity we will only generate 1D spectra and skip the more computationally intensive (yet still instructive!) step of extracting 1D spectra from simulated 2D spectra (i.e., so-called \"pixel-level simulations\").\n",
     "\n",
-    "For additional (albeit somewhat outdated) information and documentation about *quickgen* see  \n",
+    "For additional (albeit somewhat outdated) information and documentation about `quickgen` see  \n",
     "https://desi.lbl.gov/DocDB/cgi-bin/private/ShowDocument?docid=1429\n",
+    "\n",
+    "The heart of `quickgen` is the `SpecSim` package, which you can read out here:  \n",
+    "http://specsim.readthedocs.io/en/stable\n",
     "\n",
     "If you identify any errors or have requests for additional functionality please create a new issue on  \n",
     "https://github.com/desihub/desisim/issues\n",
@@ -54,12 +57,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Populating the interactive namespace from numpy and matplotlib\n"
+      "WARNING:log.py:19:get_logger: desispec.log is deprecated, please use desiutil.log.\n",
+      "WARNING:log.py:19:get_logger: desispec.log is deprecated, please use desiutil.log.\n",
+      "WARNING:log.py:19:get_logger: desispec.log is deprecated, please use desiutil.log.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/anaconda3/envs/desi/lib/python3.5/site-packages/matplotlib/__init__.py:1401: UserWarning:  This call to matplotlib.use() has no effect\n",
+      "because the backend has already been chosen;\n",
+      "matplotlib.use() must be called *before* pylab, matplotlib.pyplot,\n",
+      "or matplotlib.backends is imported for the first time.\n",
+      "\n",
+      "  warnings.warn(_use_error_msg)\n"
      ]
     }
    ],
    "source": [
-    "%pylab inline"
+    "import desispec.io\n",
+    "import desisim.io\n",
+    "from desisim.obs import new_exposure\n",
+    "from desisim.scripts import quickgen\n",
+    "from desispec.scripts import group_spectra"
    ]
   },
   {
@@ -73,28 +94,21 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WARNING:log.py:19:get_logger: desispec.log is deprecated, please use desiutil.log.\n",
-      "WARNING:log.py:19:get_logger: desispec.log is deprecated, please use desiutil.log.\n",
-      "WARNING:log.py:19:get_logger: desispec.log is deprecated, please use desiutil.log.\n"
+      "Populating the interactive namespace from numpy and matplotlib\n"
      ]
     }
    ],
    "source": [
-    "import desispec.io\n",
-    "import desisim.io\n",
-    "from desisim.obs import new_exposure\n",
-    "from desisim.scripts import quickgen\n",
-    "from desispec.scripts import makebricks\n",
-    "\n",
-    "from desiutil.log import get_logger\n",
-    "log = get_logger()"
+    "%pylab inline"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Make sure we have all the right environment variables set (assuming the bash shell).  If any of these environment variables are missing please set them in your *.bashrc* file (and then restart this notebook) or create them for just this notebook session using the *%set_env* magic command, as we demonstrate below."
+    "#### Check and set your environment\n",
+    "\n",
+    "Next, make sure we have all the right environment variables set (assuming the bash shell).  If any of these environment variables are missing please set them in your `.bashrc` file (and then restart this notebook) or create them for just this notebook session using the `%set_env` magic command, as we demonstrate below."
    ]
   },
   {
@@ -125,13 +139,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DESIMODEL environment set to /Users/sbailey/desi/git/desimodel/svn/trunk\n",
-      "DESI_ROOT environment set to /data/desi\n",
-      "DESI_SPECTRO_SIM environment set to /data/desi/spectro/sim\n",
-      "DESI_SPECTRO_DATA environment set to /data/desi/spectro/data\n",
-      "DESI_SPECTRO_REDUX environment set to /data/desi/spectro/redux\n",
-      "SPECPROD environment set to debug\n",
-      "PIXPROD environment set to debug\n"
+      "DESIMODEL environment set to /Users/ioannis/repos/desihub/desimodel\n",
+      "DESI_ROOT environment set to /Users/ioannis/research/projects/desi\n",
+      "DESI_SPECTRO_SIM environment set to /Users/ioannis/research/projects/desi/spectro/sim\n",
+      "DESI_SPECTRO_DATA environment set to /Users/ioannis/research/projects/desi/spectro/data\n",
+      "DESI_SPECTRO_REDUX environment set to /Users/ioannis/research/projects/desi/spectro/redux\n",
+      "SPECPROD environment set to dailytest\n",
+      "PIXPROD environment set to dailytest\n"
      ]
     }
    ],
@@ -143,7 +157,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's reassign the *\\$SPECPROD* environment to something other than \"dailytest\" so that we don't conflict with the outputs of the standard DESI integration test.  In addition, we need to make raw data input *\\$DESI_SPECTO_DATA* match *\\$DESI_SPECTRO_SIM/\\$PIXPROD* where the simulated data will be written."
+    "Let's reassign the `$SPECPROD` environment to something other than `dailytest` so that we don't conflict with the outputs of the standard DESI integration test.  In addition, we need to make raw data input `$DESI_SPECTO_DATA` match `$DESI_SPECTRO_SIM/$PIXPROD` where the simulated data will be written."
    ]
   },
   {
@@ -159,11 +173,11 @@
      "text": [
       "env: SPECPROD=example\n",
       "env: PIXPROD=example\n",
-      "env: DESI_SPECTRO_DATA=/data/desi/spectro/sim/example/\n",
-      "Simulated raw data will be written to /data/desi/spectro/sim/example/\n",
-      "Pipeline will read raw data from /data/desi/spectro/sim/example/\n",
+      "env: DESI_SPECTRO_DATA=/Users/ioannis/research/projects/desi/spectro/sim/example/\n",
+      "Simulated raw data will be written to /Users/ioannis/research/projects/desi/spectro/sim/example/\n",
+      "Pipeline will read raw data from /Users/ioannis/research/projects/desi/spectro/sim/example/\n",
       "    (without knowing that it was simulated)\n",
-      "Pipeline will write processed data to /data/desi/spectro/redux/example\n"
+      "Pipeline will write processed data to /Users/ioannis/research/projects/desi/spectro/redux/example\n"
      ]
     }
    ],
@@ -173,10 +187,10 @@
     "rawdata_dir = desisim.io.simdir()\n",
     "%set_env DESI_SPECTRO_DATA=$rawdata_dir\n",
     "\n",
-    "print('Simulated raw data will be written to '+desisim.io.simdir())\n",
-    "print('Pipeline will read raw data from '+desispec.io.rawdata_root())\n",
+    "print('Simulated raw data will be written to {}'.format(desisim.io.simdir()))\n",
+    "print('Pipeline will read raw data from {}'.format(desispec.io.rawdata_root()))\n",
     "print('    (without knowing that it was simulated)')\n",
-    "print('Pipeline will write processed data to '+desispec.io.specprod_root())"
+    "print('Pipeline will write processed data to {}'.format(desispec.io.specprod_root()))"
    ]
   },
   {
@@ -185,7 +199,7 @@
    "source": [
     "## Specify the parameters of the simulation.\n",
     "\n",
-    "Next, specify the number and spectral type distribution of spectra we want to simulate, and the random seed.  Setting the seed here (which can be any number at all!) ensures that your simulations are reproducible.  Let's also explicitly set the *night* of the \"observations\" (the default is to use the current date) and the *expid* or exposure ID number (which would allow you to simulate more than one DESI exposure).\n",
+    "Next, let's specify the number and spectral type distribution of spectra we want to simulate, and the random seed.  Setting the seed here (which can be any number at all!) ensures that your simulations are reproducible.  Let's also explicitly set the *night* of the \"observations\" (the default is to use the current date) and the *expid* or exposure ID number (which would allow you to simulate more than one DESI exposure).\n",
     "\n",
     "The *flavor* option is used to choose the correct sky-brightness model and it also determines the distribution of targets for a given flavor.  For example, *flavor='dark'* returns the right relative sampling density of ELGs, LRGs, and QSOs.  The other available (science target) options for *flavor* are 'dark', 'gray', 'grey', 'bright', 'bgs', 'mws', 'lrg', 'elg', 'qso', and 'std'.  (You can also set flavor to either 'arc' or 'flat' but that would be boring!)"
    ]
@@ -198,11 +212,30 @@
    },
    "outputs": [],
    "source": [
-    "nspec = 50\n",
+    "nspec = 100\n",
     "seed = 555\n",
     "flavor = 'dark'\n",
     "night = '20170615'\n",
     "expid = 0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generating noiseless spectra. ##\n",
+    "\n",
+    "The first step is to generate the `fibermap` and `simspec` files needed by `quickgen`.  The `fibermap` table contains (simulated) information about the position of each target in the DESI focal plane, while the `simspec` table holds the \"truth\" spectra and the intrinsic properties of each object (redshift, noiseless photometry, [OII] flux, etc.).\n",
+    "\n",
+    "In detail, the *simspec* and *fibermap* data models are described at  \n",
+    "* http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_SIM/PIXPROD/NIGHT/simspec-EXPID.html\n",
+    "* http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_DATA/NIGHT/fibermap-EXPID.html\n",
+    "\n",
+    "To generate these files we'll use `new_exposure`, a convenience function for generating random typical exposures of various types for testing.  However, note that `new_exposure` isn't intended for every possible analysis; if you want to use your own mix of objects, you just need to write your own fibermap and simspec files following that format instead of calling `new_exposure`.\n",
+    "\n",
+    "Note that in our call to `new_exposure`, the `tileid` and `exptime` (exposure time) optional inputs are shown for demonstration purposes but do not need to be explicitly set.  In particular, the default exposure time is based on the value specified in the *$DESIMODEL/data/desi.yaml* parameter file.\n",
+    "\n",
+    "**Note**: The simspec file format may change in the near future, so structure your code to separate generating spectra from the code for writing these particular formats."
    ]
   },
   {
@@ -216,27 +249,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/data/desi/spectro/sim/example/20170615\n"
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:obs.py:226:new_exposure: skyfile /Users/ioannis/repos/desihub/desimodel/data/spectra/spec-sky.dat\n",
+      "INFO:obs.py:297:new_exposure: Wrote /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
+      "INFO:obs.py:305:new_exposure: Wrote /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits\n"
      ]
     }
    ],
    "source": [
-    "simdir = desisim.io.simdir(night=night)\n",
-    "print(simdir)"
+    "fibermap, truth = new_exposure(flavor=flavor, nspec=nspec, seed=seed, night=night, \n",
+    "                               expid=expid, tileid=None, exptime=None)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Generate the fibermap and truth tables.\n",
+    "## Reading the fibermap and spectral metadata ##\n",
     "\n",
-    "The first step is to generate the *fibermap* and *simspec* files needed by *quickgen*.  The *fibermap* table contains (simulated) information about the position of each target in the DESI focal plane, while the *simspec* table holds the \"truth\" spectra and the intrinsic properties of each object (redshift, noiseless photometry, [OII] flux, etc.).\n",
-    "\n",
-    "Note that the *tileid* and *exptime* (exposure time) optional inputs are shown here for demonstration purposes but do not need to be explicitly set.  In particular, the default exposure time is based on the value specified in the *$DESIMODEL/data/desi.yaml* parameter file.\n",
-    "\n",
-    "The *fibermap* object is an astropy Table with lots of goodies while the *truth* object is a dictionary that we won't use anymore (we'll instead use the *simspec* table; see below).  The fibermap data model is described at  \n",
-    "http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_DATA/NIGHT/fibermap-EXPID.html"
+    "First, let's see what got written to the raw data directory as a result of that last command."
    ]
   },
   {
@@ -250,48 +294,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
-      "INFO:obs.py:226:new_exposure: skyfile /Users/sbailey/desi/git/desimodel/svn/trunk/data/spectra/spec-sky.dat\n",
-      "INFO:obs.py:297:new_exposure: Wrote /data/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
-      "INFO:obs.py:305:new_exposure: Wrote /data/desi/spectro/sim/example/20170615/simspec-00000000.fits\n"
-     ]
-    }
-   ],
-   "source": [
-    "fibermap, truth = new_exposure(flavor=flavor, nspec=nspec, seed=seed, night=night, \n",
-    "                               expid=expid, tileid=None, exptime=None)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Let's see what got written to the raw data directory as a result of that last command:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/data/desi/spectro/sim/example/\r\n",
-      "/data/desi/spectro/sim/example//20170615\r\n",
-      "/data/desi/spectro/sim/example//20170615/fibermap-00000000.fits\r\n",
-      "/data/desi/spectro/sim/example//20170615/simspec-00000000.fits\r\n",
-      "/data/desi/spectro/sim/example//etc\r\n",
-      "/data/desi/spectro/sim/example//etc/obslog.sqlite\r\n"
+      "/Users/ioannis/research/projects/desi/spectro/sim/example/\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/sim/example//20170615\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/sim/example//20170615/fibermap-00000000.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/sim/example//20170615/simspec-00000000.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/sim/example//etc\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/sim/example//etc/obslog.sqlite\r\n"
      ]
     }
    ],
@@ -304,36 +312,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Generating your own spectra. ##\n",
+    "Let's go a step further and read the *fibermap* and *simspec* files from on-disk.\n",
     "\n",
-    "`new_exposure` is a convenience function for generating random typical exposures of various types for testing, but it isn't intended for every possible analysis.  If you want to use your own mix of objects, you just need to write your own fibermap and simspec files following that format instead of calling `new_exposure`.\n",
-    "\n",
-    "The *simspec* and *fibermap* data models are described at  \n",
-    "* http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_SIM/PIXPROD/NIGHT/simspec-EXPID.html\n",
-    "* http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_DATA/NIGHT/fibermap-EXPID.html\n",
-    "\n",
-    "**TODO**: update the datamodel documentation to match what is actually written!\n",
-    "\n",
-    "**NOTE**: the simspec file format may change in the near future, so structure your code to separate generating spectra from the code for writing these particular formats."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Reading the input spectra metadata ##\n",
-    "\n",
-    "Finally, even though we have the *fibermap* table in hand, the code below demonstrates how it and the *simspec* table can be read from on-disk.  In particular, the simspec METADATA HDU contains an extensive (and useful!) metadata table.\n",
-    "\n",
-    "In general code should not generate filepaths by hand, but rather call `desispec.io.findfile` to find the file it needs.  If you\n",
-    "need to override the standard environment variable locations, you can use the `outdir` option,\n",
-    "while still letting it construct the canonical filename for each type of file.\n",
-    "\n"
+    "Note that in general code should not generate filepaths by hand, but rather call `desispec.io.findfile` to find the file it needs.  If you need to override the standard environment variable locations, you can use the `outdir` option, while still letting it construct the canonical filename for each type of file."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -345,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -354,20 +340,58 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:<ipython-input-12-55ef607f5bdd>:1:<module>: Reading fibermap file /data/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
-      "Filename: /data/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
+      "Reading fibermap file /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
+      "Filename: /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
       "No.    Name         Type      Cards   Dimensions   Format\n",
-      "0    PRIMARY     PrimaryHDU       6   ()              \n",
-      "1    FIBERMAP    BinTableHDU     98   50R x 26C    [10A, 20A, 8A, K, K, K, K, 5E, 50A, J, J, J, J, J, J, E, D, D, D, D, D, D, D, D, E, E]   \n"
+      "  0  PRIMARY     PrimaryHDU       6   ()      \n",
+      "  1  FIBERMAP    BinTableHDU     98   100R x 26C   [10A, 20A, 8A, K, K, K, K, 5E, 50A, J, K, J, J, J, J, E, D, D, D, D, D, D, D, D, E, E]   \n"
      ]
     }
    ],
    "source": [
-    "log.info('Reading fibermap file {}'.format(fiberfile))\n",
+    "print('Reading fibermap file {}'.format(fiberfile))\n",
     "hdu = fits.open(fiberfile)\n",
     "hdu.info()\n",
     "fibermap = Table(hdu['FIBERMAP'].data)\n",
     "hdu.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "&lt;Table length=3&gt;\n",
+       "<table id=\"table4641429376\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>OBJTYPE</th><th>TARGETCAT</th><th>BRICKNAME</th><th>TARGETID</th><th>DESI_TARGET</th><th>BGS_TARGET</th><th>MWS_TARGET</th><th>MAG [5]</th><th>FILTER [5]</th><th>SPECTROID</th><th>POSITIONER</th><th>LOCATION</th><th>DEVICE_LOC</th><th>PETAL_LOC</th><th>FIBER</th><th>LAMBDAREF</th><th>RA_TARGET</th><th>DEC_TARGET</th><th>RA_OBS</th><th>DEC_OBS</th><th>X_TARGET</th><th>Y_TARGET</th><th>X_FVCOBS</th><th>Y_FVCOBS</th><th>Y_FVCERR</th><th>X_FVCERR</th></tr></thead>\n",
+       "<thead><tr><th>str10</th><th>str20</th><th>str8</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>float32</th><th>str10</th><th>int32</th><th>int64</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>float32</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float32</th><th>float32</th></tr></thead>\n",
+       "<tr><td>ELG</td><td></td><td>3331p155</td><td>5920414735219039951</td><td>2</td><td>0</td><td>0</td><td>23.1645 .. 21.7528</td><td>DECAM_G .. WISE_W2</td><td>0</td><td>95</td><td>95</td><td>95</td><td>0</td><td>0</td><td>5400.0</td><td>333.237503875</td><td>15.5578749931</td><td>333.237503875</td><td>15.5578749931</td><td>-4.13464340313</td><td>-176.016389199</td><td>-4.13464340313</td><td>-176.016389199</td><td>0.0</td><td>0.0</td></tr>\n",
+       "<tr><td>ELG</td><td></td><td>3334p155</td><td>5523080440782501539</td><td>2</td><td>0</td><td>0</td><td>22.9234 .. 22.1754</td><td>DECAM_G .. WISE_W2</td><td>0</td><td>62</td><td>62</td><td>62</td><td>0</td><td>1</td><td>5400.0</td><td>333.413137964</td><td>15.4815165289</td><td>333.413137964</td><td>15.4815165289</td><td>-45.5863791815</td><td>-157.134697634</td><td>-45.5863791815</td><td>-157.134697634</td><td>0.0</td><td>0.0</td></tr>\n",
+       "<tr><td>ELG</td><td></td><td>3334p157</td><td>7067568092200589017</td><td>2</td><td>0</td><td>0</td><td>21.8622 .. 21.6234</td><td>DECAM_G .. WISE_W2</td><td>0</td><td>102</td><td>102</td><td>102</td><td>0</td><td>2</td><td>5400.0</td><td>333.423893658</td><td>15.631559969</td><td>333.423893658</td><td>15.631559969</td><td>-48.26471976</td><td>-194.58679079</td><td>-48.26471976</td><td>-194.58679079</td><td>0.0</td><td>0.0</td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Table length=3>\n",
+       "OBJTYPE TARGETCAT BRICKNAME ...    Y_FVCOBS    Y_FVCERR X_FVCERR\n",
+       " str10    str20      str8   ...    float64     float32  float32 \n",
+       "------- --------- --------- ... -------------- -------- --------\n",
+       "    ELG            3331p155 ... -176.016389199      0.0      0.0\n",
+       "    ELG            3334p155 ... -157.134697634      0.0      0.0\n",
+       "    ELG            3334p157 ...  -194.58679079      0.0      0.0"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fibermap[:3]"
    ]
   },
   {
@@ -378,30 +402,35 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "&lt;Row index=3&gt;\n",
-       "<table id=\"table4468786120\">\n",
-       "<thead><tr><th>OBJTYPE</th><th>TARGETCAT</th><th>BRICKNAME</th><th>TARGETID</th><th>DESI_TARGET</th><th>BGS_TARGET</th><th>MWS_TARGET</th><th>MAG [5]</th><th>FILTER [5]</th><th>SPECTROID</th><th>POSITIONER</th><th>LOCATION</th><th>DEVICE_LOC</th><th>PETAL_LOC</th><th>FIBER</th><th>LAMBDAREF</th><th>RA_TARGET</th><th>DEC_TARGET</th><th>RA_OBS</th><th>DEC_OBS</th><th>X_TARGET</th><th>Y_TARGET</th><th>X_FVCOBS</th><th>Y_FVCOBS</th><th>Y_FVCERR</th><th>X_FVCERR</th></tr></thead>\n",
-       "<thead><tr><th>str10</th><th>str20</th><th>str8</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>float32</th><th>str10</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>float32</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float32</th><th>float32</th></tr></thead>\n",
-       "<tr><td>SKY</td><td></td><td>3350p205</td><td>4183104322407110374</td><td>4294967296</td><td>0</td><td>0</td><td>0.0 .. 0.0</td><td>..</td><td>0</td><td>82</td><td>82</td><td>82</td><td>0</td><td>3</td><td>5400.0</td><td>335.167583443</td><td>20.5840708185</td><td>335.167583443</td><td>20.5840708185</td><td>-31.5795923296</td><td>-172.635369698</td><td>-31.5795923296</td><td>-172.635369698</td><td>0.0</td><td>0.0</td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Row index=3>\n",
-       "OBJTYPE TARGETCAT BRICKNAME       TARGETID      DESI_TARGET BGS_TARGET MWS_TARGET  MAG [5]   FILTER [5] SPECTROID POSITIONER LOCATION DEVICE_LOC PETAL_LOC FIBER LAMBDAREF   RA_TARGET     DEC_TARGET      RA_OBS       DEC_OBS       X_TARGET       Y_TARGET       X_FVCOBS       Y_FVCOBS    Y_FVCERR X_FVCERR\n",
-       " str10    str20      str8          int64           int64      int64      int64     float32     str10      int32     int32     int32     int32      int32   int32  float32     float64       float64       float64       float64       float64        float64        float64        float64     float32  float32 \n",
-       "------- --------- --------- ------------------- ----------- ---------- ---------- ---------- ---------- --------- ---------- -------- ---------- --------- ----- --------- ------------- ------------- ------------- ------------- -------------- -------------- -------------- -------------- -------- --------\n",
-       "    SKY            3350p205 4183104322407110374  4294967296          0          0 0.0 .. 0.0        ..          0         82       82         82         0     3    5400.0 335.167583443 20.5840708185 335.167583443 20.5840708185 -31.5795923296 -172.635369698 -31.5795923296 -172.635369698      0.0      0.0"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reading simspec file /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits.\n",
+      "Filename: /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits\n",
+      "No.    Name         Type      Cards   Dimensions   Format\n",
+      "  0  PRIMARY     PrimaryHDU      15   ()      \n",
+      "  1  WAVE        ImageHDU         9   (31901,)   float64   \n",
+      "  2  FLUX        ImageHDU         9   (31901, 100)   float32   \n",
+      "  3  SKYFLUX     ImageHDU         8   (31901,)   float32   \n",
+      "  4  WAVE_B      ImageHDU         9   (12326,)   float64   \n",
+      "  5  PHOT_B      ImageHDU         8   (12326, 100)   float32   \n",
+      "  6  SKYPHOT_B   ImageHDU         7   (12326,)   float32   \n",
+      "  7  WAVE_R      ImageHDU         9   (11205,)   float64   \n",
+      "  8  PHOT_R      ImageHDU         8   (11205, 100)   float32   \n",
+      "  9  SKYPHOT_R   ImageHDU         7   (11205,)   float32   \n",
+      " 10  WAVE_Z      ImageHDU         9   (12765,)   float64   \n",
+      " 11  PHOT_Z      ImageHDU         8   (12765, 100)   float32   \n",
+      " 12  SKYPHOT_Z   ImageHDU         7   (12765,)   float32   \n",
+      " 13  METADATA    BinTableHDU     61   100R x 24C   [10A, 10A, J, K, E, E, 6E, 2E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E]   \n"
+     ]
     }
    ],
    "source": [
-    "fibermap[3]"
+    "print('Reading simspec file {}.'.format(simspecfile))\n",
+    "hdu = fits.open(simspecfile)\n",
+    "hdu.info()\n",
+    "meta = Table(hdu['METADATA'].data)\n",
+    "hdu.close()"
    ]
   },
   {
@@ -412,49 +441,10 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:<ipython-input-14-f05bf983fedc>:1:<module>: Reading simspec file /data/desi/spectro/sim/example/20170615/simspec-00000000.fits.\n",
-      "Filename: /data/desi/spectro/sim/example/20170615/simspec-00000000.fits\n",
-      "No.    Name         Type      Cards   Dimensions   Format\n",
-      "0    PRIMARY     PrimaryHDU      15   ()              \n",
-      "1    WAVE        ImageHDU         9   (31901,)     float64   \n",
-      "2    FLUX        ImageHDU         9   (31901, 50)   float32   \n",
-      "3    SKYFLUX     ImageHDU         8   (31901,)     float32   \n",
-      "4    WAVE_B      ImageHDU         9   (12326,)     float64   \n",
-      "5    PHOT_B      ImageHDU         8   (12326, 50)   float32   \n",
-      "6    SKYPHOT_B   ImageHDU         7   (12326,)     float32   \n",
-      "7    WAVE_R      ImageHDU         9   (11205,)     float64   \n",
-      "8    PHOT_R      ImageHDU         8   (11205, 50)   float32   \n",
-      "9    SKYPHOT_R   ImageHDU         7   (11205,)     float32   \n",
-      "10   WAVE_Z      ImageHDU         9   (12765,)     float64   \n",
-      "11   PHOT_Z      ImageHDU         8   (12765, 50)   float32   \n",
-      "12   SKYPHOT_Z   ImageHDU         7   (12765,)     float32   \n",
-      "13   METADATA    BinTableHDU     61   50R x 24C    [10A, 10A, J, K, E, E, 6E, 2E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E]   \n"
-     ]
-    }
-   ],
-   "source": [
-    "log.info('Reading simspec file {}.'.format(simspecfile))\n",
-    "hdu = fits.open(simspecfile)\n",
-    "hdu.info()\n",
-    "meta = Table(hdu['METADATA'].data)\n",
-    "hdu.close()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
      "data": {
       "text/html": [
        "&lt;Table length=3&gt;\n",
-       "<table id=\"table4490940368\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<table id=\"table4641429712\" class=\"table-striped table-bordered table-condensed\">\n",
        "<thead><tr><th>OBJTYPE</th><th>SUBTYPE</th><th>TEMPLATEID</th><th>SEED</th><th>REDSHIFT</th><th>MAG</th><th>DECAM_FLUX [6]</th><th>WISE_FLUX [2]</th><th>OIIFLUX</th><th>HBETAFLUX</th><th>EWOII</th><th>EWHBETA</th><th>D4000</th><th>VDISP</th><th>OIIDOUBLET</th><th>OIIIHBETA</th><th>OIIHBETA</th><th>NIIHBETA</th><th>SIIHBETA</th><th>ZMETAL</th><th>AGE</th><th>TEFF</th><th>LOGG</th><th>FEH</th></tr></thead>\n",
        "<thead><tr><th>str10</th><th>str10</th><th>int32</th><th>int64</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th></tr></thead>\n",
        "<tr><td>ELG</td><td></td><td>3512</td><td>3244113739</td><td>1.25838</td><td>22.937</td><td>0.441517 .. 1.32143</td><td>2.19795 .. 1.99019</td><td>8.25246e-17</td><td>-1.0</td><td>73.3845</td><td>-1.0</td><td>1.00652</td><td>68.2661</td><td>0.733237</td><td>-0.0850786</td><td>0.275525</td><td>-0.248196</td><td>-0.19466</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
@@ -472,7 +462,7 @@
        "    ELG               6928  369720621 ...    -1.0    -1.0    -1.0    -1.0"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -485,12 +475,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### Make a simple plot\n",
+    "\n",
     "Here's a fun simple plot of the redshift histogram distributions.  Now you try!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false,
     "scrolled": true
@@ -499,18 +491,18 @@
     {
      "data": {
       "text/plain": [
-       "(-0.2, 1.6220408082008364)"
+       "(-0.2, 2.3472768068313599)"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaQAAAElCAYAAACroJZIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAMTQAADE0B0s6tTgAAIABJREFUeJzt3XucV1W9//HXZwbioqUoYCgpJ0Xwgs7IMiqh4lKaP1PU\nijypYZRw8hKCpPboaGoe80cOeclLRxQ1OdJR8XghURIvqYlLGDU7ihcQIePiBSJG5bLOH3vP+B0c\n5rtnmP2d/Z39fj4e8/ju69qfzZc9n1l7r72WhRAQERFpbxXtHYCIiAgoIYmISEYoIYmISCYoIYmI\nSCYoIYmISCYoIYmISCYoIYmISCYoIYmISCYoIYmISCYoIYmISCZ0au8AmjJlypTQp0+f9g5DRES2\n08yZM+/y3h+fZNtMJqQ+ffowadKk9g5DRES208yZM99Iuq1u2YmISCYoIYmISCYoIYmISCYoIYmI\nSCZkslGDSEuEEFizZg1btmxp71BEcquiooKePXtiZq0uQwlJyt6aNWvYcccd6datW3uHIpJbdXV1\nrFmzhl69erW6jNQTknPuSOAXRLcHOwFTvfc3p31cyY8tW7YoGYm0s27durFu3brtKiPVZ0jOOQN+\nB4z13lcBRwHXO+c+meZxRUSk/JTill0Ado6nPwW8DXxQguNKTk17aHEq5Z711X1TKTerrqm9JpVy\nf1T1o1TKbW8L7n09lXI/943PplJuFqVaQ/LeB2AMcJdz7g3gT8D3vPcfpnlckfbUr18/BgwYQFVV\nVcPPCy+8QL9+/aitrW1yn9tvv51DDz2U/v3745xj2LBh3HnnnSWOPFua+vcaO3Yse+yxB1VVVQwc\nOJCTTjqJDRs2NKzfuHEjF154IQMHDuSAAw6gurqa0aNHb/PfvaO56667GDx4cMO/z4gRIzjyyCMb\n/h+aGYMGDaKqqophw4Y17Pf6669TUVHBxRdf3Ki8GTNmsNNOO1FVVcWBBx7I8OHDWbw4nT/4IOUa\nknOuE/Az4Djv/WPOuUOBe5xzg7z3awq2mwQ09BVUXV2dZlgiqZs1axZVVVWJtr3hhhv41a9+xV13\n3cX+++8PwMsvv8w999yTZohla8qUKUycOJEPPviAESNGcPXVV/OTn/wEgFNOOYX169fz1FNP0aNH\nDwDmzZvHyy+/nPj7KFdvvfUWp556Ks8++yx77bUXAAsXLqS6urqh5ZuZ8fjjj7Pzzjs32vfGG29k\nxIgR3HTTTfzsZz9r1FJu+PDh3H333QCcffbZTJw4kTlz5qRyDmnfsqsCdvfePwbgvX/GObccqAYe\nqt/Ie18D1NTP19TUhJTjEsmMn//859xwww0NyQhgwIABTJkypR2jyr4uXbowdOhQ3ngj6irtlVde\nYfbs2bz55psNyQhg1KhR7RViSa1cuZLKykp22WWXhmWHHHJI0f02b97MjBkzePDBBznhhBN4+OGH\nGTlyZJPbjhw5kj/84Q9tFvPW0n4x9k2gj3NuPwDn3D7A3sDLKR9XpF2NGTOm0S27urq6JrdbtWoV\nK1asYMiQISWOsPytXbuWRx55hOOPjzqSXrRoEfvss0+jX8h5ctBBBzF06FD22msvjj32WKZOncqK\nFSuK7jd37lz69u3L/vvvz7hx45g+fXqT223ZsoXZs2fzne98p61Db5D2M6SVwKnA751zzwGzgdO9\n98vSPK5Ie5s1axa1tbUNPy1plj58+HAGDRrEgAEDUoywfE2dOpWDDjqI3Xbbjb59+zJ8+PAmt3vt\ntdeoqqpiwIABnHLKKSWOsvQqKiq48847efLJJzniiCN44oknOOCAA3j11Veb3W/69Ol8//vfB+C7\n3/0uc+bM4d13321YP3/+fKqqqujZsycPP/wwP/pReo1SUu86yHv/X977Qd77g+PPmWkfU6Rc9O7d\nmz322IMFCxY0LJs/fz733nsvK1eubMfIsmvKlCk8//zzLF68GO891113HRA9e3711Vcbfpnuvffe\n1NbWct555zX6BdvRDRw4kPHjx3P33Xfz+c9/vtlnkatXr+b+++/n4osvpl+/fgwePJiNGzdy2223\nNWwzfPhwamtrWb58Ofvuu295JyQRad7555/PWWedxUsvvdSw7J///Gc7RlQe9txzT6666iouuugi\n6urq6N+/P8cccwzjxo3jvffea9guL/+WK1as4IknnmiYf/fdd1myZAl77733Nve55ZZbGD16NG++\n+SZLly5l6dKl3HHHHU3etuvevTs33HADc+bMYdGiRamcg7oOkg4nC+8LjRkzptFtumnTpgFw+OGH\n07lz54blf/7znzn11FPZYYcdOPHEE1m7di29evWia9eu/OY3vyl53IWy8L7Q1v9eAwcObNRa7uij\nj2batGlcc801TJ48mRkzZnDJJZcwZMgQOnXqRI8ePejVqxfnnHNO6rG29/tCmzZt4qKLLmLJkiV0\n796dTZs28b3vfY9jjjlmm/tMnz6dyy67rNGyr371q4wdO5aFCxd+bPvdd9+ds88+m/PPP5977723\nzc/BQsheg7aampqgEWMlqZUrV7Lbbru1dxgiudfUteicm+a9T/QLXbfsREQkE5SQREQkE5SQREQk\nE5SQREQkE5SQREQkE5SQREQkE/QeknQ88y9Np9zh5yXarF+/fnTp0qXhPSTnHBdccAGnnXYaS5Ys\nAaCyspKamhoWL17c0NPAsmXL6NatW8MQ0NOmTePmm2/moYceonfv3qxfv57ddtuN8ePHc9JJJ6Vw\ngo2tvurqVMrtdcbpibe96667uOSSS9i8eTPvv/8+u+++O/PmzWPEiBFMnDiR0aNHs2XLFk477TRe\nfPFFJk+ezJQpU6itraV79+4A/P73v+fSSy9lwYIFjd5pkuxRQhJJwdbDTxx11FGMHDmyoRuXNWvW\nsGHDBkaMGMGECROAaKyfqqoqJk6c2LDfzTff3DDcAkBtbS1jxoxh9erVdPR39bY1nELh0AgbN27k\n5JNPZv369cydO5du3boxd+5czj33XK688kpWrVrFpEmTeOCBB5SMyoBu2YmUwPLly9ljjz0a5nv2\n7Mmee+7Z4nKqqqq44ooruOyyy8jiS+1taVvDKdQnpLq6OkaPHk1lZSWzZ89uqJFOnTqVBx54gEcf\nfZQJEyZw5plncuCBB7bLOUjLKCGJpKBw+InZs2dzzjnnMG7cOA477DAmT57MY4891uqyhwwZwqpV\nq1i9enUbRpw9xYZTOOOMM9h555259dZb6dTpo5s9O+ywAzfddBPHHXccq1at4uyzz26P8KUVlJBE\nUlA4/MSxxx7LCSecwLJly5g8eTIAxxxzDFOnTm1V2R29ZlSv2HAKhx9+OA8//DAvvPDCx/Y97LDD\n2H///TnrrLOoqNCvuXKhb0qkRHr06MFxxx3H5ZdfzrXXXsutt97aqnKeeeYZevfuTe/evds4wmza\n1nAK3/rWt7jiiiv42te+Rm1t7cf2q6yspLKystThynZQQhIpgfvuu48NGzYAUQ1n0aJFzQ4LsC3P\nP/88EydOLEnv1e0tyXAK3/72t7n66qs54ogjUhsSQUpHrexESuDRRx9lypQpdOrUiRACAwYM4Oqr\nkzWrnjp1KjNmzGDDhg307t2b8847j5NPPjnliNtfc8Mp1A/nAfDNb36TiooKjjjiCObMmcPgwYPb\nMWrZHhp+Qsqehp8QyQYNPyEiIh2CEpKIiGRCqs+QnHO7An8sWNQd+CzQ23v/TprHFhGR8pJqQvLe\nvw009J/inDsb+LKSkYiIbK3Ut+zGAdNLfEzp4CoqKqirq2vvMERyra6ubrtfQk5UQzKzbsAZRLWd\nrvXLQwjHJT2Qc+6LQA/gvibWTQIaWmFUV1cnLVaEnj17smbNGtatW9feoUjOLf77P9o7hFbZ99Of\n3O4yKioq6Nmz53aVkfSW3X8C64AvApcDY4GWdsY1DrjFe79p6xXe+xqgpn6+pqYme23RJbPMrGHI\nBpH2NPP5te0dQqsMOzgbr00kTUgHhxAGmdnzIYSrzGwGcH/SgzjndgS+DRzaihhFRCQHkt7wq79B\nv8nMdggh/ANoyZ+kY4DnvPcvtSg6ERHJjaQ1pHfMrAcwB5hrZmuA5S04zjii234iIiJNSpqQ/l8I\nYbOZ/Tvwr0SNE25JehDv/RdbE5yIiORH0YRkZpXAXGBUiDq+uy31qEREJHeKPkMKIWwGupuZuhkS\nEZHUJL1l9wxwn5n9DlhfvzCEcE8qUYmISO4kTUgHxZ8/LFgWACUkERFpE4kSUghheNqBiIhIviV6\nLmRmC5IsExERaa2kDRUa1aTMrDOw/Z0fiYiIxJpNSGZ2jpm9Cwwys3fqf4j6tWtpX3YiIiLbVOwZ\n0nXALOBaYELB8nUhhHdTi0pERHKn2YQUQlgLrDWz8cCqEML7AGbW1cw+E0J4sxRBiohIx5f0GdId\nW81bE8tERERaLWlC+kR97QgghFAHdEknJBERyaOkCSmYWe/6GTP7NFEtSUREpE0k7anhSuApM7s1\nnj8RuDCdkEREJI+S9tRwk5ktAY6MF50SQng8vbBERCRvktaQAJ4A3gwhvJZWMCIikl9Juw76CvAG\nMD+ePzTu+VtERKRNJG3U8EtgGPA2QAjhGaA6raBERCR/kiakyiZu1X3Y1sGIiEh+JU1I75vZjkRj\nIGFmg4C61KISEZHcSdqo4WLgQaBv/OxoFPCvSXZ0znUBLgcOB94HnvPen9iKWEVEpANL2uz7QTN7\nBTiC6IXYC1rQ2u6XRDWrfb33wTn36daFKiIiHVlLmn2vAl4gSi5/T7KDc24HYBzQ13sfALz3ifYV\nEZF8SZSQzGwkMBNYQVRD6mNmJ4QQ5hfZdW/gHeCnzrlRRM+dfu69/2PhRs65ScCk+vnqajXgExHJ\nm6SNGn4NHB1COCSEUA0cTdSdUDGdgL2Av3rvHXAmMMs5t1vhRt77Gu993/qf/fbbrwWnICIiHUHS\nhLQlhPB0/UwIYQGwOcF+y4AtwG0A3vtFwBJgUAvjFBGRDi5pQnrQzMbaR04manXXLO/9GuCPRC3s\ncM79C/AvwP+2NmAREemYkjZq+AGwE3B9PN+ZaCTZHwIhhLBLM/tOAKY75y4jqi2N996vaG3AIiLS\nMSVNSFWtPYD3/nVgeGv3FxGRfEj6HtIbAGbWCTiQqNfvt9MMTERE8qXZZ0hmdlncTRBm1hV4mqjH\n76VmdlQJ4hMRkZwo1qjhG8CL8fQJRM+AdgOGAuenGJeIiORMsYT0QQhhSzz9FeD2EMKHIYTnaFkv\nDyIiIs0qlpA6mdkn4umhRKPG1uuaTkgiIpJHxWo5/w3MN7N3iHrqfhrAzD4LrE05NhERyZFmE1II\n4SIzexHoS3S7LsSregAXpB2ciIjkR9HnQCGEO5tY9mw64YiISF4l7TpIREQkVUpIIiKSCUpIIiKS\nCc0+QzKzLzW3PoTwWNuGIyIieVWsUcPl8WclUQerrxMNYb43UAsckl5oIiKSJ83esgshHBpCOJQo\n+RweQtgnhNAf+BqwsBQBiohIPiR9huRCCA/Vz4QQ5gGHphOSiIjkUdKEtNnMGsY0MrMvE3W0KiIi\n0iaSdpB6GnC7mW0s2G9MOiGJiEgeJR2g70kz2xsYGC96KYSwsbl9REREWqIl7yEdDXwjhPAC0Kt+\n4D4REZG2kKiGZGYXETVi2Bv4D6Km39cDXyy2r3NuKfABUBcvutR7P6s1wYqISMeV9BnSMUTvHHmA\nEMJbZrZjC44zxntf29LgREQkP5LesqsLIWzeapm1dTAiIpJfSWtIb5jZMCCYWWfgp0QvyyZ1q3MO\nYAFwrvd+dcvCFBGRji5pQjoTuBkYBPwTmA+cmHDfL3nvlznnOgO/iMs5snAD59wkYFL9fHV1dcKi\nRaQ9THtocWpln/XVfVMrO824Zfslbfa9EjjCzLoDFkL4Z9IDeO+XxZ8bnXO/Bj72P8J7XwPU1M/X\n1NSErbcREZGOLdEzJDNbABBC2FCfjOqXNcc5t4NzbueCRScAi1oTqIiIdGxJb9k12i5+jvTJBPvt\nBtzpnKskagTxOnByiyIUEZFcKDYe0jnAucCOZvZOwapuwC3FCvfevw7ogZCIiBRVrIZ0HTALuBaY\nULB8XQjh3dSiEhGR3Gk2IYUQ1gJrga+XJhwREcmrpF0H9QYuBA4GutYvDyFoxFgREWkTSXtqmA4s\nBXoCFwB/A+5PKSYREcmhpAnpMyGEy4APQgj3AscBo9ILS0RE8iZpQvow/nzfzHYFNhHVlkRERNpE\n0veQFseJ6HfA08A64NnUohIRkdxJ2nVQfb91V5jZs8DOwAOpRSUiIrmTtIbUIITwpzQCERGRfCvW\nU8O7RKPDfmwVEEIIu6QSlYiI5E6xGlJVSaIQEZHcK9ZTwxulCkRERPItaU8NS2ji1l0I4bNtHpGI\niORS0kYNRxVMdwVOAt5u+3BERCSvkjb7fnGrRc+a2ZPAxW0fkoiI5FHSnhoaiV+S/XQbxyIiIjmW\n9BnSIj56hlQJ7AX8/7SCEhGR/En6DGliwfQm4PUQwlspxCMiIjmV9BnSo2kHIiIi+Zb0lt3+ROMg\n9S/cJ4RwUEpxiYhIziS9ZXc7cAvwG2Bzaw7knDsFuBE41nt/d2vKEBGRjitpQtocQvhVaw/inOsH\n/BD4c2vLEBGRji1ps+/5Zval1hzAOVcB3ACcAXzQmjJERKTjS5qQ7gDuN7O/mdnrZrbEzF5PuO8k\n4AnvvQb0ExGRbUp6y+4m4MeApwXPkJxzBwLHA83Wrpxzk4gSFwDV1dVJD9Eqq6+6OrWye51xempl\nS8cy7aHFqZbfpde8FEsflVrJaf+7SHYlTUjrQwg3tqL8YUA/4BXnHES9O/zWOdfHe39t/Ube+xqg\npn6+pqamqTGYRESkA0uakO43s2+EEO5tSeFx0mlIPM65R4Bfq5WdiIhsLWlCOgPYyczqiBomaMRY\nERFpU0kTUpuMHOu9/0pblCMiIh1P0q6DNHKsiIikqtmEZGb/FUI4YavevhuEEA5JLTIREcmVYjWk\n+t4ZJja7lYiIyHZqNiGFEJ6NPxt6+zaznUMI76UdmIiI5EuzPTWY2UQz2y+erjCze4F3zGy1mX2h\nJBGKiEguFOs66AfAa/H0t4B9gD7AWOCy9MISEZG8KZaQNoUQPoynRwK3hhBWhhDuBz6ZbmgiIpIn\nxRJSJzOzePow4MmCdZ3TCUlERPKoWCu7PwKzzGwVUY3oTwBm9mk0lISIiLShYjWkycDTwEbgiBDC\npnh5fwo6QxUREdlexZp9bwIub2L546lFJCIiuZR0gD4REZFUKSGJiEgmFHsx9qvx56dKE46IiORV\nsRrSL+PPR1KOQ0REcq5Ys+/OZnYO0NvMztx6ZQjhynTCEhGRvCmWkH4IfA/oBlRvte5jw1GIiIi0\nVrFm308DT5vZGyEE9V0nIiKpSTpi7GVm9jlgVLzowRCCTy8sERHJm0TNvs3sVOAOoDfQC7jTzH6Q\nZmAiIpIviWpIwOnA4BDCagAz+w+ifu5uKLajc+5B4NPAFuAfwJne+0WtC1dERDqqpAmJ+mRUP/1R\nJ+BFfdt7/x6Ac+5YYAZwcAtiFBGRHEjaU8MrZnaJme0Z/1wMvJJkx/pkFNsJtc4TEZEmJK0hTQCu\nAhYSJZR5wL8lPYhz7hZgeDx7ZBPrJwGT6uerq7duYS4iIh1d0lZ2q4HvtPYg3vuTAZxz3yMa+vzI\nrdbXUDCcRU1NjWpRIiI5U9LOVb33NwPDnXO7lvK4IiKSfakmJOfczs653QvmRwNvA++keVwRESk/\niVvZtdJOwH8757oRNfteDRzlvdctORERaaRoQjKzSmBuCGFUsW235r1/A/hcawITEZF8KXrLLoSw\nGehuZhrMT0REUpP0lt0zwH1m9jtgff3CEMI9qUQlIiK5kzQhHRR//rBgWQCUkEREpE0kfQ9pePGt\nREREWi9pb9+dzGyymV0Tz+9tZiPSDU1ERPIk6S27q4FKYGg8/zYwC3BpBCUiIvmTNCF9PoRQZWaL\nAEII75lZ5xTjEhGRnEnalPv9wpn43SQ1AxcRkTaTNKk8b2YnAhVmtg9wHfBIalGJiEjuJE1Ik4Bh\nRCO/PknUDdA5aQUlIiL5k7TZ93pgfPwjIiLS5hIlJDPrApwFjCJ6IfYh4IoQwgcpxiYiIjmStJXd\ndcCuRKPGApwCDAS+n0ZQIiKSP0kT0heA/UIIAcDM7gNeTC0qERHJnaSNGt4GuhXMdwHWtH04IiKS\nV83WkMzszHjyJeBpM/t9PP9Noh7ARURE2kSxW3bVBdMe+Gw8vZCoKyEREZE20WxCCiGcUqpAREQk\n35I2asDMvg70L9wnhFCTRlAiIpI/Sd9DmgnsBywCNseLQ1pBiYhI/iStIR0CHBBC2Fx0ywLOua7A\n7cD+QB2wCvg37/2rLYpSREQ6vKTNvpcSNfVujd8CA7z3BwP/A9zQynJERKQDS1pDmgzMM7NHKBiK\nIoRwUXM7ee/fB+YULPozcHYLYxQRkRxImpAuBT4EugLbMzDfj4lqSY045yYR9SgOQHV19dabtK2l\nj6dY+Okpli2ldtKdF7d3CK32hV67tncIIi2SNCENCCEM2J4DOed+CuwDjNx6nfe+BmhosVdTU6MG\nEyIiOZP0GdLLZvap1h7EOXc2cBzwde/9htaWIyIiHVfSGlIdsNDMHqTxM6RJ294lEt+OOwEY5b1/\nr1VRiohIh5c0If01/mkR51xf4HLgdWC+cw7gA+/9kJaWJSIiHVvSEWMvbE3h3vvlgLVmXxERyZek\nPTWc39TyYs2+RUREkkp6y+6TBdNdgSOBp9o+HBERyaukt+ymFM6b2c+BGSnEIyIiOZW02XcjIYS3\n+WhsJBERke2W9BnSmQWzlcDngL+nEpGIiORS0mdIhX35bAJqiTpNFRERaRNJnyFp5FgREUlVswnJ\nzL7U3PoQwmNtG46IiORVsRrS5U0sC8DuQB+i50kiIiLbrdmEFEI4tHDezHYBfgacCFyQYlwiIpIz\niZp9m1lXMzuPj/qz2y+E8Iv0whIRkbxpNiGZWYWZnQq8AgwEhoQQJsXvIYmIiLSZYs+Q/gJ0AX4K\nPAfsZGYH1a8MITyfYmwiIpIjxRJSd6JGDE11ohpQbw0iItJGijVq6FeiOEREJOda1ZediIhIW1NC\nEhGRTFBCEhGRTFBCEhGRTEja23erOeeuBI4G9gKqvfe1aR9TRETKTylqSHcAQ4E3SnAsEREpU6nX\nkLz3jwE459I+lIiIlDE9QxIRkUxIvYaUhHNuEjCpfr66urqZrbffXz4cnFrZw1MrWaRlnnotvS4n\nD/lUakVLjmUiIXnva4Ca+vmamprQjuGIiEg70C07ERHJhNQTknPueufccqAvMNc592raxxQRkfJT\nilZ249M+hoiIlD/dshMRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIR\nkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQ\nQhIRkUxQQhIRkUxQQhIRkUzolPYBnHP9gZuBnsBaYKz3/sW0jysiIuWlFDWk64Hfeu/3BS4DZpTg\nmCIiUmZSTUjOud6AA34XL7oT+Ixzbp80jysiIuUn7RrSZ4C3vPebALz3AVgG7JnycUVEpMyk/gwp\nCefcJGBSwaIXZs6cOa+94knoEGDhx5a635c+ku3X9LmUJ51LCfwv/9PSXTJ7Lq3Q4c7ltvNSPcZe\nSTe0EEJqUcS37F4FdvHeb3LOGfAWMNR7/2pqBy4B59xy733f9o6jLehcsknnkk06l/SkesvOe7+K\n6C+JE+NFxwPLyz0ZiYhI2yvFLbvxwAzn3E+BdcApJTimiIiUmdQTkvf+ZeALaR+nHdS0dwBtSOeS\nTTqXbNK5pCTVZ0giIiJJqesgERHJBCUkERHJhEy8h5QVSfvdc84dBfwKqAReiLdbF68bAvwW6AYs\nB07y3q8ozRk0irHouTjnBgG/AXoDm4AFwGne+7p4fQD+AmyOdznDe/94ac6gsYTn0w94jeg7qXe8\n9/61eH05fTeHE3W1Va838Hfv/SHx+nb/bpxzVwJHE71nUu29r93GduVwvRQ9l3K5XhKeSz8yeK2o\nhtRY0X73nHM7AtOB0d77/sDfgH+P11UAtwET4zLmAL8uTegfk6QPwfeB0733A4GDgR2Ac7baZpj3\nvir+aZdkFEvaJ+I/CuKtKrjAyuq78d7PLTwPotcnbttqs/b+bu4AhgJvbGuDMrpeip4L5XO9JDkX\nyOC1ooQUa0G/e18HFnnvX4rnrwFOiKcHA5u89/Pj+euBbzjnuqYX+cclPRfv/Sve++fj6c3AM0C/\nEoaaSBv1iVhW381W++wOjARuTT/C5Lz3j3nvlxfZLPPXCyQ7l3K5XhJ+L81pt+9FCekjSfvd25PG\nf3ksBfo45zptvc57/w+id692Ty/sJrW4D0Hn3A7AD+BjfcLMd84955yribdpDy05nx2cc8865xY6\n5853zlXGy8v2uwHGAnPiF80LZeG7KaYcrpcWy/j1klTmrhUlJME59wlgFvCg9352waq9vPfVwBeB\nXsDU9oivBd4C9vDeDwZGAcOAye0b0vaJu9v6PtFtr0Ll9t10GB3kesnktaKE9JE3+egvt/pfBHsS\n/fVaaBmNOwvsx0d/8TZa55z7JLAT0X3zUkp6LjjnOhNdXG8BPy5c571fFn/+k+hWy7B0w96mROfj\nvf+gvhbhvX8HuJGPYi677yb2ZaArMLdwYYa+m2LK4XpJrEyul6Kyeq0oIcVa0O/eA8AhzrmB8fyP\ngNvj6WeBzs654fH8eOBe7/376UX+cUnPJf6leDvwDnBqfPuofl0P51z3eLoCGAMsKkH4H9OC8+kd\n/8LAOdcFOI6PYi6r76bAOGBG/MwCyNZ3k0Dmr5ekyuV6SSKr14oSUmPjgfHOucXAucT97jnnLnLO\nTYCG+6k/AO52zr0K9AUujtdtIfpFc0VcxlHAWSU/i0jRcyG6aI4jesi+yDlX65z7TbxuIPBn59xz\nRE1DdwWw548yAAACvElEQVQmlvIEtpLkfIYSncdzRL/0/w5cAmX53eCc24no+7lxq/0z8d045653\nzi0nugbmxtdDWV4vSc6FMrleEp5LJq8VdR0kIiKZoBqSiIhkghKSiIhkghKSiIhkghKSiIhkghKS\niIhkghKSSBFmttTMXjaz2vjz3FaUcZSZPVJkm5+bWZOdWJrZ0WY2rWD+QjN7ycyeNrN+Zjahqf1E\nyomGnxBJZkwIodbM9gD+amYPhxAWlOrgIYR7gHsKFv0E+GwI4S0z+wowAbiuVPGIpEE1JJEWCCGs\nAF4i7lrFzE6KaykLzewxMzs4Xt7ZzK4xs1fMbAFQ/9Y7ZtbfzJ4ws+fM7AUz+0XBIfqY2b1m9lcz\ne9jMdon3GWtmd8fTTxJ1J/SgmV1JlIgGxDW4wqQlUlZUQxJpATMbSPQW/iNmdhjRUApfCiF8YGbD\ngJnAAcCpwIB4Ghr3RXc6cF8I4dK4zF0K1g0BBocQ3jaz24l6dbi0MIYQwhfNLADDQgjvxTWkX4cQ\nqtr4dEVKSglJJJlZZraFKMmcFUJYbWZTiAZqe9rM6rfbxcy6EY1fdEsI4UMAM7uRqF86gMeAqWa2\nI/AoMK/gOA+EEN6Op58CBqV5UiJZolt2IsmMCSHsB3wN+KWZDQIMuDmEUFXw0yeEUNfE/g19dIUQ\n7gQOA14mri0VbFfYgeVm9Eej5IgSkkgLhBDmAdcCvyBqZHCime0JYGYVZubiTefF6zqb2SeIO1CN\nt+sPrAwh3ELUOOHz2xnWOqLhAUTKmhKSSMtdTNRb8gaihDLbzJ4DXgS+E2/zn8ArwF+BPwG1Bft/\nE3jBzBYRja2zvU22nwdeNLO/qFGDlDP19i0iIpmgGpKIiGSCEpKIiGSCEpKIiGSCEpKIiGSCEpKI\niGSCEpKIiGSCEpKIiGSCEpKIiGSCEpKIiGTC/wHoYrJHE2foTAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEKCAYAAAAfGVI8AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAH+BJREFUeJzt3Xt8FeW1//HPSggCDQiVIAhF8IhUlIoYRbH1YC2Wo4gU\nUUTr/UjlohRFLqKgP7y+ELQVrUVrhSMiVYq11ks9LWqtdyJHRaooogZBEMGAiiCs3x+zkyaY7AzZ\ne2aHzPf9eu1X9syemWdl3Lgy8zyzHnN3REQkufJyHYCIiOSWEoGISMIpEYiIJJwSgYhIwikRiIgk\nnBKBiEjCKRGIiCScEoGISMIpEYiIJFyjXAcQRuvWrb1Tp065DkNEZLeyePHiT929qLbtdotE0KlT\nJ1599dVchyEislsxsw/CbKdbQyIiCadEICKScEoEIiIJt1v0EUiybNu2jdLSUrZs2ZLrUER2C02a\nNKFDhw4UFBTUaX8lAql3SktLad68OZ06dcLMch2OSL3m7qxfv57S0lI6d+5cp2Po1pDUO1u2bGGv\nvfZSEhAJwczYa6+9MrqCViKQeklJQCS8TP+9KBGIiCSc+gik3rvlqXeyerwxfQ+odZv8/Hy6d+9e\nsXz66aczYcIE+vTpw80330xxcXGV7V9++WXGjRvHqlWraN68Oe3atePGG2+scoyo3bHkjqweb0SP\nEbVuU1hYyObNm6usu/rqq7nrrrsoKipi69atXHXVVQwdOrTi8xkzZjBr1iwKCgrIy8vjuOOO46ab\nbqpzR2dtXv7ziqwe74iT9qt1m+uuu47777+f/Px88vLy+O1vf8v48eMrvjvvv/8+xx9/PNdeey3j\nx4/nxRdfpG3btgCMHDmSDh06MHHixKzGnY4SgUg1mjZtypIlS0Jt+8knn3Daaadx//3307t3bwCe\ne+453nvvvVgTQX0yZswYxo4dy/LlyznssMMYPHgwBQUF3Hnnnfz1r3/lxRdfpGXLlmzdupUZM2bw\n1VdfRZYI4vbCCy/w6KOPUlJSwh577MGnn37K1q1bKz4vLS2lX79+TJ8+nQEDBrBhwwbGjh3Lfffd\nR0lJCf/4xz9YvHhxrDErEYhkaObMmZxzzjkVSQDghz/8YQ4jqj+6dOlCs2bN2LBhA23atOG6667j\n2WefpWXLlgA0btyYCRMm5DjK7Fq9ejWtW7dmjz32AKB169ZVPjv77LO57rrrGDBgAADDhg1j9uzZ\nLFq0iCuuuIKZM2fGnhTVRyBSja+++ooePXpUvObPn1/jtkuXLqVnz54xRrf7KCkpoUuXLrRp04ay\nsjI2b95c5yGOu4vjjz+ejz76iAMOOIARI0bwzDPPVHx2zjnnMGrUKAYPHlyxLi8vj9/85jeccsop\ndO3alWOOOSb2mJUIRKpRfmuo/DVkyJDQ+/bq1YsDDzyQ0aNHRxhh/XbLLbdw0EEH0atXLyZNmlTt\nNk8++SQ9evSgU6dOPP/88zFHGJ3CwkIWL17MrFmzKCoqYsiQIdx7770A/OQnP+G+++7jyy+/rLJP\njx49OPjggxkxovZ+mSgoEYhk6KCDDqKkpKRi+aWXXmLq1Kl8/vnnOYwqt8aMGcPSpUtZsGABF1xw\nAVu2bKFFixYUFhby/vvvA/DTn/6UJUuWcPDBB1e5h94Q5Ofn06dPH6655hpmzpzJggULABg3bhyH\nH344p556Kt98802VffLy8sjLy83/kiNr1czuMbO1ZvZmpXXTzOxfZva6mS00s5ZRtS8Sl5EjR3Lv\nvfdW+at257/4kmrAgAEUFxcze/ZsACZOnMjw4cPZuHEjEDwV29BKibz99tssX768YnnJkiXsu+++\nFcu33norLVq04IILLsDdcxHit0TZWXwvMBOYU2ndU8BEd//GzG4CJgLjI4xBGoAwwz2zrbyPoFy/\nfv248cYbATjxxBMrOvOOOuooHnzwQebPn8/48eNZtWoVbdq0oXXr1kyePDnWmMMM98y2L7/8kg4d\nOlQsX3rppd/aZvLkyZxxxhlceOGFDB8+nC+++IJevXqxxx57UFhYyNFHH82hhx4aWYxhhntm0+bN\nm7n44ovZuHEjjRo1Yv/992fWrFkV/QJmxuzZs+nfvz/jxo1j2rRpscZXHYsyI5lZJ+BRdz+4ms9+\nBgx29zNrO05xcbFrYprkWLZsGQceeGCuwxDZrVT378bMFrt7cQ27VMhlH8H5wOM5bF9ERMhRIjCz\nScA3wNw02wwzs1fN7NV169bFF5yISMLEngjM7FygP3Cmp7kv5e6z3L3Y3YuLimqde1lEROoo1ieL\nzawfMA74T3fXsAoRkXogyuGj84AXgK5mVmpmFxCMImoOPGVmS8zszqjaFxGRcCK7InD3odWs/l1U\n7YmISN2o6JzUf4tuyO7xjq29vO/OZagffvhh2rRpw4UXXsjrr7+Ou9OyZUvmzp3LySefDMCaNWvI\nz8+nvE/r5ZdfpmnTpnTv3p1t27bRqFEjzj77bMaMGRPJE6TrbpuZ1eMVXTwq1HalpaWMHDmSt956\ni+3bt3PCCScwffp0tm/f/q3z9cQTT1BYWFhlnx07dtC/f3+mTZtG48aNs/o7ADz/YI1jUuqk96m1\njnj/VhnqVq1asWHDBjZv3sy6desq6i3dcccd9O7dm08//ZR27dpx2223cdFFF1Ucp1OnTjRv3hwz\no1WrVsyZM6fKw2nZokQgUo3qylDfcMMN7L333rzxxhtA8ARp27ZtK7a7+uqrKSwsZOzYsdUeZ+3a\ntZxxxhmUlZVxzTXXxPSbRMvdGTRoEMOHD+dPf/oT27dvZ9iwYYwbN462bdt+63wVFBTUuM+kSZPq\nxcNVmaqpDPU+++zD008/zc0338yjjz5aZZ8HH3yQI488knnz5lVJBACLFi2idevWTJkyhWuvvZa7\n7ror6zGr1pBISKtXr6Z9+/YVy127dq0oNRxGmzZtmDVrFjNnzqw3pQUy9fe//50mTZpw3nnnAcGV\n1C233MKcOXNYvnx5teerpn3uueeeBlGao7oy1Pvss0/afebNm8f06dNZtWoVpaWl1W5z1FFHsWrV\nqqzHC0oEItWqXIb6Zz/7GQDnn38+N910E0cddRRXXnlllXoyYe23335s376dtWvXZjvknFi6dCmH\nHXZYlXUtWrSgU6dOXHLJJdWer5r26dixI++++25ssUclXRnq6nz00UesXr2aI444gtNOO63GkudP\nPPEEAwcOjCJkJQKR6lQuQ71w4UIgKBW8YsUKLr/8cj777DMOP/xwli1bluNI67cknq90ZairM3/+\nfE477TQgmBJ13rx5VT4/9thjad++PY8//niVKT+zSX0EIrugsLCQQYMGMWjQIPLy8njsscd2qS7S\nihUryM/Pp02bNhFGGZ9u3brx0EMPVVlXVlbGmjVr6Nq1K02bNv3W+TrkkEOq3efDDz9k//33jzP8\nyJSXoe7Tpw/du3dn9uzZnHvuudVuO2/ePNasWcPcuUGn9scff8zy5cvp0qULEPQRtGzZkjPPPJMp\nU6YwY8aMrMerKwKRkP75z3+yYcMGALZu3cpbb721SyM41q1bx0UXXcSoUaMws6jCjNVxxx3Hl19+\nyZw5QZHh7du3c9lllzFq1ChKSkqqPV817XPuuefSrFmznP0u2VJbGerK3nnnHTZv3syqVatYuXIl\nK1euZOLEid+6KmjUqBG33norc+bM4bPPPst6zLoikPovxHDPOLz33nsMHz4cd2fHjh2ceOKJnHLK\nKWn3Ke9rKB8+etZZZ1Vbqjkbwg73zCYzY+HChYwcOZKpU6eybt06hgwZwqRJk5gzZ06156t8nxEj\nRjB16lR27NjBCSecwPXXXx9JjGGGe2ZTTWWoqzNv3ryKPqhyp5xyCkOGDPlWGfN27doxdOhQbr/9\ndq666qqsxhxpGepsURnqZFEZ6t3X888/z9ChQ1m4cKHmcY5ZJmWodUUgIlnTu3dvPvjgg1yHIbtI\nfQQiIgmnRCD10u5wy1Kkvsj030utt4bMrAtwA9ANaFKp4XgnApXEaNKkCevXr2evvfZqMKNr4vJJ\nWbiJ4Pdu0aT2jWS34O6sX7+eJk3q/t80TB/B74EpwC3AscB56EpCItShQwdKS0vRzHS7ruyrbaG2\n+6xpQcSRSJyaNGlChw4d6rx/mETQ1N3/Zmbm7h8AV5vZYmBybTuK1EVBQUFFdUbZNbc89U6o7cb0\nPSDiSGR3EiYRfG1mecByMxsFrAIKow1LRETiEuYWz2igGXAJcBjwc+CcKIMSEZH4pL0iMLN8YIi7\njwU2E/QPiIhIA5L2isDdtwM/jCkWERHJgTB9BK+Z2SPAg8AX5Svd/Y+RRSUiIrEJkwiaAOuBH1da\n54ASgYhIAxAmEdzt7v+svMLMjo4oHhERiVmYUUO3hVwnIiK7oRqvCMzsKKA3UGRmlQuotwDyow5M\nRETike6KoDHBg2ONgOaVXmXA4NoObGb3mNlaM3uz0rrvmtlTZrY89bNVZuGLiEimarwicPdngGfM\n7N5UaYlddS8wE5hTad0E4G/ufqOZTUgtj6/DsUVEJEvC9BHcbWYtyxfMrJWZPVnbTu7+LLDz5Jon\nA7NT72cDA8MGKiIi0QiTCFq7+8byBXffALSpY3t7u/vq1Ps1wN51PI6IiGRJmESww8w6li+Y2b4E\nzxFkxIOZFGo8jpkNM7NXzexVlSMWEYlOmOcIJgHPmdkzgAE/AobVsb1PzKydu682s3bA2po2dPdZ\nwCwIJq+vY3siIlKLWq8I3P0JoCcwH3gAOMzda+0jqMEj/Lty6TnAn+p4HBERyZJaE4EFcwX2A3q6\n+6NAMzM7IsR+84AXgK5mVmpmFwA3An3NbDnwk9SyiIjkUJhbQ3cAOwhqDf0/YBOwADg83U7uPrSG\nj47blQBFRCRaYRJBL3fvaWavQTBqyMwaRxyXiIjEJMyooW2pCWocwMyKCK4QRESkAQiTCH4NLAT2\nNrPrgOeA6yONSkREYlPrrSF3n2tmi/n3vf2B7r4s2rBERCQuYfoIIJi8vvz2UNPowhERkbiFGT46\nmaAu0HeB1sDvzezKqAMTEZF4hLkiOBM4xN23AJjZjcAS4NooAxMRkXiE6Sz+mGDe4nJ7AKuiCUdE\nROIW5orgc2CpmT1F0EfQF3jZzH4N4O6XRBifiIhELEwiWJh6lXs6mlBERCQXwgwfnQ1gZgXAwcAq\nd6+xaqiIiOxeauwjMLM7zeyg1Ps9gf8jmHbyNTOrqY6QiIjsZtJ1Fv/I3Zem3p8HvOPu3YHDgHGR\nRyYiIrFIlwi2VnrfF3gYwN3XRBqRiIjEKl0i2Ghm/c3sUOBo4AkAM2uEni4WEWkw0nUW/4Kg4Fxb\n4JeVrgSOA/4SdWAiIhKPGhOBu79DMDPZzuufBOo6VaWIiNQzYZ4sFhGRBkyJQEQk4ZQIREQSrsY+\nAjO7NN2O7j4j++GIiEjc0o0aap762RU4HHgktXwS8HKUQYmISHzSjRq6BsDMngV6uvum1PLVaPio\niEiDEaaPYG+qPmW8NbVOREQagDBlqOcQzD9QXop6IMHUlXVmZmOA/yaY3+AN4LzyGdBERCRetV4R\nuPt1BEXnNqRe57n79XVt0MzaA5cAxe5+MJAPnF7X44mISGbCDh9tBpS5+6+AUjPrnGG7jYCmqbpF\nzQimwxQRkRyoNRGY2RRgPDAxtaoAuK+uDbr7KuBm4ENgNfC5u/+1rscTEZHMhOkj+BlwKFAC4O4f\nm1nz9LvUzMxaAScDnYGNwINm9nN3v2+n7YYBwwA6duxY1+aq9fKfV4Ta7oiT9stquyJ1dctT7+Q6\nBGnAwtwa2uruTtCxi5l9J8M2fwK87+7r3H0b8Eeg984bufssdy929+KioqIMmxQRkZqESQR/MLPf\nAi3N7ELgf4G7M2jzQ+BIM2tmZkZQ1npZBscTEZEMhJm8/mYz6wuUETxlPNndn6prg+7+kpk9RHCr\n6RvgNWBWXY8nIiKZqTURmNlN7j4eeKqadXXi7lOAKXXdX0REsifMraG+1az7r2wHIiIiuZGu+uhw\nYASwn5m9Xumj5sA/ow5MRETike7W0P3A48ANwIRK6ze5+2eRRiUiIrFJV330c+BzYCiAmbUBmgCF\nZlbo7h/GE6KIiEQpzJPFJ5nZcuB94BlgJcGVgoiINABhOouvBY4E3nH3zgTj/l+MNCoREYlNmESw\nzd3XA3lmlufui4DiiOMSEZGYhKk1tNHMCoFngblmthb4ItqwREQkLmGuCE4GvgLGAE8A7xHMWywi\nIg1AmBITlf/6z2hmMhERqX/SPVC2iVTF0Z0/AtzdW0QWlYiIxCbdcwR1nnNAROq3sPMbjOl7QMSR\nSH0QpuhctbPC6IEyEZGGIcyoob9Uet+EYGaxt4GDIolIRERiFaazuHvlZTPrSVCMTkREGoAww0er\ncPcSoFcEsYiISA6E6SO4tNJiHtAT+DiyiEREJFZh+ggqjx76hqDPYEE04YiISNzC9BFcE0cgIiKS\nG2FuDRUDk4B9K2/v7j+IMC4REYlJmFtDc4HLgTeAHdGGIyIicQuTCNa5+yORRyIiIjkRJhFMMbO7\ngb8BX5evdPc/RhaViIjEJkwiOA/4PlDAv28NOaBEICLSAIRJBIe7e9dsNmpmLYG7gYMJksr57v5C\nNtsQEZFwwjxZ/LyZdctyu78CnnD37wOHAMuyfHwREQkpzBXBkcASM3ufoI+gfD6COg0fNbM9gWOA\ncwkOtBXYWpdjiYhI5sIkgn5ZbrMzsA74vZkdAiwGRu80E5qIiMQk3QxlLdy9DNgUQZs9gYvd/SUz\n+xUwAbhqp/aHAcMAOnasdkoEkVhpMhdpqNL1Edyf+rkYeDX1c3Gl5boqBUrd/aXU8kMEiaEKd5/l\n7sXuXlxUVJRBcyIikk66qSr7p352zmaD7r7GzD4ys67u/jZwHPBWNtsQEZHw0t0a2hfY6O6fp5aP\nBQYCK4HbU528dXUxMNfMGgMrCJ5VEBGRHEh3a+gPwHcAzKwH8CDwIdADuCOTRt19Seq2zw/cfaC7\nb8jkeCIiUnfpRg01dffyCWh+Dtzj7tPNLA9YEn1oIiISh3RXBFbp/Y8Jag3h7qpAKiLSgKS7Ivi7\nmf0BWA20Av4OYGbt0ANgIiINRrpE8EtgCNAO+KG7b0utb0swUY2IiDQA6YaPOvBANetfizQiERGJ\nVZiicyIi0oApEYiIJFyNicDM/pb6eVN84YiISNzSdRa3M7PewAAze4Cqw0lx95JIIxMRkVikSwST\nCSqCdgBm7PSZEzxbICIiu7l0o4YeAh4ys6vcfWqMMYmISIxqnZjG3aea2QCCWcUAnnb3R6MNS6Rm\nDWlegLC/i0iUah01ZGY3AKMJSkW/BYw2s+ujDkxEROIRZqrKE4Ee5TWGzGw28BpwRZSBiYhIPMI+\nR9Cy0vs9owhERERyI8wVwQ3Aa2a2iGAI6TEEcwyLiEgDEKazeJ6ZPQ0cnlo13t3XRBqViIjEJswV\nAe6+Gngk4lhERCQHVGtIRCThlAhERBIubSIws3wz+1dcwYiISPzSJgJ33w68bWYdY4pHRERiFqaz\nuBWw1MxeBr4oX+nuAyKLSkREYhMmEVwVeRQiIpIzYZ4jeMbM9gW6uPv/mlkzID/Ths0sH3gVWOXu\n/TM9noiI1E2YonMXAg8Bv02tag88nIW2RwPLsnAcERHJQJjhoyOBo4EyAHdfDrTJpFEz60BQzO7u\nTI4jIiKZC5MIvnb3reULZtaIYIayTNwKjAN2ZHgcERHJUJjO4mfM7AqgqZn1BUYAf65rg2bWH1jr\n7ovNrE+a7YYBwwA6dszy6NWVz4XccL/stptQZy0IN8Hd/5wSblxCSdn8kC2HO162J4fRZDOyuwlz\nRTABWAe8AfwCeAy4MoM2jwYGmNlK4AHgx2Z2384bufssdy929+KioqIMmhMRkXTCjBrakZqM5iWC\nW0Jvu3udbw25+0RgIkDqimCsu/+8rscTEZHM1JoIzOxE4E7gPYL5CDqb2S/c/fGogxMRkeiF6SOY\nDhzr7u8CmNl/AH8BMk4E7v408HSmxxERkboL00ewqTwJpKwANkUUj4iIxKzGKwIzG5R6+6qZPQb8\ngaCP4FTglRhiExGRGKS7NXRSpfefAP+Zer8OaBpZRCIiEqsaE4G7nxdnICIikhthRg11Bi4GOlXe\nXmWoRUQahjCjhh4GfkfwNLFKQoiINDBhEsEWd/915JGIiEhOhEkEvzKzKcBfga/LV7p7SWRRiYhI\nbMIkgu7AWcCP+fetIU8ti4jIbi5MIjgV2K9yKWoREWk4wjxZ/CbQMupAREQkN8JcEbQE/mVmr1C1\nj0DDRxMsipr7YectCEvzAoiEEyYRTIk8ChERyZkw8xE8E0cgIiKSG2GeLN7Ev+cobgwUAF+4e4so\nAxMRkXiEuSJoXv7ezAw4GTgyyqBERCQ+YUYNVfDAw8BPI4pHRERiFubW0KBKi3lAMbAlsohERCRW\nYUYNVZ6X4BtgJcHtIRERaQDC9BFoXgIRkQYs3VSVk9Ps5+6e3ad/REQkJ9JdEXxRzbrvABcAewFK\nBCIiDUC6qSqnl783s+bAaOA84AFgek37iYjI7iVtH4GZfRe4FDgTmA30dPcNcQQmIiLxqPE5AjOb\nBrwCbAK6u/vV2UgCZvY9M1tkZm+Z2VIzG53pMUVEpO7SPVB2GbAPcCXwsZmVpV6bzKwsgza/AS5z\n924ETyiPNLNuGRxPREQykK6PYJeeOg7L3VcDq1PvN5nZMqA98FYU7YmISHqR/M8+LDPrBBwKvJTL\nOEREkizMk8WRMLNCYAHwS3f/1q0mMxsGDAPo2LFjVtv+4IM3Q213RFZblfqqpGx+qO16thgScST1\nT7Yn9xnT94CsHk+yIydXBGZWQJAE5rr7H6vbxt1nuXuxuxcXFRXFG6CISILEnghSpax/Byxz9xlx\nty8iIlXl4orgaOAs4MdmtiT1OiEHcYiICDnoI3D35wCLu10REaleTkcNiYhI7ikRiIgknBKBiEjC\nKRGIiCScEoGISMIpEYiIJJwSgYhIwikRiIgknBKBiEjCKRGIiCScEoGISMLlbD4CqZ/uWHJHqO1K\nytaHPuaP/vZ6qO3+cdwPQh8zjLDzDEjm9n9sXrgN+06JNpB6aN1tM0NtV3TxqIgjqZmuCEREEk6J\nQEQk4ZQIREQSTolARCThlAhERBJOiUBEJOGUCEREEk6JQEQk4ZQIREQSTolARCThlAhERBJOiUBE\nJOFykgjMrJ+ZvW1m75rZhFzEICIigdgTgZnlA7cD/wV0A4aaWbe44xARkUAurgiOAN519xXuvhV4\nADg5B3GIiAi5SQTtgY8qLZem1omISA6Yu8fboNlgoJ+7/3dq+Sygl7uP2mm7YcCw1GJX4O0YwmsN\nfBpDO/WdzkNA50HnoNzueh72dfei2jbKxQxlq4DvVVrukFpXhbvPAmbFFRSAmb3q7sVxtlkf6TwE\ndB50Dso19POQi1tDrwBdzKyzmTUGTgceyUEcIiJCDq4I3P0bMxsFPAnkA/e4+9K44xARkUBOJq93\n98eAx3LRdi1ivRVVj+k8BHQedA7KNejzEHtnsYiI1C8qMSEiknCJTAS1lbiwwK9Tn79uZj1zEWfU\nQpyHPmb2uZktSb0m5yLOKJnZPWa21szerOHzpHwXajsPSfgufM/MFpnZW2a21MxGV7NNw/w+uHui\nXgQd1O8B+wGNgf8Duu20zQnA44ABRwIv5TruHJ2HPsCjuY414vNwDNATeLOGzxv8dyHkeUjCd6Ed\n0DP1vjnwTlL+35DEK4IwJS5OBuZ44EWgpZm1izvQiKnUB+DuzwKfpdkkCd+FMOehwXP31e5eknq/\nCVjGt6seNMjvQxITQZgSF0kogxH2d+ydugR+3MwOiie0eiUJ34WwEvNdMLNOwKHASzt91CC/DzkZ\nPiq7jRKgo7tvNrMTgIeBLjmOSXIjMd8FMysEFgC/dPeyXMcThyReEYQpcRGqDMZurtbf0d3L3H1z\n6v1jQIGZtY4vxHohCd+FWiXlu2BmBQRJYK67/7GaTRrk9yGJiSBMiYtHgLNTIwSOBD5399VxBxqx\nWs+DmbU1M0u9P4Lg+7I+9khzKwnfhVol4buQ+v1+Byxz9xk1bNYgvw+JuzXkNZS4MLOLUp/fSfDU\n8wnAu8CXwHm5ijcqIc/DYGC4mX0DfAWc7qmhEw2Fmc0jGBHT2sxKgSlAASTnuwChzkOD/y4ARwNn\nAW+Y2ZLUuiuAjtCwvw96slhEJOGSeGtIREQqUSIQEUk4JQIRkYRTIhARSTglAhGRhFMikMQxs+2p\nCppvmtmfzazlLu5/tZmNrcvnZvZ8pffTUlUup5nZQDPrtitxiGSLEoEk0Vfu3sPdDyYotDYyrobd\nvXelxWHAD9z9cmAgoEQgOaFEIEn3ApWKhpnZ5Wb2Sqq42jWV1k8ys3fM7Dmga6X1l6Tq179uZg9U\nOm43M3vazFaY2SWVtt+c+vkIUAgsNrMpwABgWupK5T8i+21FqpG4J4tFyplZPnAcQVkBzOx4gkJq\nRxDUm3/EzI4BviAowdGD4N9MCbA4dZgJQGd3/3qnW0zfB44lqGv/tpn9xt23lX/o7gPMbLO790i1\n3Zmg3v9Dkf3CIjVQIpAkapoqIdCeoOb8U6n1x6der6WWCwkSQ3Ngobt/CRV/zZd7HZhrZg8TVOQs\n9xd3/xr42szWAnsTlCwWqXd0a0iS6KvUX+L7EvzlX95HYMANqf6DHu6+v7v/rpZjnQjcTjC71ytm\nVv7H1deVttmO/uiSekyJQBIr9Rf+JcBlqf+BPwmcn6pHj5m1N7M2wLPAQDNrambNgZNSn+cB33P3\nRcB4YE+Cq4i62ERw5SESO/2VIonm7q+Z2evAUHf/HzM7EHghVXF5M/Bzdy8xs/kE8zqvJSjhDUHV\n1vvMbE+Cq4lfu/vG1L676gHgrlTH8mB3fy+z30wkPFUfFRFJON0aEhFJOCUCEZGEUyIQEUk4JQIR\nkYRTIhARSTglAhGRhFMiEBFJOCUCEZGE+/+9FTq/Gxe6LwAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x10e278630>"
+       "<matplotlib.figure.Figure at 0x11691dfd0>"
       ]
      },
      "metadata": {},
@@ -538,12 +530,14 @@
    "source": [
     "## Simulating spectra using quickgen.\n",
     "\n",
-    "We're now ready to simulate DESI spectra using *quickgen*!  Since we're calling *quickgen* from within this notebook (rather than from the command line in a terminal) we have to parse the *simspec* and *fibermap* filename inputs first.\n",
+    "We're now ready to simulate DESI spectra using `quickgen`!  Since we're calling `quickgen` from within this notebook (rather than from the command line in a terminal) we have to parse the `simspec` and `fibermap` filename inputs first.\n",
     "\n",
-    "*quickgen* generates four types of files and writes them to the *\\$DESI_SPECTRO_REDUX/\\$SPECPROD/exposures* directory: *calib*, *sky*, *cframe*, and *frame* files.  We will use the *cframe*, or calibrated frame files, which contain the flux-calibrated and sky-subtracted DESI spectra.  The data model and the other files and their contents are documented here:  \n",
+    "`quickgen` generates four types of files and writes them to the *\\$DESI_SPECTRO_REDUX/\\$SPECPROD/exposures* directory: `calib`, `sky`, `cframe`, and `frame` files.  We will use the `cframe`, or calibrated frame files, which contain the flux-calibrated and sky-subtracted DESI spectra (one file per *brz* camera and spectrograph).  \n",
+    "\n",
+    "The data model and the other files and their contents are documented here:  \n",
     "http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_REDUX/PRODNAME/exposures/NIGHT/EXPID/index.html\n",
     "\n",
-    "The following code calls the equivalent of the command line:\n",
+    "The code in the following cell calls the equivalent of the command line:\n",
     "```\n",
     "quickgen --simspec {simspecfile} --fibermap {fiberfile}\n",
     "```"
@@ -551,7 +545,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
@@ -560,16 +554,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:quickgen.py:242:main: Reading fibermap file /data/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
+      "INFO:quickgen.py:242:main: Reading fibermap file /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
       "INFO:quickgen.py:275:main: Initializing SpecSim with config desi\n",
-      "INFO:quickgen.py:281:main: Reading input file /data/desi/spectro/sim/example/20170615/simspec-00000000.fits\n",
-      "INFO:quickgen.py:310:main: Only 50 spectra in input file\n",
-      "INFO:quickgen.py:672:main: Writing files for channel:b, spectrograph:0, spectra:0 to 50\n",
-      "INFO:quickgen.py:699:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/frame-b0-00000000.fits\n",
-      "INFO:quickgen.py:717:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\n",
-      "INFO:quickgen.py:732:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/sky-b0-00000000.fits\n",
-      "INFO:quickgen.py:753:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/calib-b0-00000000.fits\n",
-      "INFO:quickgen.py:672:main: Writing files for channel:r, spectrograph:0, spectra:0 to 50\n"
+      "INFO:quickgen.py:281:main: Reading input file /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits\n",
+      "INFO:quickgen.py:672:main: Writing files for channel:b, spectrograph:0, spectra:0 to 100\n",
+      "INFO:quickgen.py:699:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-b0-00000000.fits\n",
+      "INFO:quickgen.py:717:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\n",
+      "INFO:quickgen.py:732:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-b0-00000000.fits\n",
+      "INFO:quickgen.py:753:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-b0-00000000.fits\n",
+      "INFO:quickgen.py:672:main: Writing files for channel:r, spectrograph:0, spectra:0 to 100\n"
      ]
     },
     {
@@ -583,15 +576,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:quickgen.py:699:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/frame-r0-00000000.fits\n",
-      "INFO:quickgen.py:717:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-r0-00000000.fits\n",
-      "INFO:quickgen.py:732:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/sky-r0-00000000.fits\n",
-      "INFO:quickgen.py:753:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/calib-r0-00000000.fits\n",
-      "INFO:quickgen.py:672:main: Writing files for channel:z, spectrograph:0, spectra:0 to 50\n",
-      "INFO:quickgen.py:699:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/frame-z0-00000000.fits\n",
-      "INFO:quickgen.py:717:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-z0-00000000.fits\n",
-      "INFO:quickgen.py:732:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/sky-z0-00000000.fits\n",
-      "INFO:quickgen.py:753:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/calib-z0-00000000.fits\n"
+      "INFO:quickgen.py:699:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-r0-00000000.fits\n",
+      "INFO:quickgen.py:717:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-r0-00000000.fits\n",
+      "INFO:quickgen.py:732:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-r0-00000000.fits\n",
+      "INFO:quickgen.py:753:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-r0-00000000.fits\n",
+      "INFO:quickgen.py:672:main: Writing files for channel:z, spectrograph:0, spectra:0 to 100\n",
+      "INFO:quickgen.py:699:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-z0-00000000.fits\n",
+      "INFO:quickgen.py:717:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-z0-00000000.fits\n",
+      "INFO:quickgen.py:732:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-z0-00000000.fits\n",
+      "INFO:quickgen.py:753:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-z0-00000000.fits\n"
      ]
     }
    ],
@@ -607,16 +600,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Regrouping the spectra ##\n",
+    "#### Inspect the output cframe files ####\n",
     "\n",
-    "Next, let's combine and reorganize the individual *cframe* files into *spectra* files grouped on the sky.  For this simple example of a single exposure, regrouping doesn't matter so much, but it becomes more important for real observations with overlapping tiles where the same object could be reobserved on different exposures separated by short or large amounts of time.\n",
-    "\n",
-    "**TODO**: Add the spectra files to the desidatamodel\n",
-    "\n",
-    "To regroup the spectra, we want to run:\n",
-    "```\n",
-    "desi_group_spectra --hpxnside 64\n",
-    "```"
+    "Let's briefly look at one of the `cframe` files for the blue camera using `desispec.io.frame.read_frame`, which returns a `Frame` class with all the attributes you might want."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reading /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\n"
+     ]
+    }
+   ],
+   "source": [
+    "cframefile = desispec.io.findfile('cframe', night=night, expid=expid, camera='b0')\n",
+    "print('Reading {}'.format(cframefile))\n",
+    "cframe = desispec.io.frame.read_frame(cframefile)"
    ]
   },
   {
@@ -627,53 +634,64 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:group_spectra.py:74:main: Starting at Sat Jun 17 11:47:43 2017\n",
-      "INFO:group_spectra.py:75:main:   using raw dir /data/desi/spectro/sim/example\n",
-      "INFO:group_spectra.py:76:main:   using spectro production dir /data/desi/spectro/redux/example\n",
-      "INFO:group_spectra.py:197:main: Distributing 1 spectral groups among 1 processes\n",
-      "INFO:group_spectra.py:220:main:   (0000) Begin spectral group spectra-64-12637 at Sat Jun 17 11:47:43 2017\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/sbailey/anaconda/envs/desi/lib/python3.5/site-packages/matplotlib/__init__.py:1401: UserWarning:  This call to matplotlib.use() has no effect\n",
-      "because the backend has already been chosen;\n",
-      "matplotlib.use() must be called *before* pylab, matplotlib.pyplot,\n",
-      "or matplotlib.backends is imported for the first time.\n",
-      "\n",
-      "  warnings.warn(_use_error_msg)\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:group_spectra.py:294:main:   (0000) End spectral group spectra-64-12637 at Sat Jun 17 11:48:35 2017\n",
-      "INFO:group_spectra.py:301:main: Finishing at Sat Jun 17 11:48:35 2017\n"
-     ]
+     "data": {
+      "text/plain": [
+       "['R',\n",
+       " '__class__',\n",
+       " '__delattr__',\n",
+       " '__dict__',\n",
+       " '__dir__',\n",
+       " '__doc__',\n",
+       " '__eq__',\n",
+       " '__format__',\n",
+       " '__ge__',\n",
+       " '__getattribute__',\n",
+       " '__getitem__',\n",
+       " '__gt__',\n",
+       " '__hash__',\n",
+       " '__init__',\n",
+       " '__le__',\n",
+       " '__lt__',\n",
+       " '__module__',\n",
+       " '__ne__',\n",
+       " '__new__',\n",
+       " '__reduce__',\n",
+       " '__reduce_ex__',\n",
+       " '__repr__',\n",
+       " '__setattr__',\n",
+       " '__sizeof__',\n",
+       " '__str__',\n",
+       " '__subclasshook__',\n",
+       " '__weakref__',\n",
+       " 'chi2pix',\n",
+       " 'fibermap',\n",
+       " 'fibers',\n",
+       " 'flux',\n",
+       " 'ivar',\n",
+       " 'mask',\n",
+       " 'meta',\n",
+       " 'nspec',\n",
+       " 'nwave',\n",
+       " 'resolution_data',\n",
+       " 'spectrograph',\n",
+       " 'vet',\n",
+       " 'wave']"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "from desispec.scripts import group_spectra\n",
-    "args = group_spectra.parse(['--hpxnside', '64'])\n",
-    "group_spectra.main(args)"
+    "dir(cframe)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Inspect output spectra. ##\n",
-    "\n",
-    "So what did we end up with in the redux output directory?\n",
-    "* `exposures/{night}/{expid}/`: individual spectrograph camera spectra (\"frames\")\n",
-    "  grouped by night/expid\n",
-    "* `spectra-64/`: spectra grouped by healpix location on the sky"
+    "Let's make a quick plot of the zeroth spectrum."
    ]
   },
   {
@@ -687,33 +705,151 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/data/desi/spectro/redux/example\r\n",
-      "/data/desi/spectro/redux/example/exposures\r\n",
-      "/data/desi/spectro/redux/example/exposures/20170615\r\n",
-      "/data/desi/spectro/redux/example/exposures/20170615/00000000\r\n",
-      "/data/desi/spectro/redux/example/exposures/20170615/00000000/calib-b0-00000000.fits\r\n",
-      "/data/desi/spectro/redux/example/exposures/20170615/00000000/calib-r0-00000000.fits\r\n",
-      "/data/desi/spectro/redux/example/exposures/20170615/00000000/calib-z0-00000000.fits\r\n",
-      "/data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\r\n",
-      "/data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-r0-00000000.fits\r\n",
-      "/data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-z0-00000000.fits\r\n",
-      "/data/desi/spectro/redux/example/exposures/20170615/00000000/frame-b0-00000000.fits\r\n",
-      "/data/desi/spectro/redux/example/exposures/20170615/00000000/frame-r0-00000000.fits\r\n",
-      "/data/desi/spectro/redux/example/exposures/20170615/00000000/frame-z0-00000000.fits\r\n",
-      "/data/desi/spectro/redux/example/exposures/20170615/00000000/sky-b0-00000000.fits\r\n",
-      "/data/desi/spectro/redux/example/exposures/20170615/00000000/sky-r0-00000000.fits\r\n",
-      "/data/desi/spectro/redux/example/exposures/20170615/00000000/sky-z0-00000000.fits\r\n",
-      "/data/desi/spectro/redux/example/spectra-64\r\n",
-      "/data/desi/spectro/redux/example/spectra-64/126\r\n",
-      "/data/desi/spectro/redux/example/spectra-64/126/12609\r\n",
-      "/data/desi/spectro/redux/example/spectra-64/126/12609/spectra-64-12609.fits\r\n",
-      "/data/desi/spectro/redux/example/spectra-64/126/12637\r\n",
-      "/data/desi/spectro/redux/example/spectra-64/126/12637/spectra-64-12637.fits\r\n",
-      "/data/desi/spectro/redux/example/spectra-64/194\r\n",
-      "/data/desi/spectro/redux/example/spectra-64/194/19435\r\n",
-      "/data/desi/spectro/redux/example/spectra-64/194/19435/spectra-64-19435.fits\r\n",
-      "/data/desi/spectro/redux/example/spectra-64/194/19438\r\n",
-      "/data/desi/spectro/redux/example/spectra-64/194/19438/spectra-64-19438.fits\r\n"
+      "(4760,) (100, 4760)\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(cframe.wave.shape, cframe.flux.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.text.Text at 0x11beed128>"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZEAAAEKCAYAAADTgGjXAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3XmYHHd95/H3d3oujTS6kGzLOpAgXDI2AiQbcYUjYMDs\nGhJAELIhibMWWQKbkBDMkgSFhABJCNlsApEhXFkIcgAHHuzFxIQ8ecDCtnzKljkMkrHksSUjSzPS\naEbT09/9o6p6qmuqe6p7+pz+vJ5nnumurq7+VR+/b/1uc3dERERq0dPqBIiISOdSEBERkZopiIiI\nSM0UREREpGYKIiIiUjMFERERqZmCiIiI1ExBREREaqYgIiIiNettdQIaadWqVb5x48ZWJ0NEpKPc\ndtttj7r76iz7LuggsnHjRvbt29fqZIiIdBQzeyDrvqrOEhGRmimIiIhIzRRERESkZgoiIiJSMwUR\nERGpmYKIiIjUTEFERERqpiAiIiI1UxApY8fuvezYvbfVyRARaWttF0TM7FNmdtTM7olt22VmR8zs\nzvDvVa1Mo4iIBNouiACfAV6Rsv2j7r4l/Lu+yWkSEZEUbRdE3P0/geOtToeIiMyt7YJIBW83s7vD\n6q4VrU6MiIh0ThD5OPAEYAswAnyk3I5mdqWZ7TOzfceOHWtW+kREulJHBBF3f8Tdp929AHwCuLjC\nvle7+1Z337p6dabp8EVEpEYdEUTMbE3s7muBe8rtKyIizdN2i1KZ2T8DLwJWmdlh4H3Ai8xsC+DA\nIWBnyxIoIiJFbRdE3P1NKZv/sekJERGROXVEdZaIiLQnBRERkQRNe5SdgoiIiNRMQURERGqmICIi\nIjVTEBERkZopiIiISM0UREREpGYKIiIiUjMFkSqp/7iIyAwFERERqZmCiIiI1KztJmBsFwdGRlud\nBBGRtqeSiIiI1ExBREREaqYgIiIiNVMQERGRmimIiIhIzRREUuzYvZfxyXyrkyEi0vYUREREpGYK\nIiIiUjMFERERqZlGrKdwdwoOBfdWJ0VEWkAzVmSnkkiKE2emcGByqtDqpIiItDUFkRRRASRfUElE\nRKSStgsiZvYpMztqZvfEtq00s38zsx+F/1e0Mo0iIhJouyACfAZ4RWLbVcC33P1JwLfC+yIi0mJt\nF0Tc/T+B44nNlwOfDW9/FnhNI9NgjTy4iMgC0nZBpIxz3X0kvP0wcG4zX1xL4oqIpOu4Lr7u7mZW\ntsXbzK4ErgTYsGFDXV5T3f1EpN1FF7p7dm5v6ut2SknkETNbAxD+P1puR3e/2t23uvvW1atXNy2B\nIiLdqFOCyNeAt4S33wJ8tYVpqYmqxEQ6x/hkXpOwZtR21Vlm9s/Ai4BVZnYYeB/wIeAaM7sCeAB4\nQ6vSd3Rsgqnp0tq0ZHBodnFSRKRV2i6IuPubyjz00qYmpIyDj44Xb6tkISLtolVtt51SndW2DoyM\nquFdRLpWTSURM1sMTLj7dJ3T0x5SBoqMT+ZLSh4qhYgsXJ0492qr2nAylUTMrMfMftnMrjOzo8D3\ngREzO2Bmf2lmP9fYZHYWNaKLdDYHCsDBR0+3OilVa3b+k7U669vAE4H3AOe5+3p3Pwd4PvA94MNm\n9isNSmNLKRiIdJ+oIDJy4kxL09EJslZn/YK7TyU3uvtx4MvAl82sr64payPjk3mmO7B4KyLdZdqD\ndtrNa5Y27TUzlUTSAkgt+3SKB4+Pl9xXABERSTdnEDGzl5nZJ8xsS3j/ysYnq3Opt5aIdJMs1Vm/\nAfwW8IdmthLY0tgktZd4QNh3KDm5sIgsZKqEmFuW6qwxdz/h7r8PvBzY1uA0tS1Va4l0l07s6tts\nWYLIddENd78K+FzjkiMiIvMxNpFvapX6nNVZ7l6c7NDMtgIvMbNfD59rwS5+UeOS2FqVBvAcGBll\nfDLP0ECv2kFEFiBXhdacqh2x/nngXcB+grE4QhD5AYYHy7+d42fzDPbmmpUkEekyrapurzaIHHP3\nrzUkJW1kcqq+8fHY2CT7j4yyakl/XY8rItJq1QaR95nZJ4FvAZPRRnf/Sl1T1QGqqb46FVaJRSUW\nEZGFotog8uvAU4E+ZqqzHFiwQaQeRUSvootHq5a4FJHZ1DtrbtUGkW3u/pSGpGSBOTAyyo7de0uC\nQcrkwEWao0tE6iWadbwZF6PVridyk5ltbkhKOlS8pFJwZ7qgSxeRhaJTf83NbGSvNog8B7jTzH5g\nZneb2X4zu7sRCWulLO9/Wtff05PTjJ+dWWIlKo106hdRRGQu1VZnvaIhqWgz8830T03kMWBxmS6/\navcQkflqlyrwqoKIuz/QqIQsJM5MIDowMsrvfvHOOZ8T9fZq5hTOIlJZNZ1iWqmVg52rqs4ys8+a\n2fLY/RVm9qn6J6v9TTvkpyuPJ5lV5VWpZT3cP/5lqOcKZVptUUQaodo2kYvc/UR0x90fA55Z3yR1\njjMZByX++NgpACbzBXbs3suBkVH2HTpezNR37N7bsvWRRaS8ziiHtFa1bSI9ZrYiDB6EU8NXe4yu\ncybW2C4iUg/R0hRDA70tvQitNgB8BPiemV0T3n898IH6JmnhmqM2q+XU4C+ycDSrnSRTdZaZbTcz\nc/fPAa8FHgn/ftHd/6mRCVwIokqvRg8hKdfuEVWhiYjUW9aSyK8Cf29mPwS+AXzJ3R9uXLLKM7ND\nwBgwDeTdfWsr0jFf055+peDujJ6ZKmb8tfTWUolCpD7avfagHWQqibj7b7n7s4BdwArgM2a218z+\n3MxeaGbNnuP8xe6+pVMDSBr34G8yX+C+h8eK7SjRgMW5qLQhIq1Q7TiR7wPfBz5qZouAFxO0i/w1\nsGAy9HrJMvXAjt172X/kJAWCq55o2pR8IVvPL3XbFZFWqrlnlbufAa4P/5rJgRvNbBrY7e5X1/sF\njMZ07espUzaOBjQ5M8XnQz8bZ3JqmqEBdX4TkfZV7WDD15vZcHj7j8zsK2bW7HEiz3f3LcArgbeZ\n2QsTabzSzPaZ2b5jx441OWnZJLvjxRfBihrfJ8LqrOQAxFqdzRe4+eBxJqaa091YgxtlITBTq8hc\nqh1s+EfuPmZmzwdeCvwj8A/1T1Z57n4k/H8UuBa4OPH41e6+1d23rl69uplJm1MUIOoxw2a1mfTZ\nfBCoRiemyh5PbSoinWHH7r0tWw43qdogEl3GXgZc7e7XAU1b89XMFsdKQouBlwP3NOv1azHXIKAD\nI6NlF6uf9soB58DIaF0z/rP5Aj98ZAxQSUKknUW/+2mHQsEbPnygkmor3I+Y2W7gZcCHzWyA6gPR\nfJwLXBsWMXuBL7j7N5r4+vMWz/THJ/Nl2zzigSW+Rsl8M/adn7uN+4+dYvOapbO6AE/mC0zmZ145\nbWEtEWkvp1s8I0ZVgw2BNwA3AJeGc2itBN7VwPSVcPefuPszwr8L3L3tR8snJwGNl0yyFkcnKnxJ\n4m0mU9OFYrVV3MjJiZKOAuOT+ZK5u0SkNiqxVznYEIgGG44BuPsIMNKYpC0MySw9GVROT8w9502B\nmRLIgZHRkhLMtMPYRJ57HzrJxFShOEDxvlgp4qfHxyseP9ke0qj2EQ2CFFl4MgURd/8tADN7KkGv\nqM+Y2TLg2wRB5bvurlkGM0gGlWyjQWaMT+YrlmAm8wXuOnyCggdtHLVcJcUndovER9CXCwLRa/35\nL17IzQeP87Q1w1W/tkgnaXZnlOg31k6zfmuwYYeYawqU8cmZGB6Vdu548ESZvWeOmRZkqu31kTzG\nd370KAD3Hz3VlDYVlXCkUdqlg287V5lVFUTM7J0pm+8k6OorDXZgZLRsBt+qzhlpc3xVsxqcAoBI\nqUq/iaiWoJ1U27NqK/BWYG34t5Ng3fWrzewP6pw2SRiLtZ+MT+bLFmkrZeE/PDpW7Docb5SfTBmE\nOF3wzHN3ZX19kU6QKze9RAsk2yjn6vofaVaVV7VdfNcBz3L3UwBm9j7gOuDngduAv6hv8qSceg80\nOptywPGz0wwPln5FDoyMcuGuG8oe58DIKA+fnJi1fcfuvdz70Mni7UaUPJLBTqUbkcarNoicA0zG\n7k8B57r7GTObLPMcqYOxOXpx1RJTstQ6nZ4IugNHjezR1U3yfpa0TEwVyLdyVJRIlTTrydyqrc76\nPHCzmb0vLIV8F/hCOHr8QN1TJ3WXHEcyPpkvlhDSFAhKPWfOTlOIRZ206rSo+/Ejo0FJJBkvGhVA\nCu7BWJhY+ipVw7VL3/4s6WiXtErzlJuJolKbaJoqmibnJXMQCQcbfga4EjgR/r3V3d/v7qfd/c2N\nSaLU01TsWxgFiFOTc/fOzhecianCrC9mVD97YGSUqelCsWsxBG0qdx0+MSsTjGfwZ/MFToyfLfu6\nWTLRh09O8NPj4zwyOlk8floJqZEZsjJ7qZdCwTk9kZ/396na4QO1ylyd5e5uZte7+4XAvgamSdpU\nNP1K2gpkk/n00fKFsHE+KQok9zx0siSwzSdd03OUdKJ0VOoqHf/hVhoXk2XcTDO1ay+3dk1XO4re\nq9OxBemi/6cn8vT1NnOGqeyqbRO53cy2ufutDUmNdIQoz49/pdMCCAQN9tOF0jnC4qWEeADJ2jBe\nLgOfnC4wMTXN2EQ+c//+emRy1S5lXM0VpmZWbm/VdGePq+Z7d3oiTwFK5rVrJ9UGkUuAN5vZA8Bp\nwvWb3P2iuqdM2l7Wr7Q7nE6ZMyw51UokmXFWmghyx+69jIS9wY6NTXJsLKjScuBUhc4I8Sq1aiaa\nrKWKId5FMx5oxiby9OXKh7uxiSnGJvIM9jXnCrRcxlZLoI2e04xMtpWiziLuXvPaIxfuuqE4lVHa\nhUh7ho4Z1QaRSxuSClnQnLkb+dIy2R2793L34RPFOcGqde/IKBf88Te49/2vKNl++08fY2raZ5Ue\nspQoylWJTU0Hi369/h9u4l/e+tyK6YrabNJq8eKZ54PHzwClpbz5ZOiRPTu3zyuTrua59zw0yniL\nZ5mdr0rnG3UWmZgqsKg/raJ37mOUMz45/3aRZqh22pMHGpUQWbjKxY94tVbUhTkZLM5Mze867EyY\ngZ2ezDM2kaeHmSu7tFUj3Z2z+QI9PeWvoscn89x1+ARGEDz6cj3F1SnzYWSYKyBlaQZ695fvSt0e\njdWJV+eNTeRT01ttVdtcsh4vel87NYBE7WuWsWI0XyiQ3lqYrtxFUXJQYTuOUE+qdtoTA94MPMHd\n329mG4Dz3P2WhqROFrS0jDQeWJJrr0QZZ1JfzlIHS8bdFx6rZJ0Wn6lvvvngcXIGmJXMOXb34Znb\nO3bvLaZvIgwat//0BFvWLysGyjsePFHMaMdiY2yiksfNB2dnCsmMOdk9OdlfIP4exavkkseshrtz\n8NHTnDM8MOs4+4+cnPW+7zt0nAt33cD+XZdmusqu9kp8Mj/N6JlsI67Tjh3fVum1q0lXpX3n6r2e\ndrFS8JnvVPRdTDaeN6ub7nxUW531MYLf4UuA9xNMCf9lYFud0yVdKt5on9ZN98DIKO5OvuD87NQk\nj1syMGufpB2796Zm3jA7qCR/tWemCsVMPvrhJ3/X942MzUpjfHDo9Bwrz0X7HxgZ5SnnDpeMx4mf\nAwQlH/cg3WklguQUGclBqvuPnGTH7r3F40ROjE9xdGySo2OTJaWcQsEZPzvNvgceK6ah4F4xc9ux\ney+nMnZuKNdedN/IGJP5AuNn8wz1l8+mypWM5qr+rDSGKOn46bMsHezlh0dPFauYkoGkMEcUSS75\nEHWZv+vwieJ3Pq3xvN3bQ6CGhnV3f5aZ3QHg7o+ZWdOWx5XuUYCS3DpaNyXu/mOn+cmjpytm0FEp\nYz6iKoX+3p7Uqrm5es3MVaUTD5a3//Sx4vn8+Njp4va0c4iel6W96MDIKOcMDzB+dpq7D58oqSaM\nT0kTHfdASsntwMgopybyJe9BFKDj/QPufehk0A6WeC6J50Xb01b4nJoOXtmd4jQ7+3ddOusY8W6w\n8cw9em+icytX/ebus54b95ufu7VY6oxEC7rF908G/mRJKDpCdC7RMRfCBA7VBpEpM8sRfj/MbDWd\nESxlgWrGjzC6UszaPhMPClmqI6Ljj0/mqzqf6NhpU+IkS3FjE/li+1AygBwYGZ0VHKMr7nij/vhk\naQCJpsSJziGq3ko7hahkEp93LcrY3Wcm+0wGlOSx4iWFeHDP9VhJFVv8fT81Oc0dD56YFYyiEmBv\nzsrOCZf2+UWDa+Np2fZnN7Jt08ricaPz27F7b0m7RqUlsTtVtWfzt8C1wDlm9gHgdcAf1j1VLdab\ns3kPgJPuFf/qVHOFFX/ePQ+d5EzKzMpxaaWsW8P7aa9badqZ07FZC6Iqu+Sxk09PlhYjaYM+oy3x\nudfiJZt4ae30RL64kMevfeqW8rNVh9V68aAYBb9oS1TNNDXtDPbNPPeeh04Wzzk/7dA389rx967c\n+CeY3egdr8aMJi7dd+j4rLa/eNXWVJuO/ahGtb2zPm9mtwEvJfiYX+Pu9zUkZSJd7HSGqWjSVJsl\npWVy5ULNXJdVYxNB54dk9U/8+dFrnc0XylYDxoOTk17aLFdFmezRtO+Bx4q3o8z7wl03zHp/y01w\nWu6ck9V6hcQxoiWrk+9t1ve6k1RdroqtbigiHa7eBe65ZpuOZB19/YOHZ6raNl51XabnxM8pmdFD\n9jRWkuVtyzIn3ULQnpOxiIjQPRlxJ1MQERGRms0ZRMzsO2b238M1Q0RERIqylETuA44CnzKz3Wb2\nnAanSUREOkSWhvW8u38V+KqZrQeuAL7X2GSJiEgnyFIS+Xx0w90fdPddjUtOZWb2CjP7gZndb2ZX\nNex1GnVgEZEFZs4g4u7faUZC5hKOlP974JXAZuBNZra5takSEeluVffOMrN3NyIhGVwM3O/uP3H3\ns8AXgctblBYRESFDm4iZXRO/C2wBPtywFJW3Fngwdv8wwUqLJczsSuBKgA0bNjQnZSIiXSpLw/qo\nu/9mdMfMPt7A9Mybu18NXA2wdevWhTCrgIhI28pSnfWBxP33NiIhGRwB1sfurwu3iYhIi2RpWD8I\nYGarwvutWq/xVuBJZrYpXMPkjcDXWpQWERGhuob1TzUsFRm4ex74beAGggGQ17j7va1Mk4hIt6tm\nFt+WD59w9+uB61udDhHpbsbsmXx76M4V+qopiaiRWqSLrFk2mLo91/LLyUAP2a5st21cUbc09wB9\nOWPxQI6e2DH7e3tYPLiwVizMqpog0iZfHZHuNTzYy8bHDTXk2MnMYMVQ/6zHeoCtG1fW7TWSkpl9\nWuY/PNjL8GAviwd7GejtmbVvMrj0mBUfXzKQY8lAriQdw4nMf7CvfCq3bVrJYF+OC85fxjPXLy9u\nf+b65Wxes7StMslmpaWaIPKehqVCpAnWr1hUvF2vK9OcVc50IvVYc8EI1u0+d2l6CSEyPNjL4oEc\na5cvYtvjV8x6/JJNKzOlZ3iwl3OGB4r3c0bxavuC85dWk/QiMzj0ocs49KHLuGRTaTDqzxlDA70l\nn83QQG8xaBiweCBXXJsd4KJ1y1jU10NPuG+UxiVhOnMGe3Zu58cfvIwff/AyzAwzKyk17N91aUkA\n6suVvjtPPW+4eHvPzu3F1+9N7Ldn53aesLp0svNWBpV2DCJ5M3u3mf1t+PduM3taw1ImC14P2b+A\nRpAhzOeHsWzRzCLbQwP1qXoYGujlpqtemvpYzmbO0ax0ey0uWreMPTu3A0EGnzOKf8lj95ixbsUi\nenpmv9iendt5cixjjF/ZR8+PnrXxcUM8e8Nytm1aWfKeLYll7pXkYq8/PNg7633vIagKumTTSp65\nYQX7d11a3CdnQQa/ec1SNq9ZysWbVvL085cVM/LNa5ZyzVufy0XrgvTt33UpWzeuLAkyydeLnhdZ\nPJAr7jc82Mu2TaXPh9LvzVwG+4LjDfT2BJ9/OxVNGiTTbzic6uSLBN+tW8I/A/65kRMhtsqq2NWX\nNM62TSsz1yP3hrnbQIar/t4yv9yvv+MF2RNXRjLT3LxmKSsX93PJppXFDHNRXw/Dg71s3biy5Byj\nDD9+dZ0MKNHdof7crHP6yv94Xsm2rRtXFv8u2bRyzuA02NfDU85dAsBXf/t59PYYPczOWHNG8Ure\nzEquuDevWVoMZNH9ZEAb6s8Vg2e8yif5Ont2bp9VJRXtF71P0X7x1yy3Lb5985qlXBIGlnKPDw/2\n8vTzl1V8z9Le0nKvDXDdO17AM9Ytoy8sVQ0NBKXCi9Yuoz/8gJYM5FKf26myXo5dAVzg7lPxjWb2\n18C9wIfqnbBW6oKLh7YyPNg757rXm9csZbAvx6OnJvnxsdMlj0WZpzv09fbQl7Pisqo5K11ze9vG\nFdw3Mjrr+QWf3XNkUV8PZ6YKqceJxDOT4tX7qsUsHZy5eo0yzgMjo8VMeMfuvcVt0bn39/bQnzPO\nnJ3mwrXLOH76LD86eipIS3+u5Ko+LR0X7roBCK7eo+PHbXzc4uJV9UBvjkX9OcYn8yXnsWP33tR0\nlss0o/OLnhOd07ZNs9tN0o6RvOqf67WymusY8XMrl45aX2OwL4eFRc/4cft7e8hPT2NmJd/ZoYFc\nRy8DnDWIFIDzgQcS29fQnb3auooRFMvTMtFqpWXGm9csZd+h40x7etfJoN0h/eotfvVtFvxQ448N\nDZQGqB4zLgirRC7cdQPjk3mGBnpxdybzBabCxOUsqPPumZr99Y7OIXnlP9jXw+OWDHD9O17AG68u\nXXInmWnFM+2bDwbjd/tzQX390EDvrP3LHSuekcWvuuPbn/i/rme6kP7hRa9VrfhzduzeOyvozOd4\n1e5Ta9CJPy95jIs/cCNHxyaLj2286rqqjp0WlC44fxkHYhcwaVWq0XeqHr+1ZskaRH4H+JaZ/YiZ\nSRA3AD9HMABQ2tx8vpzG7Mw42l7N4ZYMBFdoYxP5WRnw0EBv8ao4SuOhD11WvDKG4Mf8ldsP885r\n7io+b+vGlbOuguM2r1lazKSToitoCKptBqIrxTA9yaqXyI7de9l36PisTMDMOG/pIGZWEiTSjhHX\n39vD2Xwh6N1j6aWNZKZUTcZ53tJBjpw4UxJg046ZdtxqM/e0QDLUn2P8bPqVdj1KHY2QrGJ71obl\nZfYsL+07EL3n+w6VfieHB3uLFzTAnCXzdpIpiLj7N8zsyQTTsa8NNx8BbnX3zi2HSdWBIDI82MvU\ndIGJlCv1SDJwmdmsTD1exx5lznHJTMljie2x9EyrmqqJePCJXynOdYy0IJN2FZ61WuXAyGhJ8InU\no1fX2uWDrFrSz1d/+/lVpa1WyeP+0se+y2S+syoskr+JZI+tSsoF4vj3I/n9iX/v9uzczqarrium\noVxV6lyGmtT2krmLirsX0LK4HSnq/hhd6ceVqz6CmS9uf19PSZVT8bixq+Z1KxZx+LEzwf4542yF\nb31UzZT2Y4tX78wl+mEnSwnJY5ariqj0vLkkG5gbxcq8V9Udw8pWBzZDb65nVnfYTtFXx5GVaZ9h\n9L2Ll4ohCACnJ6eLv912LpnMu5+jmf26u3+6HomR5ktr1EsWqdevGEpteE1WHUVF8oG+HGeny3/p\nk1dh1VixeKbBOu0HnuXKv5Is6WpE8EgLSvNpY5DOUO5CJrhAmvld1loaaYZ6dJb/E2BBBZHXPXs9\n//tbP2p1MpriaWuWcuuhx0q2RRlpVCJYPpTeT37zmqXccvB4anVYVNqIl35qbXyN/9Be/JRz+Llz\nlvCTo6fKth8krV+xiOOnz2Z6jSy9kbKkUxaWZn+2T1y1mNt/eoKMX/GWyhREzOzucg8B59YvOZJV\nuSuTcg3oUckhrXG80mtAabVVuSCQPM7WjSuLP7xkdVKlH+Sendt50nuvL/aSmvU6ZjxucT8Hq/hx\nnb98EecvXzT3ji3S6Ayq1cGt1a/fKeLvU2+uh57wQizqsp21mrfZspZEzgUuBR5LbDfgprqmqA10\nQvSvRbJRe3iwt9hnvdaishEMBPzm7/48v/bpW1L3GerPUXDPnJk8/fxlTExV7q8xnyqxStotw2u3\n9HSNNq06gvar2sra2vV1YIm7P5D4OwT8R8NSJ1UxghLA0EBvSclgUX9uVmbUn7OKmfCenduLo6Er\n9c9fPNjLYF+u+Bpp+164dhnPWJe9i2R/bw9Lq5hqQqQbRDUD9Zqyp14yBRF3v8Ldv1PmsV+ub5Ja\nz1o8Zr3WV4+PA4gf4+lrg6kd4hn8QKK3zlxzIMVVmvahWZrVO0q604rFwQzGrexVtnXjzLQte3Zu\nL04w2YgS+HxkbRMxd69YgMqyT6do9+qsKMOf1b6RGL2dtUgeVQ3Vq851odfxy8I31J9jeLAxVaa1\niveIzLIAVtaOJ/OVNcx+28zebmYb4hvNrN/MXmJmnwXeUv/kSZpoIrvkDK4Xra08mVxW1WTSyUn1\n2lE7lJxE6iEqgbfThW7WOoxXAL9BMGvvJuAEMAjkgG8Cf+PudzQmic3XrM+nXE+qvnAajKRFfT08\n5dzh8j2kwhHP8ZHf0XoK5cQfq3Z+IBFpjE666Mk67ckE8DHgY2bWB6wCzrj7iUYmbqFLq0YaHgwm\nAywUjHxs0ry0onWWeXbm0wjXqi9yJ/2ARLpd1TlMOB38SAPSIpQ2mkXBJS2ApM0CG38sbR4qCBYZ\nimYnbRYFBZGFq736irWJZvQOGOrPzQoMtfQD2bNzO098z3XF23M5d+kgPyszersvZ2UH+VV6fRFp\nvPhvLZpPq9YJVOtJQaRBKg0I6oHUBYayrvKXVaUBeWldZLesX976b6SIZFavdX7mlYZqdjazzSnb\nXlS31HSJZLDoyxl9FQb/ZZmWvB4DkHrMUtfkFhEpp9oalGvM7N0WWGRm/wf4YCMSttDFSwKDfbnU\nqboXD+R45vrlc3ZRLdfNttyAPA3UE+l88XXo0zSr6321QeQSYD3BfFm3Ag8Bz6t3opLMbJeZHTGz\nO8O/VzX6NRuh2mv8HrNZq9FlpbERIrXbs3N7249/ahfV1oFMAWeARQTjRA6Gi1U1w0fd/a+a8UKt\nHHeftgqaiMhcWjUxY7WXubcSBJFtwAuAN5nZv9Q9VQtUX29Pce4blRJEZD6ijjN9OStOG98K1b7q\nFe6+L7zJKBAnAAAMTElEQVQ9AlxuZv+tzmkq5+1m9qvAPuD33D05LT0AZnYlcCXAhg0b0naZ0+I6\nrU2cvDI4Z3iAk2emaj6eAo+IJA325VJXGm2WaoPIqxrVHmFmNwLnpTz0XuDjwJ8SdED9U+AjBNOw\nzOLuVwNXA2zdurVlFVPRqn7xQLJiqG9WEIkGBrbqCyAiC1OzLjqrDSKnY7cHgVcD99UjIe7+C1n2\nM7NPEKxv0nGG+ls/LEelGRGpp6pyNXf/SPy+mf0VcENdU5TCzNa4ezTVymuBexr9mvWQZW6rdqIA\nIyLVmu+l8RCwrh4JmcNfmNkWguqsQ8DOJrzmvEVdBG8+eLzqHgzlZuott6+ISCtUFUTMbD8zE2Pk\ngNXA++udqCR3b1bjPdCYxVzmOqR6bIlIteIXm5vXLGXfoeNMe+k6Q41W7QXyq4H/Ev69HDjf3f+u\n7qlaANIGKmkAk4jUQ9osFdESus1WbZvIA41KSDtp5Cq/Km2IyEKSdY31MWaqsSx52911eR1Tr5Kk\nAo6ItLusJZGnd0sppB40Ea6ItFIzq7WyvtK1wLMAzOzL7v5LjUtS69WjYT1eiogWjcqyr4hIraLG\n9WbKGkTiueoTGpGQhaRVc9iISHdopwvPrL2zvMxtSVBNloi0UqUVTRsh6yXzM8xslCCPXBTehi5v\nWE9OsDgcrliY/ABVMhGRRml1qSRT7ubu9ZnWdoEZGujtmClNRKQ6rc6ca1HNTBf1UtuyeV0uZxTX\nBRER6WYKIiIiUjMFERERqZlafOukUq8sVXuJyEKlIJKilm66lUapd2IDnYhIFqrOEhGRmimIZBD1\nxoobGuhVCUNEup6CyDwtGdAQGhHpXgoiKZ6+dlnmfaPJGps91YCISDtQw3qKizetZPFAjtOT0yWN\n7M1cclJEpBbNrmZXSaSMHjN6gKFEddXQQG/JXFib1yxVcBGRrqWSSAVmQTCB7JMobl6zVA3uItI1\nVBIREZGaKYhkoEZzEZF0CiIiIlIztYlUYf+uSwGaPl+/iEi7aqsgYmavB3YBTwMudvd9scfeA1wB\nTAPvcPcbGpmWzWuWcmBkNLUaq1zDuRrURaTbtFUQAe4BfhHYHd9oZpuBNwIXAOcDN5rZk919uvlJ\nFBGRSFsFEXe/D2ZGgcdcDnzR3SeBg2Z2P3Ax0JR6JZUwRETSdUrD+lrgwdj9w+G2WczsSjPbZ2b7\njh071pTEiYh0q6aXRMzsRuC8lIfe6+5fne/x3f1q4GqArVu3+nyPJyIi5TU9iLj7L9TwtCPA+tj9\ndeE2ERFpoU6pzvoa8EYzGzCzTcCTgFtanCYRka7XVkHEzF5rZoeB7cB1ZnYDgLvfC1wDHAC+Abyt\nnXpmaUS7iHSrduuddS1wbZnHPgB8oLkpykaTLopIt2qrkoiIiHQWBREREalZW1VndSJVY4lIN1NJ\nREREaqYgIiIiNVMQERGRmimIiIhIzRRERESkZgoiIiJSMwURERGpmYKIiIjUTEFERERqpiAiIiI1\nUxAREZGaKYiIiEjNFEQq0DohIiKVKYiIiEjNNBV8GSqBiIjMTSURERGpmYKIiIjUTEFERERqpiAi\nIiI1UxAREZGaKYiIiEjNFERERKRmCiIiIlIzBREREamZuXur09AwZnYMeCDloVXAo01OTjvR+ev8\ndf7dK8v5P97dV2c52IIOIuWY2T5339rqdLSKzl/nr/PX+dfreKrOEhGRmimIiIhIzbo1iFzd6gS0\nmM6/u+n8u1tdz78r20RERKQ+urUkIiIidbAggoiZDZrZLWZ2l5nda2Z/Em7fZWZHzOzO8O9Vsee8\nx8zuN7MfmNmlse3PNrP94WN/a2bWinOqhZnlzOwOM/t6eH+lmf2bmf0o/L8itm83nH/XfP5mdihM\n951mti/c1jWff5nz76bPf7mZfcnMvm9m95nZ9qZ9/u7e8X+AAUvC233AzcBzgF3A76fsvxm4CxgA\nNgE/BnLhY7eEzzXg/wGvbPX5VfE+vBP4AvD18P5fAFeFt68CPtxl5981nz9wCFiV2NY1n3+Z8++m\nz/+zwG+Gt/uB5c36/BdEScQDp8K7feFfpcaey4Evuvukux8E7gcuNrM1wFJ3/54H7+jngNc0Mu31\nYmbrgMuAT8Y2X07w5SL8/5rY9m44/3IW3PmX0TWff5UW1Pmb2TLghcA/Arj7WXc/QZM+/wURRKBY\nlXEncBT4N3e/OXzo7WZ2t5l9KlacWws8GHv64XDb2vB2cnsn+BvgD4BCbNu57j4S3n4YODe83S3n\nD93z+Ttwo5ndZmZXhtu66fNPO3/ojs9/E3AM+HRYnftJM1tMkz7/BRNE3H3a3bcA6wii6tOBjwNP\nALYAI8BHWpjEhjGzVwNH3f22cvuEVxYLsitehfPvis8/9Pzw+/9K4G1m9sL4gwv58w+lnX+3fP69\nwLOAj7v7M4HTBNVXRY38/BdMEImExbhvA69w90fC4FIAPgFcHO52BFgfe9q6cNuR8HZye7t7HvBf\nzewQ8EXgJWb2f4FHwiIq4f+j4f5dcf5d9Pnj7kfC/0eBawnOtVs+/9Tz76LP/zBwOFb78iWCoNKU\nz39BBBEzW21my8Pbi4CXAd+P3sDQa4F7wttfA95oZgNmtgl4EnBLWPQbNbPnhL0SfhX4atNOpEbu\n/h53X+fuG4E3Av/u7r9CcJ5vCXd7CzPn0hXn3y2fv5ktNrPh6DbwcoJz7YrPv9z5d8vn7+4PAw+a\n2VPCTS8FDtCsz7/VvQrq8QdcBNwB3E3wRfnjcPs/AfvD7V8D1sSe816CXgk/INYDAdgaHuPHwN8R\nDsjslD/gRcz0Tnoc8C3gR8CNwMouO/+u+PwJqmzuCv/uBd7bTZ9/hfPvis8/TPcWYF94rv8KrGjW\n568R6yIiUrMFUZ0lIiKtoSAiIiI1UxAREZGaKYiIiEjNFERERKRmCiKyoJnZR83sd2L3bzCzT8bu\nf8TM3lnn1zw1915VH3NLYhbaXWb2+xmeZ2b272a2NLbtNWbmZvbU2LbVZvaNeqdbFj4FEVnovgs8\nF8DMeoBVwAWxx58L3NSCdFVrC/CqOfea7VXAXe4+Gtv2JuA74X8A3P0YMGJmz5tXKqXrKIjIQncT\nsD28fQHBQKoxM1thZgPA04DbzWyJmX3LzG4P11O4HMDMPmRmb4sOFi8BmNm7zOzWcIK/P0l78bR9\nzGyjBWs+fMKC9W++Gc60gJltC/e908z+0szuMbN+4P3AjnD7jvDwm83sP8zsJ2b2jjLn/2Zio47N\nbAnwfOAKgtH9cf8a7i+SmYKILGju/hCQN7MNBKWOvQTrzWwnGJ27393PAhPAa939WcCLgY+EUz/s\nAd4QO+QbgD1m9nKC6SIuJiglPDs56eEc+zwJ+Ht3vwA4AfxSuP3TwE4PJhOcDs/hLPDHwB533+Lu\ne8J9nwpcGh7/fWbWl/IWPA+IT0x5OfANd/8h8DMze3bssX3AC8q8lSKpFESkG9xEEECiILI3dv+7\n4T4G/LmZ3U0wRcRagqm07wDOMbPzzewZwGPu/iDB/EwvJ5hu53aCDP1JidettM9Bd78zvH0bsDGc\n/23Y3feG278wx3ld58GaEI8STK53bso+K919LHb/TQSTVBL+f1PssaPA+XO8pkiJ3lYnQKQJonaR\nCwmqsx4Efg8YJbjyh6AaZzXwbHefCmcEHgwf+xfgdcB5BCUTCILOB919d4XXTd3HzDYCk7FN08Ci\nGs4reYy033PezHrcvWBmK4GXABeamQM5wM3sXR7MfzQInKkhHdLFVBKRbnAT8GrguAdTgx8nWD50\nOzON6ssI1iSZMrMXA4+PPX8PQfvB6wgCCsANwG+EbQyY2VozOyfxuln2KfJgGYMxM7sk3BRvsxgD\nhqs56dAPCCYoJEz/P7n74919o7uvBw4yU4X1ZGZmuhXJREFEusF+gl5Z30tsOxlWBQF8HthqZvsJ\npsD+frSju99LkIEf8XClOHf/JkF1097wOV8ikcln2SfFFcAnLFilczFwMtz+bYKG9HjDehbXEcxs\nDEHV1bWJx7/MTJXWi8P9RTLTLL4ibcTMlrj7qfD2VQTTl//PeRxvDfA5d39Zhn3/E7jc3R+r9fWk\n+6hNRKS9XGZm7yH4bT4A/Np8DubuI2FX4qWJsSIlzGw18NcKIFItlURERKRmahMREZGaKYiIiEjN\nFERERKRmCiIiIlIzBREREamZgoiIiNTs/wPUduX3sNGuDAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x116ef9780>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots()\n",
+    "ax.errorbar(cframe.wave, cframe.flux[0, :], 1/np.sqrt(cframe.ivar[0, :]))\n",
+    "ax.set_xlabel('Wavelength (A)')\n",
+    "ax.set_ylabel('Flux ($10^{-17}$ erg/s/cm$^2$)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Regrouping the spectra ##\n",
+    "\n",
+    "As you can imagine, working with `cframe` files is pretty tedious, especially across three cameras, 10 spectrographs, and more than 35 million targets!  Therefore, let's combine and reorganize the individual `cframe` files into `spectra` files grouped on the sky. Spectra are organized into healpix pixels (here chosen to have `nside=64`).  If you're interested, you can read more about the healpix directory structure here:  \n",
+    "https://github.com/desihub/desispec/blob/master/doc/nb/Intro_to_DESI_spectra.ipynb\n",
+    "\n",
+    "Regrouping is especially important for real observations with overlapping tiles where the same object could be reobserved on different exposures separated by short or large amounts of time.\n",
+    "\n",
+    "**TODO**: Add the *spectra* files to `desidatamodel`.\n",
+    "\n",
+    "To regroup the spectra, we will run the (notebook) equivalent of the command:\n",
+    "```\n",
+    "desi_group_spectra --hpxnside 64\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:group_spectra.py:74:main: Starting at Sun Jun 18 11:20:38 2017\n",
+      "INFO:group_spectra.py:75:main:   using raw dir /Users/ioannis/research/projects/desi/spectro/sim/example\n",
+      "INFO:group_spectra.py:76:main:   using spectro production dir /Users/ioannis/research/projects/desi/spectro/redux/example\n",
+      "INFO:group_spectra.py:197:main: Distributing 4 spectral groups among 1 processes\n",
+      "INFO:group_spectra.py:220:main:   (0000) Begin spectral group spectra-64-12609 at Sun Jun 18 11:20:38 2017\n",
+      "INFO:group_spectra.py:294:main:   (0000) End spectral group spectra-64-12609 at Sun Jun 18 11:20:47 2017\n",
+      "INFO:group_spectra.py:220:main:   (0000) Begin spectral group spectra-64-12612 at Sun Jun 18 11:20:47 2017\n",
+      "INFO:group_spectra.py:294:main:   (0000) End spectral group spectra-64-12612 at Sun Jun 18 11:21:36 2017\n",
+      "INFO:group_spectra.py:220:main:   (0000) Begin spectral group spectra-64-19435 at Sun Jun 18 11:21:36 2017\n",
+      "INFO:group_spectra.py:294:main:   (0000) End spectral group spectra-64-19435 at Sun Jun 18 11:22:14 2017\n",
+      "INFO:group_spectra.py:220:main:   (0000) Begin spectral group spectra-64-19438 at Sun Jun 18 11:22:14 2017\n",
+      "INFO:group_spectra.py:294:main:   (0000) End spectral group spectra-64-19438 at Sun Jun 18 11:22:25 2017\n",
+      "INFO:group_spectra.py:301:main: Finishing at Sun Jun 18 11:22:25 2017\n"
+     ]
+    }
+   ],
+   "source": [
+    "nside = 64\n",
+    "args = group_spectra.parse(['--hpxnside', '{}'.format(nside)])\n",
+    "group_spectra.main(args)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Inspect the output (combined and regrouped) spectra ####\n",
+    "\n",
+    "So what did we end up with in the redux output directory?\n",
+    "* `exposures/{night}/{expid}/`: individual spectrograph camera spectra (\"frames\")\n",
+    "  grouped by night/expid\n",
+    "* `spectra-64/`: spectra grouped by healpix location on the sky"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/ioannis/research/projects/desi/spectro/redux/example\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-b0-00000000.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-r0-00000000.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-z0-00000000.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-r0-00000000.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-z0-00000000.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-b0-00000000.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-r0-00000000.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-z0-00000000.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-b0-00000000.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-r0-00000000.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-z0-00000000.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/126\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/126/12609\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/126/12609/spectra-64-12609.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/126/12612\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/126/12612/spectra-64-12612.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/194\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/194/19435\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/194/19435/spectra-64-19435.fits\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/194/19438\r\n",
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/194/19438/spectra-64-19438.fits\r\n"
      ]
     }
    ],
@@ -726,25 +862,170 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### TODO: Example reading cframe files ###\n",
-    "\n",
-    "### TODO: Example reading spectra files ###\n"
+    "As a quick example, let's plot up the zeroth spectrum in healpix pixel `19435`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "specfilename = desispec.io.findfile('spectra', groupname=19435, nside=nside)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reading /Users/ioannis/research/projects/desi/spectro/redux/example/spectra-64/194/19435/spectra-64-19435.fits\n"
+     ]
+    }
+   ],
+   "source": [
+    "print('Reading {}'.format(specfilename))\n",
+    "specobj = desispec.io.read_spectra(specfilename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['R',\n",
+       " '__class__',\n",
+       " '__delattr__',\n",
+       " '__dict__',\n",
+       " '__dir__',\n",
+       " '__doc__',\n",
+       " '__eq__',\n",
+       " '__format__',\n",
+       " '__ge__',\n",
+       " '__getattribute__',\n",
+       " '__gt__',\n",
+       " '__hash__',\n",
+       " '__init__',\n",
+       " '__le__',\n",
+       " '__lt__',\n",
+       " '__module__',\n",
+       " '__ne__',\n",
+       " '__new__',\n",
+       " '__reduce__',\n",
+       " '__reduce_ex__',\n",
+       " '__repr__',\n",
+       " '__setattr__',\n",
+       " '__sizeof__',\n",
+       " '__str__',\n",
+       " '__subclasshook__',\n",
+       " '__weakref__',\n",
+       " '_bands',\n",
+       " '_ftype',\n",
+       " '_single',\n",
+       " 'bands',\n",
+       " 'extra',\n",
+       " 'fibermap',\n",
+       " 'flux',\n",
+       " 'ftype',\n",
+       " 'ivar',\n",
+       " 'mask',\n",
+       " 'meta',\n",
+       " 'num_spectra',\n",
+       " 'num_targets',\n",
+       " 'resolution_data',\n",
+       " 'select',\n",
+       " 'target_ids',\n",
+       " 'update',\n",
+       " 'wave',\n",
+       " 'wavelength_grid']"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dir(specobj)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(dict_keys(['r', 'b', 'z']), dict_keys(['r', 'b', 'z']))"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "specobj.wave.keys(), specobj.flux.keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.text.Text at 0x11b160828>"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZUAAAEKCAYAAADaa8itAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3Xe8HFX5x/HPQyK9BgKGEhKkKKAEciXSg5RAQBAUJaLS\n4Yf8BFFQsIEiTQT0J0UCJhRBqQEEpQSpoYYQeg0tCYGEGsAAKc/vjzObnbt3y+zu7M7u3u/79drX\nTtvZZ/bunWfnnDPnmLsjIiKShkWyDkBERDqHkoqIiKRGSUVERFKjpCIiIqlRUhERkdQoqYiISGqU\nVEREJDVKKiIikholFRERSU3frANopJVWWskHDRqUdRgiIm3lkUceecvd+9fy2o5OKoMGDWLixIlZ\nhyEi0lbM7NVaX6viLxERSY2SioiIpEZJRUREUqOkIiIiqVFSERGR1CipiIhIapRUREQkNUoqRXzy\nCVx0EWikZRGR6iipFHHCCbD//jBuXNaRiIi0FyWVIt54Izy//362cYiItBslFRERSU3LJRUzG2Nm\nM83sydiyfmZ2m5m9ED2vkGWMIgI8/TRsvz3MmZN1JNJCWi6pABcBOxUsOxa43d3XAW6P5kUkS0ce\nCbffDvfem3Uk0kJaLqm4+93AOwWLdwcujqYvBr7enFia8S4iIp2j5ZJKCau4+4xo+g1glUa+mVkj\n9y41+/BDFbWItLh2SSoLubsDJa8hzOwQM5toZhNnzZrVxMik4ZZZBtZaK+soRKSMdkkqb5rZAIDo\neWapDd19tLt3uXtX//41DVwmrSzX3ltEWlK7JJUbgH2j6X2B65vxpqpTERGpTsslFTP7O3A/sJ6Z\nTTOzA4FTgR3M7AVg+2i+gTHkp+fPhwULGvluIiKdo+XGqHf3USVWbdfUQCJ9+8Lmm8OECVm8u4hI\ne2m5K5VWdN99WUcgItIelFRERCQ1LVf81UpUUd8i5s2DmSUb/IlIC9GVShG6+bE1fPGLsOWWhO5A\nVlst63CkFP36khhdqUjLejLXpeirN2Qah4gkpysVEamPLu0lRklFWp9OWo13G/Ba1kFIJ1DxVxkq\nKm4RSiqNtyOwDDA760Ck3elKpQidw6RX+iDrAKQTKKlI61OWF2kbSioiIpIaJZUiZkflyg8/nG0c\nEnn11awjEJGElFSKyHUeecEF2cYhItJulFSKUBG+iEhtlFRqcNddMG5c1lGIiLQe3adSRKUrleHD\nw7PuYxFB/wjSja5UilDxV+e48EK45Zaso2hx82t8nf5RpAhdqRSh/5XOcfDB4Vk/psv4tMbX6UOV\nInSlUoSSikgV9A8jMUoq0n4GDYLLLss6ChEpQkmliPlFypinTw8/yB58sPnxSIFXX4WDDso6ChEp\nQkmliKlTey476qjwfO65zY1FRKSdKKkkdNVV4fmSS7KNQ0Q6hANjqL2hRItSUpH2pMrh9KgRVzau\nAg4ETsw6kHQpqYgk4a4mtJKud6PnmZlGkTolFZEkdtoJFtG/Szfjx2cdgbQg/ZeIJHHrrVlHINIW\nlFSkPc2ZAzM7rNygXalYUGKUVKR9/elPiTctdu+RiKRPSUV6hd//PusIRHoHJZUUTJqk8VVa3fPP\nZx2BSAkdVnrYdr0Um9krwAeEDrvnuXtXlvG89x4MHRqmVbTcuvS3KWNyna/XPUMS03ZJJbKtu7+V\ndRAAq66adQS9mE5m6Xgz6wB6uQ77GtdU/GVmS5lZn7SDaUdz5mQdgSShKxWR5kiUVMxsETP7jpnd\nZGYzgWeBGWb2tJmdbmZrNzbMbhwYb2aPmNkhRWI9xMwmmtnEWbNmNTGs0t56C/bbD/7736wjESlC\nCTdbHfb5J71SuQP4HHAc8Fl3X8PdVwa2BB4ATjOz7zYoxkJbuvsQYGfgcDPbOr7S3Ue7e5e7d/Xv\n379JIZX3y1/CxReHh2Tjww+zjqCFXVnn6085JZUwep0OK/bKSVqnsr27zy1c6O7vANcA15jZZ1KN\nrAR3nx49zzSzccCmwN3NeO9a5YpeclUAb7wByy0HSyyRXUy9QbzI68UXs4uj5d1T5+vvuCOVMHqd\nDrtCyUl0pVIsodSyTb2iupxlctPAjsCTjX7fpHbYoXzZfS6pDBgQtpXGOuGE/LTqVKRlddgVS8Wk\nYmY7mNkFZjYkmu9Rj9FEqwD3mtljwEPATe5+c1bBFDY+Gj8ePi0yNkKxE9qECY2JqVep0Ppr9Oj8\n9BNPNDiWdqaE21wXAWfG5jvs809S/HUAcBjwSzPrBwxpbEiluftLwEZZvX8SuQTiDhddBN/+Nlxw\nQVimFrDNc+WVoZhRpG4PA3sCTwDLp7C//aPn81PYVwtKUvz1gbu/5+5HE4qbvtzgmDrC+PFwwAHw\nhS9kHUnvdN55WUfQRvRjp7wTgGlA2qULHXaFkpMkqdyUm3D3YwENqJtArrXRa6/llyW5Ujn0ULjh\nhsbEJCJ1aFQSMMINqA2vlW6OiknF3a/PTZtZF/BVM5tkZo+b2RNm9nhDI2xTxZqwJkkqo0fD7run\nH09vo6LGKryedQAtrtHfpf8CnyVUMnSAau+ovwwYC3wD+Bqwa/QsBX73u6wj6CXmzYN994Xnnss6\nEmmW/xBO9C3T7rNGuWSVuym6Qzqlrbbvr1nursKZCl5+uXivuPr13ACPPAKXXALPPgsPPph1NNIM\nV0fPdwEbNvF90y7+yu3PCubbXLVJ5XgzuxC4Hfgkt9Ddr001qjY3Zkzpdeeck5++8UbYddfGx9Ox\n4lm6oN22EniNPgSWzjqICgpPxo10K9CoVoTvR8/XNGj/Gak2qewPfB74DLAgWuaAkkpk/vzSfXyZ\ndS8W+9rXSt+UN2cOLLIILLZY+jF2DHdlj7RNAEZkHUQFhUnlQ2DRaP5lYN0U36uRn8WjBfO99Erl\ny+6+XkMi6RBjxsCZZxZfd955YfyVJJZcElZbDaZNSy+2jjNmTMjMoCuVRpo+PbSR33ffrCMJCpPK\nMsAwws0OZxOa/66WQVzVSlqj/VtgA0JNdhuotqL+PjNbvyGRdIi33y69buJE+Pjj7svOPbf09tOn\nl143fz7ce291sXWc11/PZw/1w9I4O+4Yutl+992sI+ku/sPhQeDOaPqdBr1f2l+xUj987iZfDgRw\nPPBNQjHcMGBGynGkrNqk8hVgspk9pybFxf3mN9Vtf/jh+a5d7r+/5/pPPw0JpNBJJ8FWW8HdLd2V\nZnYeeyzrCNrUy0BhV0O5rgkWLCjcOhtZ/X44m5AI0voYCpOKAzcD2wBnFNn+fELnVH9J6f0bpNqk\nshOwDuHOejUpTsmxx4arks0377luscVg++17Ln/qqfD8uu4xAOCTT8NFy4QJIQm/1RLjgrahw4BW\nr8drZkV93G3Rc5H+/RKL17cWi39q9FyuhXyLX5RXlVTc/dVij0YF11ucdRasvnrp9Xfe2XNZrtTn\nttt6+eiTUZcFH8wO/2m//CX0bddBsiWZeFJpt3FyDoxNF7aAdyD3v1wscbVJPWFVScXMLjaz5WPz\nK5hZmQa00mhjxoQitDS89Vb5OqGWlLtkixRLwFKDeLl9q9VXxZNKse5lGx1uPft/OjZd5F42csXn\nl1bYz1RCXUuL/Wmg+uKvL7n7wvZL7v4usHG6IUkS8dZNY8fWtg93OPFEeDW61uzfH1Zaqf7YFizI\n77Phjj8eAGvWiW/OHPjDH2Dq1MrbtrN4K8XcZxuvqD/1VGBtYFDzYroe6CJfp2HAS7H18+rY96fA\n6YT+t6YCo4CPy76iNuW+pk734rFXCrZ/Njb9TUKrsMmpRZaaapPKIma2Qm4m6gpfhQ1NcsQR8I9/\nhOnCJrMffxx6RL7sstKvX3JJ+EasWeLzz8Ovfw177JFunKedBoMGNbvnFKcP8+jDPMBZhtmNeZvj\njoNjjoGBAxuz/1YRbxySawf/gx+E57lzw+fAC4Sa/Sb5DvAI3U+8cbmTbi3FwX8EfkqojD8C+Aex\nrnRTVGlcn/j/9WDgrNj832PTD0XPhd3nzyLc//IQmak2qZwBPGBmJ5rZicB9wO/TD0uK+fOfYdSo\n4uv22y/0VPL974f5eIuxKVPgmmvCj+xrY7ep5rYpVSfz6KPwwgvVx/mf/4TneA/NzfAc6zGPz3AN\n32A2y/F9Lk7/TZK2AJgwAW6/Pf33r8WCBfB//wcffQTvv195ewgnWOjejO6DD8Lzppsmf++5hCuA\nT4DHCHmoXpUq6mtJKrnfIB8B10XTWfQaXHhGLta6M371Ev86zgNWBjYhND3OSKKkYmabmZm5+yXA\nHoSOmt8E9nT3SqV/0gRXXBGezWDSpFBZbQazZsHaa8M3v9nzNQ8/HJ4XKfEt2GQTWLfI3cnTppW/\nIsopLJF69lmY3aALiP/+Fz4XlYXsGfXMdzH7LVyf2pVL0mK2Lbcs3myvkj33hM9/Pj9/7bXhD1nu\npqVybr89JJQjj4SNN4bll09W8fTv6HlIbkw+g4/XDJOTy5S5HEIoOsoZTUhQpxOG96vnbvdcEllQ\nMF9oJtUXhRX7s5b6UdTIktbCY6pUOR+v7K+n+C9FSa9Uvg88Ymb/ADYFrnb3s9396Qqvk5S8+GJ+\n+p13St9pP38+DB2any91/njkkXB1A9Xffb7ddvDd74Z9mMG//919fbFu/yEUz9Vynk1ijbeKn+gm\nMpTvcBmzWa6xHU7OnAkHHdTz7tZqjRvXvdwwN2zo4zXeDrb99nDUUWE6d9lZ7IaokvYh3EFwDEz+\nR/ky/NeACwhFRzm578IHVbxlJZWuVL4NHFnm9fPoeRVycpF9lkoejUoqTs8zcqUeNaaRL/ZrkUr7\nREnF3Q9z900IY6CtAFxkZveb2clmtrWZ9WlkkALrrJOfXnFFuOeeZK877riey669Frq68vNz58Ju\nu+XnR44MPS3H3XknLLssLLpovgfmXAwjR+YT2S23wAMPlI4nd3XULEOZxLGcGmaOPhp+X2dp7ZMl\n+ls/+mj461/DOMalzJoVsvCNN9YXQ72q+hXxN+AW4LQw+/wnpTf9fmx6DbpXt6R5wktyn0qpnire\nJfRcuGiJ9fF9nlZlXPVy6HFBPTHB624Dfkd6N2XWqdr7VJ5197PcfSfgq8C9wF70bHEtLWLKlJ7L\nCk/6zz8P//xnfv7f/4add87P33gjbLttKFKfG/uFF7/BetKk8Jw02RW69dZQBzNvHvztb+nevD2f\n6DfPvffCz34WpqdNC03fcsVZ7qWvBuIHHd9m7NiexWHlisdyxUZ/+lPy4BvpvffKV5r9q8ixfPtb\npbeP/82mAWsBx0bzhdVLc6n+6iWNLuKLNeMt9h4QElAzfZRwu8LjPwL4VZHlGam2on4hd5/j7v9y\n9x+6e1flV0irOP30ytvES2COOKL4Ns8+233eDC6N1bDl6nn+85/Q71mce7iKeu65sP8RI+BLX4Iz\nzoDvfS8klrT0oaCfm513hjXWCE3fnoia45x3Hmy0UQh2n33CwVxzTbibctESP2sPOGBhk+aq+iAb\nP7785Vxcbn+FVxevvQY//GHxPnwquf9+eOYZGDaseKVZzi7lLgW+3HNRuc0nFcx/A1i2zPbl5D7i\n68puVZt2uMGw1GBeLZJUcPfED8JVyTLR9K8IXd5vXM0+mvkYOnSo1yL8J+uRxmPs2J7L3N2vvrr4\n9p/7XHju2ze2faODHD7c/eCDw/TgwdW/Pv6lGTOm+3zcaaflly++uPuCBaW/fDkjRoT5U05x//TT\n/PJttgnL7747hS+zV/HYzZ1Vey4fU8U+vGD+iPKHsNDS0fa7VfE+hcaXWJ9bdkqC/X6QMN5iqvqs\nq3y8VzBfT5gwsdZIqtsYHo+etyT0CboL8GCDP6qaH0oqrfm48MLqts884EqPSZPy03/9q/uECfn5\nBQvc77yz+Oseeih84V5+2f2OO9wffjh20N59P+B+1FFh+eOP55fdfbf7JZe4L7NM96RT1Ze5mv+q\nn1W5fZGHl1hWzoLYtl+r4n3i7iqy/sWCeE5NsN+p7n6zu/8gmv9JbD+V1PvZlXvMqnD8VagnqVR7\n42LuWnsXYLS732RmGo1dqnLQQVlHkLJNNslPu8MWW+TnDzgALrqo+Os+/TQUv33pSz3Xvf129/1A\nvvVafPtDDw29CH/wQXj069c9ltSd2oB9xjj5QvlPCZXq0L2gvtbD2qZgfnPgfrp3iZKk+GsvIF56\neUb0yMV1F6Hu5uDawqzZ1ZU3aYZq61Smm9n5hEZ7/zKzxWrYh0jnKryfpFRCgXAjYrGWFJC/izXu\nvvt6LnvmmXz3KfF6lxkzuie7VlLuxB1vQluqoVlajedyLavj9X0/S/C6StVhwwn36wBMp3RLtLSV\n6mmgyaq6+RH4FqF94QgPfYD1A45pYHwi7SVXcZ/EkUeWvpr417+KLy9392i/fqEZ3pQpsNlm5W9S\nbDV3A3vSM5E8S/1jxL9N+V/xaf0s/mLB/DOEgUEOJyTSRned8pMG7z+hpMVf3wfOIVzU3UzUGNDd\nZ9Dy45CJtKiZM6sfTfHQQ8uvj9/52k5yRVPxlk3XAd+rY59rEu7fuJDi3Z3knFVmXTWepHvT6cIx\ncjPsOqWZzKsodzWzzwM7AyOA5YA7CElmgrvX0Laxsbq6unxiYVvWBDS+eWvxtmjn2c4aUfcimZsF\n1NjruJk94jXeKqKbH0VEOlGR3jSaoarWX2b24yKLJwN/TSccERFJxYWEvtiarNoqqi7gf4DVoseh\nhHHrR5vZT8u9MA1mtpOZPWdmL5rZsZVfISIizVRtUlkd2MTD7T4/AYYSevDfBmL9jDdA1GnlOYQ6\nnfWBUWZWWBUmIiIZqjaprEz3Rn9zgVXcfQ6lW5WnZVPgRXd/yd0/JXSwvXuD31NERKpQ7R31lwEP\nmtn10fzXgMvNbCmg0WOrrEYYPTpnGr2mkZ6ISHtInFSimx8vIowJl+s/4n/cPddmd590Q6uNmR1C\ndD/rwE4fR1xEpMUkTiru7mb2L3f/IsmGjknbdMLQPzmrR8u6cffRhEFM6erqUgN8EemdqhngM0XV\n1qlMMrMiAyk0xcPAOmY22MwWBfYGbsgoFhGR1rZkNm9bbVIZBtxvZlPM7HEze8LMahw8uzruPg/4\nX0LfY88AV7r7U814b5G20KWx8noYCLxJ99pYaahqK+pHNCSKhNz9X0CJnvZEerH994cxY9THUNxH\nQB9gsTLbHELodbjRP41PI1kPyGnKqPC/2m5aXi32aFRwIr3Cb39b+2sXWwxuvhn+8pcwf+216cTU\nTKsQOnw8m9CG9GXCePcee9RiSconFIDzgaNq3H8559C9y/slCcMa9gJVJRULvmtmv47mB5rZpo0J\nTaSBrroqP11sDPp58/LLzz472T5vuimMG1+N+fPhV7+q7jU5P/4xfPwxjBiRj3WPPUJ3+rNm9Rzk\nK1UplTyfRujafitCF/FfAAbR3LHi+8Sm6+3k+Vjg78APgMOAK2P7LRwkrENVW6dyLrAZMCqa/4CQ\nk0WK2nDD7vO5c9/hh4fnVVYJz5deCk8+2by4+OY389MTJ8JvfhN+8b/5Zjgp9+kDL78M994bpsuZ\nOhXuvx9Gjqy8bZw7LBL9C/7yl3DPPT23GTsWTj89+T5zVloJLr88P3/zzXBWWn28A5RJnhslePk5\nwD3A0XWEMKDE8m2Bi6vYz2di059PsP3iRZb9jnCzxSmEJkQ5ewFvEc6azVY4vkuzVDP2MDApen40\ntuyxWscybvRDY9SXfxxxRPn1q67qfswxlfdz3nml1x12WH76+efd77knTE+e7L7yyu433VT8sx8y\nJD/dkIOPv1klc+bktx05Mj99wAHuLxYMTn7UUdXFUOiOO9y//OWwfu+9w7IpU4q//sQTy8c9d273\n9/rzn8P0wIHur78e25fX8Nim9Lp/Jnj99ZU+9ALF9nFMieXnJ9zH3Gj5VbFl+xTZbpOC+SUL5k+u\n8ziSPNaLTa9UYpsjC+brQB1j1Fe3cejivk8sufSPJ5hWeyipFH+ssYb7+uuHYx0+vOf6DTd0v/zy\n/Ofxxhul97X77uGce+ed7iNG9Fz/29+G529/O9lnf+ml7sOGdf87pP4BmIU3eOkl95kzq/tSvP12\nLLAiLrig9Pvutlv3+VJyWfrQQ8N8LqkMGhQ+6DfecP/jH90/+aR8zPPmdX+vadPcV1zR/emnw/zJ\nJ3v1SeUL7lzvzqLu7O7O0WH5CHf/sbtP9uYllZ+WWH5ZiX1sXbBdztWxZWOL7K8wqSxRYj+1HkeS\nx/ux6bfdfW13/3XBNh/XEVdhmE1MKvsQ7g2ZBpwEPAfsVcdH1dBHJySVxRdPf5+vv54/1ksv7bl+\n5Mjun8fHH3dfP2BA+EF9fZETQ+G+Pv3U/Yor3BcsqP3vkMZBr85r7q++GuZr+V7ET87lksKCBe79\n+hWPY//9u8+Xcs45Yf1hh4X5F18M84MHVxfz/Pnl32thgvQqHoXHtZMvTCo5NybYz3XVHUpVSeXx\nEvvYpmC7nGsKlhXurzCpLF9iP7UeR5KHu/sJ7n53if0V238d6kkq1bb+ugz4KaHkcAbwdXe/qvyr\npB7rrVd63XLL9Vw2ZUrp7VdeOTzHW52699xu7NjS+/jDH+Duu2H4cNhtt57rc2ebnM98Br71rca2\ndD2FyqMgTGMNGDgw1JHcemvjgjGDr3wlTI8dC2uuCbvuWt0+FizI7yv+XKxBQaVYINSvFNOvX/Ev\nQDd3VVjv3Z4SW6HK7ZPYDniE0nUJO5ZYXu67Ga8iu51wQ8M/yaaO5HhCg4YWV21FPR5GfzzH3c92\n92caEVRvUu48seaacN11pddPngxXXw1rrx3mn3gC1lqr53b77Qc/+hEssUSYL3aCXyPWAU4u+eTk\nznGLLQY/+Un+/VrF3udsnXzjLbYIJ9NGOvdc+M53YNQoeOUVWL/KERpyJ/pcJf7gwXDccXDjjdXt\nxyzsa9as6l7Xze+rf0mlezCvBqr4kyXWB9ikzPpjCf2sJzWTUMmeS5jLEQbe2BK4D3iVbDqsKlSs\nwUKxxgRNUnVSkXSdeWbpdWefDYMGhXNUzjmxtnaDBsE3vlE6MT36KLz2WvjBfNZZcNttcOKJPZMG\nwNZl/slzSaWahk3NNPh/8vfkvtOQn8BVWnNNuOyykIXjch9kJfPnh+dcUjGDk0/OKJvnYr4LXgcO\nOKDyS1YBvldm/TfqjwqovtnxIoQeA5PqDyxf5v0GUn8T5HrNAp4vsvyFZgeSp6SSsaWXLr1ul13C\n82GHJdtX7grkj38Mzxtu2P0KZJ11QsvV+JXKaquF5y98ofL+l1++8jaZWCT/NT6SPzGbZXiZQQBM\nYS0ODv2LZqdiEVOBIUPC85Zbph9LNVaPd6333/CLuMexlCj+ys0f2IC4Tk5hH5elsI9WsBJQ7BxS\nTfJMWcWkYmb3mtnB0ZgpkrK+fbtficQVK6YqVzeR+38/8sgw3TdBJzxf/SrceScce2x4PuGEntss\ntRT86U+hLiWpE04IV0bN9je+x3LMZhMmsR7PsjZTuJCDmx9IMUmTy/Dh8PrrsNdeDQ2nIgPOKfHl\nXKjEMeWKZL6eYjxpitdVtmrPNq0aVwVJ+v56hlC6OMbM3gPGuvsDjQ2r96j2R2wjbLNN/jk3XeiI\nI6rb5/HH1xdT1R54gF2+8tbC2fdYgfcaVRQ2YADMmFH963KVWknfI2tuMGowHP4+obHnzqV/1RR+\nj08k3AS5S0qxfI1QQV6vMcCvqHxj4Lax6Rb4H20nSZLKPHe/HrjezNYgXNAqqaRkwQLYaaf8/E03\n5Yu9isn9Txe7CunVfQkOG9a8nkYnT4Zp06p/3Vprhb65+vevLsFkxqJWWrFyz6TFX4vRc9i+l4D5\nNYZyEXA6IVnlOhio5fu+EaUHzMgVAX9I8T7DevP/VxWSJJWFpY/uPhU4oWHRdIiNNoLHHku2bZ8+\noXFPzsiR5bdfZ53wnKs3kSaZPh0++ihMr7xy8dYOpcRPxHvskW5cjWQp/UT/C7A2MLjShmX0I9zI\nAI27coj+tygs6D+IMOjGGkgCFetU3P3eZgTSST6fpP8g4Gc/C/dwVGO77WDSJPjBD/LLRo+GzTbL\nJ5zeaurU0OKtIVdsq65a+wecS0ArrphePA03Dda9JEweFevGt5YP91DCPSRpS+vvvC2hjuU3JdYf\nTkhkJW73qVm55s9trOrWX2bW7FEB2k7S/7tTTw03Bya17LLheeONu7/HFlvAffdVf29cp1l99dBw\n6uOPs46kwFFHhXbd+++fdSRV+F9YNLoyO/PM/NVWj+aKNd782EqWA54FhjTxPb9LSFYdqGLxl5ld\nGZ8lfPSnNSyiDvfjHxe/N+Vb34IvRwM133FHaIkVN3p0aBQklbVccu3bN9yB2m6K/To66aRwh/6v\nfx0taOdskiGnYz+6JHUqs939oNyMmZ3XwHg6QrkWXdtuWzypXHFFfnr48J4J5OAWaRUrvcXzFK0E\nWXrpMP7LwqQSaeYJslNOxpWOwxJs04KSFH+dVDD/i0YE0ql+/vPuv5yr7QZKpOn2eY5wJ0ESGRZ/\nGbADsCih65QzMoihHpU+s1a92biCJBX1LwOY2UrR/DuNDipr9d45Hi81OOkk+OST+vbXW02cCA/U\n2Hi90d17dbQ1Z4fnRJWDURvhKuoG6xY/Gd8KfEIY8GvD4pu3pMLir8JGAovRtjduVFNRP6ZhUbSY\nUjcAVmPjjevfR283dCgMG1bbaxvZEXHHWxCd7RIllXvg4PfCfSRSnXhS2aFg3Q/IN3FuM9UkFd36\nk9C668KDD7ZgK6RO8pOflF29eIa9tHaMckll9VznUg4/fw9WbUpE7e/U2PQGCbZvh3tkCySpqM9p\nwyqj5hs/PlzpJOl3S+qQ60QySU+YUp3cZ1uuGd0TT8AKGfcI3Y4/c1eLTefuZ9uO0h1yvgK82+CY\nUqYrlZRtt50SSlOYhRPbhAlZR9J5NtkYjj4azivT0HP55cOgZ1lo55+38bPoSsAthPFlSh3TynTv\n/LINVHP6O65hUbSYRtyR/fOfqzgsdRu2U81sG1mkD5x+euXtcrLqdK4TfubmRqNs0bGKalFNUpkX\n3U2fu4CrgSuDAAAQ00lEQVSbDtyg0R+TOamwYbbUp8KJbPWC8STaqoeUdjF4cBgFrtl3m+aG1G3E\n6JHNUnhlMozQq+JH5DvMbFOJir+iZPIPwm+Dh6KHAX83s8oDhHeocqM2lvOXv4SSG6lDhTEDlluu\n+/wiGo4uuWUSbnftteHR7G76hwMf0LPFVDso9VvICGPQt8CIB/VKeqVyILCBu8+NLzSzM4Gn6N6m\nodc46qjQ7Uq1Dj00/VhEUpO088d+/bLrdbnMiKltLddp5Sp17CPjZJv099sCijcaHEB+EOte6fLL\n4eGH4eutOsJdp+rVg8c0mD7axit1ob0PcClwdI37fQm4rsbXpiTplcqPgNvN7AVgarRsIGGUhP9t\nRGDtYtSo8DxuXLZxiKTi8qwD6OUWIfRgXKt6xqxJSaKk4u43m9m6wKZ0r6h/2N1rHcstMTM7ATgY\nmBUt+rm7N2ygP/0Ill5rVNYB9BIdfI5J3PrL3ReQbW80Z7n7HzJ8f2ljFer1RZqrg7+PdbeJMbN2\nGnlIepFNOnRkPWljHXyFkpNGQ8tSg3Cm7Ydm9riZjTGzjPuHkMwlKKO8/Xa4NxoMOzcAmog0VqLi\nLzN7vNQq6mv8Fn+P8cBni6z6BXAecCLhovFEwsgJB5TYzyHAIQADs+pGQhpvlcpfu+WXD0MtP/SQ\nugiTFtPBxV9J61RWAUbQs2szA+5LIxB33z7JdmZ2AXBjmf2MBkYDdHV1dfCfrpf74Q8Tb6qrFGkZ\nvaD4K2lSuRFY2t0nF64wsztTjagIMxvg7jOi2T2AJxv9ntLi+nRQZ0mt4otZByCdIGmT4gPLrPtO\neuGU9HszG0K4aHwFyPye9K99LesIRFK2btYBSCdIWqdi7uUbZSbZplbu/r1G7LdWap4qHeVHwB+B\njbIORDpB0tZfd5jZD82sW823mS1qZl81s4uBfdMPT0QabqmsA5BOkrROZSdCa6u/m9lg4D1gccIo\nALcCf3T3RxsToog0RS+oRG4ZHVzakbRO5WPgXOBcM/sMoS/NOe7+XiODawUrrADvttlwnh3vtNOy\njkCkNr0gcVd986O7z3X3GZ2cUOL31V2XcY+fUoRuOklXB/9qlubT0EUVbL01rBcbI/pHP8ouFpGG\n6gW/oltGBydyJZUE4lcuK61UejsRkbJ6QeKuKqmY2fpFlg1PLRqRJDQ2Qbq2jJ6/kmkUvUMHX6Hk\nVHulcqWZ/cyCJczsz8ApjQislegcJh1tZ+Btkg8jLFJGtUllGLAGob+vh4HXgS3SDqqVDRmSdQQi\nDdAv6wB6iV7wA7XapDIXmAMsQbhP5eVo8K6OUu7KZJddmheHlKBLR5GWVW1SeZiQVL4MbAWMMrOr\nUo+qxegclrF++hktHaaD61YSDyccOdDdJ0bTM4Ddzayl+uVqBPX11WKWXTbrCERq0wt+oFabVEaa\n2ciGRCJSSuGl4lZbZROHiFRUbVL5KDa9OLAr8Ex64YgUoUtF6TQd/JWuKqm4+xnxeTP7A3BLqhG1\nINWpiIgkU+8d9UsCq6cRSCvrG6VeDcyVEWV16TQd/JWu6krFzJ4gf+HWB+gP/DbtoLJWeA7LjVx7\n/PHNj0VEOpCKvxbaNTY9D3jT3eelGE9L0g9lEUlFLziXVFun8mqjAhERkfaXqE7FzD4ws9nRo8d0\no4PM2rnnwrBhsMEGWUciIh1BxV9s2JuvUoYNgwceyDoKEWl7vaD4K2nrr3G5CTO7pkGxtIwddsg6\nAulGlVoibSNpUon/V6/ViEBaycEHZx2BdLPoollHIJKOAdFzj5GpOkfSpOIlpjuSGdx4I0ycWHlb\naYKLLso6ApF0bA7cBXTw7QlJ61Q2iirkDVgiVjlvgLt7x/Xwpy7uW8iAAfnp3E1DIu1q66wDaKxE\nScXd9Z8srUH1KyItrd5uWkSaa/jwrCMQkTKUVKT1xa9Oxo0rvZ2IZE5JRdrL0ktnHYGIlKGkIiIi\nqWmppGJme5nZU2a2wMy6CtYdZ2YvmtlzZjYiqxhFRKS0anspbrQngT2B8+MLzWx9YG9gA2BVYLyZ\nrevu85sfooiIlNJSVyru/oy7P1dk1e7AP9z9E3d/GXgR2LS50YmISCUtlVTKWA2YGpufFi0TEZEW\n0vTiLzMbD3y2yKpfuPv1Kez/EOAQgIEDB9a7OxERqULTk4q7b1/Dy6YDa8TmV4+WFdv/aGA0QFdX\nV8f3UyYi0krapfjrBmBvM1vMzAYD6wAPZRyTiIgUaKmkYmZ7mNk0YDPgJjO7BcDdnwKuBJ4GbgYO\nV8uvXkT9fYm0jZZqUuzu44gNCFaw7iTgpOZGJCIi1WipKxUREWlvSioiIpIaJRUREUmNkoqIiKRG\nSUVan1p/ibQNJRUREUmNkoq0vpVXzjoCEUlISUVa34orZh2BiCSkpCIiIqlRUhERkdQoqYiISGqU\nVEREJDVKKiIikholFRERSY2SioiIpEZJRUREUqOkIiIiqVFSERGR1CipiIhIapRUREQkNUoqIiKS\nGiUVERFJjZKKiIikRklFRERSo6QiIiKpUVIREZHUKKmIiEhqlFRERCQ1SioiIpKavlkHIJLIuHHQ\np0/WUYhIBUoq0h6+/vWsIxCRBFqq+MvM9jKzp8xsgZl1xZYPMrM5ZjY5evwlyzhFRKS4VrtSeRLY\nEzi/yLop7j6kyfGIiEgVWiqpuPszAGaWdSgiIlKDlir+qmBwVPR1l5ltVWojMzvEzCaa2cRZs2Y1\nMz4RkV6v6VcqZjYe+GyRVb9w9+tLvGwGMNDd3zazocB1ZraBu88u3NDdRwOjAbq6ujytuEVEpLKm\nJxV3376G13wCfBJNP2JmU4B1gYkphyciInVoi+IvM+tvZn2i6bWAdYCXso1KREQKtVRSMbM9zGwa\nsBlwk5ndEq3aGnjczCYDVwP/4+7vZBWniIgUZ+6dW+1gZrOAV7OOI2Yl4K2sg6hTux9Du8cPOoZW\n0O7xQ/ljWNPd+9ey045OKq3GzCa6e1flLVtXux9Du8cPOoZW0O7xQ+OOoaWKv0REpL0pqYiISGqU\nVJprdNYBpKDdj6Hd4wcdQyto9/ihQcegOhUREUmNrlRERCQ1SiopMLM+Zvaomd0Yzfczs9vM7IXo\neYXYtseZ2Ytm9pyZjYgtH2pmT0Tr/s+a2Kummb0SvfdkM5vYbsdgZsub2dVm9qyZPWNmm7VZ/OvF\nhnWYbGazzexHbXYMR0XDVjxpZn83s8XbKf7ovY+M4n/KzH4ULWvpYzCzMWY208yejC1LLWYzW8zM\nroiWP2hmgyoG5e561PkAfgxcDtwYzf8eODaaPhY4LZpeH3gMWAwYDEwB+kTrHgK+Ahjwb2DnJsb/\nCrBSwbK2OQbgYuCgaHpRYPl2ir/gWPoAbwBrtssxAKsBLwNLRPNXAvu1S/zR+25IGHpjSUL3VeOB\ntVv9GAg3hm8CPBlbllrMwA+Av0TTewNXVIyp2f80nfYAVgduB75KPqk8BwyIpgcAz0XTxwHHxV57\nC6H3gAHAs7Hlo4Dzm3gMr9AzqbTFMQDLRSc0a8f4ixzPjsCEdjoGQlKZCvQjnJBvjI6jLeKP3msv\n4K+x+V8BP22HYwAG0T2ppBZzbptoui/hZkkrF4+Kv+r3R8KXb0Fs2SruPiOafgNYJZrO/fPlTIuW\nrRZNFy5vFgfGm9kjZnZItKxdjmEwMAsYa6EI8kIzW4r2ib/Q3sDfo+m2OAZ3nw78AXiN0KP4++5+\nK20Sf+RJYCszW9HMlgRGAmvQXseQk2bMC1/j7vOA94EVy725kkodzGxXYKa7P1JqGw8pvtWb2G3p\nYVTNnYHDzWzr+MoWP4a+hMv/89x9Y+AjwiX/Qi0e/0JmtiiwG3BV4bpWPoaozH53QoJfFVjKzL4b\n36aV44eFAwSeBtwK3AxMBuYXbNPSx1BMFjErqdRnC2A3M3sF+AfwVTP7G/CmmQ0AiJ5nRttPJ/z6\nyVk9WjY9mi5c3hTRL03cfSYwDtiU9jmGacA0d38wmr+akGTaJf64nYFJ7v5mNN8ux7A98LK7z3L3\nucC1wOa0T/wAuPtf3X2ou28NvAs8T5sdQyTNmBe+xsz6Eoqb3y735koqdXD349x9dXcfRCi2+I+7\nfxe4Adg32mxfIDf42A3A3lGLisGELvwfii5VZ5vZV6JWF9+PvaahzGwpM1smN00oC3+yXY7B3d8A\npprZetGi7YCn2yX+AqPIF33lYm2HY3gN+IqZLRm973bAM20UPwBmtnL0PBDYk9D4pq2OIRZbWjHH\n9/VNwjmu/JVPMyrBesMDGE6+on5FQuX9C4RWJP1i2/2C0OriOWKtQoAuwsl8CnA2FSrDUox7LUKL\nkMeApwgjcLbbMQwhDNj2OHAdsEI7xR+991KEX4DLxZa1zTEAvwGejd77UkILo7aJP3rvewg/SB4D\ntmuHvwHhR8gMYC7hqv3ANGMGFicUx75IaCG2VqWYdEe9iIikRsVfIiKSGiUVERFJjZKKiIikRklF\nRERSo6QiIiKpUVKRjmZmZ+V6nI3mbzGzC2PzZ5jZj1N+zw/T3F+0zyFmNjI2f4KZHZ3gdWZm/zGz\nZWPLvm5mbmafjy3rb2Y3px239D5KKtLpJhDu7sbMFgFWAjaIrd8cuC+DuKo1hNAfVbVGAo+5++zY\nslHAvdEzAO4+C5hhZlvUFaX0ekoq0unuI/TECiGZPAl8YGYrmNliwBeASWa2tJndbmaTonEldgcw\ns1PN7PDczuJXCGZ2jJk9bGaPm9lvir15sW3MbJCFcV8usDB2x61mtkS07svRtpPN7HQL43ssCvwW\n+Ha0/NvR7tc3szvN7CUzO6LE8e9D7I5uM1sa2JJwk9zeBdteF20vUjMlFelo7v46MC/qemNz4H7g\nQUKi6QKecPdPgY+BPdx9E2Bb4Iyoy4orgG/Fdvkt4Aoz25HQzcWmhKuIoVbQEWeFbdYBznH3DYD3\ngG9Ey8cCh3ro4HN+dAyfAr8mjGUxxN2viLb9PDAi2v/xZvaZIh/BFkC8w9PdgZvd/XngbTMbGls3\nEdiqxEcpkoiSivQG9xESSi6p3B+bnxBtY8DJZvY4oWuL1QhdiD8KrGxmq5rZRsC77j6V0EfajsCj\nwCTCCX6dgvctt83L7j45mn4EGGRmywPLuPv90fLLKxzXTe7+ibu/Reg0cJUi2/Rz9w9i86MInZ8S\nPY+KrZtJ6GVYpGZ9sw5ApAly9SpfJBR/TQV+AswmXBlAKPbpDwx197kWep5ePFp3FaEzvc8Srlwg\nJKFT3P38Mu9bdBsLQ7J+Els0H1iihuMq3Eex/+d5ZraIuy8ws36EweS+aGZOGGXSzewYD/01LQ7M\nqSEOkYV0pSK9wX3ArsA77j7f3d8hDDm8GflK+uUIY+PMNbNtCcP55lxBqH/4JvmxTm4BDojqKDCz\n1XK93MYk2WYhd3+PUN8zLFoUr/P4AFimmoOOPEfoNJQo/kvdfU13H+TuaxBGzcwVea1LSLoiNVNS\nkd7gCUKrrwcKlr0fFR0BXAZ0mdkThK6/n81t6O5PEU7o0z0aUc/DyIaXA/dHr7magpN+km2KOBC4\nwMwmE3oufj9afgehYj5eUZ/ETYQetCEUdY0rWH8N+SKwbaPtRWqmXopFWoiZLe3uH0bTxxLGGj+y\njv0NAC5x9x0SbHs3sLu7v1vr+4moTkWktexiZscR/jdfBfarZ2fuPiNqurxswb0q3ZhZf+BMJRSp\nl65UREQkNapTERGR1CipiIhIapRUREQkNUoqIiKSGiUVERFJjZKKiIik5v8B5bE3BSfujRkAAAAA\nSUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x116eedd30>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "thisone = 0\n",
+    "fig, ax = plt.subplots()\n",
+    "for camera, color in zip( ('b', 'r', 'z'), ('blue', 'red', 'magenta') ):\n",
+    "    ax.plot(specobj.wave[camera], specobj.flux[camera][thisone], color=color)\n",
+    "ax.set_xlabel('Wavelength (A)')\n",
+    "ax.set_ylabel('Flux ($10^{-17}$ erg/s/cm$^2$)')"
+   ]
   }
  ],
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python [default]",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/doc/nb/simulating-desi-spectra.ipynb
+++ b/doc/nb/simulating-desi-spectra.ipynb
@@ -125,13 +125,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DESIMODEL environment set to /Users/ioannis/repos/desihub/desimodel\n",
-      "DESI_ROOT environment set to /Users/ioannis/research/projects/desi\n",
-      "DESI_SPECTRO_SIM environment set to /Users/ioannis/research/projects/desi/spectro/sim\n",
-      "DESI_SPECTRO_DATA environment set to /Users/ioannis/research/projects/desi/spectro/data\n",
-      "DESI_SPECTRO_REDUX environment set to /Users/ioannis/research/projects/desi/spectro/redux\n",
-      "SPECPROD environment set to dailytest\n",
-      "PIXPROD environment set to dailytest\n"
+      "DESIMODEL environment set to /Users/sbailey/desi/git/desimodel/svn/trunk\n",
+      "DESI_ROOT environment set to /data/desi\n",
+      "DESI_SPECTRO_SIM environment set to /data/desi/spectro/sim\n",
+      "DESI_SPECTRO_DATA environment set to /data/desi/spectro/data\n",
+      "DESI_SPECTRO_REDUX environment set to /data/desi/spectro/redux\n",
+      "SPECPROD environment set to debug\n",
+      "PIXPROD environment set to debug\n"
      ]
     }
    ],
@@ -143,7 +143,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's reassign the *SPECPROD* environment to something other than \"dailytest\" so that we don't conflict with the outputs of the standard DESI integration test.  In addition, we are going to make the *\\$DESI_SPECTRO_SIM* path point to *\\$DESI_SPECTRO_DATA*, in order to simplify some of the file-finding below."
+    "Let's reassign the *\\$SPECPROD* environment to something other than \"dailytest\" so that we don't conflict with the outputs of the standard DESI integration test.  In addition, we need to make raw data input *\\$DESI_SPECTO_DATA* match *\\$DESI_SPECTRO_SIM/\\$PIXPROD* where the simulated data will be written."
    ]
   },
   {
@@ -159,16 +159,24 @@
      "text": [
       "env: SPECPROD=example\n",
       "env: PIXPROD=example\n",
-      "env: DESI_SPECTRO_SIM=/Users/ioannis/research/projects/desi/spectro/redux\n"
+      "env: DESI_SPECTRO_DATA=/data/desi/spectro/sim/example/\n",
+      "Simulated raw data will be written to /data/desi/spectro/sim/example/\n",
+      "Pipeline will read raw data from /data/desi/spectro/sim/example/\n",
+      "    (without knowing that it was simulated)\n",
+      "Pipeline will write processed data to /data/desi/spectro/redux/example\n"
      ]
     }
    ],
    "source": [
-    "specprod_dir, pixprod_dir = 'example', 'example'\n",
-    "desi_spectro_data_dir = os.getenv('DESI_SPECTRO_REDUX')\n",
-    "%set_env SPECPROD=$specprod_dir\n",
-    "%set_env PIXPROD=$pixprod_dir\n",
-    "%set_env DESI_SPECTRO_SIM=$desi_spectro_data_dir"
+    "%set_env SPECPROD=example\n",
+    "%set_env PIXPROD=example\n",
+    "rawdata_dir = desisim.io.simdir()\n",
+    "%set_env DESI_SPECTRO_DATA=$rawdata_dir\n",
+    "\n",
+    "print('Simulated raw data will be written to '+desisim.io.simdir())\n",
+    "print('Pipeline will read raw data from '+desispec.io.rawdata_root())\n",
+    "print('    (without knowing that it was simulated)')\n",
+    "print('Pipeline will write processed data to '+desispec.io.specprod_root())"
    ]
   },
   {
@@ -208,7 +216,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/20170615\n"
+      "/data/desi/spectro/sim/example/20170615\n"
      ]
     }
    ],
@@ -242,24 +250,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
-      "INFO:obs.py:226:new_exposure: skyfile /Users/ioannis/repos/desihub/desimodel/data/spectra/spec-sky.dat\n",
-      "INFO:obs.py:297:new_exposure: Wrote /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/fibermap-00000000.fits\n",
-      "INFO:obs.py:305:new_exposure: Wrote /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/simspec-00000000.fits\n"
+      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:obs.py:226:new_exposure: skyfile /Users/sbailey/desi/git/desimodel/svn/trunk/data/spectra/spec-sky.dat\n",
+      "INFO:obs.py:297:new_exposure: Wrote /data/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
+      "INFO:obs.py:305:new_exposure: Wrote /data/desi/spectro/sim/example/20170615/simspec-00000000.fits\n"
      ]
     }
    ],
@@ -272,9 +272,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, even though we have the *fibermap* table in hand, the code below demonstrates how it and the *simspec* table can be read from on-disk.  The *simspec* data model is described at  \n",
-    "http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_SIM/PIXPROD/NIGHT/simspec-EXPID.html\n",
-    "In particular, HDU=13 contains an extensive (and useful!) metadata table."
+    "Let's see what got written to the raw data directory as a result of that last command:"
    ]
   },
   {
@@ -283,10 +281,52 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/data/desi/spectro/sim/example/\r\n",
+      "/data/desi/spectro/sim/example//20170615\r\n",
+      "/data/desi/spectro/sim/example//20170615/fibermap-00000000.fits\r\n",
+      "/data/desi/spectro/sim/example//20170615/simspec-00000000.fits\r\n",
+      "/data/desi/spectro/sim/example//etc\r\n",
+      "/data/desi/spectro/sim/example//etc/obslog.sqlite\r\n"
+     ]
+    }
+   ],
    "source": [
-    "fiberfile = desispec.io.meta.findfile('fibermap', night=night, expid=expid, outdir=simdir)\n",
-    "simspecfile = desisim.io.findfile('simspec', night=night, expid=expid, outdir=simdir)"
+    "rawdata_dir = desispec.io.rawdata_root()\n",
+    "!find $rawdata_dir | sort"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generating your own spectra ##\n",
+    "\n",
+    "`new_exposure` is a convenience function for generating random typical exposures of various types for testing, but it isn't intended for every possible analysis.  If you want to use your own mix of objects, you just need to write your own fibermap and simspec files following that format instead of calling `new_exposure`.\n",
+    "\n",
+    "The *simspec* and *fibermap* data models are described at  \n",
+    "* http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_SIM/PIXPROD/NIGHT/simspec-EXPID.html\n",
+    "* http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_DATA/NIGHT/fibermap-EXPID.html\n",
+    "\n",
+    "**TODO**: update the datamodel documentation to match what is actually written!\n",
+    "\n",
+    "**NOTE**: the simspec file format may change in the near future, so structure your code to separate generating spectra from the code for writing these particular formats."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, even though we have the *fibermap* table in hand, the code below demonstrates how it and the *simspec* table can be read from on-disk.  In particular, the simspec METADATA HDU contains an extensive (and useful!) metadata table.\n",
+    "\n",
+    "In general code should not generate filepaths by hand, but rather call `desispec.io.findfile` to find the file it needs.  If you\n",
+    "need to override the standard environment variable locations, you can use the `outdir` option,\n",
+    "while still letting it construct the canonical filename for each type of file.\n",
+    "\n"
    ]
   },
   {
@@ -295,25 +335,10 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:<ipython-input-11-59b7db187c0a>:1:<module>: Reading fibermap file /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/fibermap-00000000.fits\n",
-      "Filename: /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/fibermap-00000000.fits\n",
-      "No.    Name         Type      Cards   Dimensions   Format\n",
-      "  0  PRIMARY     PrimaryHDU       6   ()      \n",
-      "  1  FIBERMAP    BinTableHDU     98   50R x 26C   [10A, 20A, 8A, K, K, K, K, 5E, 50A, J, K, J, J, J, J, E, D, D, D, D, D, D, D, D, E, E]   \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "log.info('Reading fibermap file {}'.format(fiberfile))\n",
-    "hdu = fits.open(fiberfile)\n",
-    "hdu.info()\n",
-    "fibermap = Table(hdu[1].data)\n",
-    "hdu.close()"
+    "fiberfile = desispec.io.findfile('fibermap', night=night, expid=expid)\n",
+    "simspecfile = desisim.io.findfile('simspec', night=night, expid=expid)"
    ]
   },
   {
@@ -324,30 +349,23 @@
    },
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "&lt;Row index=3&gt;\n",
-       "<table id=\"table4569910632\">\n",
-       "<thead><tr><th>OBJTYPE</th><th>TARGETCAT</th><th>BRICKNAME</th><th>TARGETID</th><th>DESI_TARGET</th><th>BGS_TARGET</th><th>MWS_TARGET</th><th>MAG [5]</th><th>FILTER [5]</th><th>SPECTROID</th><th>POSITIONER</th><th>LOCATION</th><th>DEVICE_LOC</th><th>PETAL_LOC</th><th>FIBER</th><th>LAMBDAREF</th><th>RA_TARGET</th><th>DEC_TARGET</th><th>RA_OBS</th><th>DEC_OBS</th><th>X_TARGET</th><th>Y_TARGET</th><th>X_FVCOBS</th><th>Y_FVCOBS</th><th>Y_FVCERR</th><th>X_FVCERR</th></tr></thead>\n",
-       "<thead><tr><th>str10</th><th>str20</th><th>str8</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>float32</th><th>str10</th><th>int32</th><th>int64</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>float32</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float32</th><th>float32</th></tr></thead>\n",
-       "<tr><td>ELG</td><td></td><td>3334p155</td><td>3561499325993422263</td><td>2</td><td>0</td><td>0</td><td>23.2547 .. 22.5634</td><td>DECAM_G .. WISE_W2</td><td>0</td><td>82</td><td>82</td><td>82</td><td>0</td><td>3</td><td>5400.0</td><td>333.353689493</td><td>15.5440849197</td><td>333.353689493</td><td>15.5440849197</td><td>-31.5795923296</td><td>-172.635369698</td><td>-31.5795923296</td><td>-172.635369698</td><td>0.0</td><td>0.0</td></tr>\n",
-       "</table>"
-      ],
-      "text/plain": [
-       "<Row index=3>\n",
-       "OBJTYPE TARGETCAT BRICKNAME       TARGETID      DESI_TARGET BGS_TARGET MWS_TARGET      MAG [5]           FILTER [5]     SPECTROID POSITIONER LOCATION DEVICE_LOC PETAL_LOC FIBER LAMBDAREF   RA_TARGET     DEC_TARGET      RA_OBS       DEC_OBS       X_TARGET       Y_TARGET       X_FVCOBS       Y_FVCOBS    Y_FVCERR X_FVCERR\n",
-       " str10    str20      str8          int64           int64      int64      int64         float32             str10          int32     int64     int32     int32      int32   int32  float32     float64       float64       float64       float64       float64        float64        float64        float64     float32  float32 \n",
-       "------- --------- --------- ------------------- ----------- ---------- ---------- ------------------ ------------------ --------- ---------- -------- ---------- --------- ----- --------- ------------- ------------- ------------- ------------- -------------- -------------- -------------- -------------- -------- --------\n",
-       "    ELG            3334p155 3561499325993422263           2          0          0 23.2547 .. 22.5634 DECAM_G .. WISE_W2         0         82       82         82         0     3    5400.0 333.353689493 15.5440849197 333.353689493 15.5440849197 -31.5795923296 -172.635369698 -31.5795923296 -172.635369698      0.0      0.0"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:<ipython-input-12-55ef607f5bdd>:1:<module>: Reading fibermap file /data/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
+      "Filename: /data/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
+      "No.    Name         Type      Cards   Dimensions   Format\n",
+      "0    PRIMARY     PrimaryHDU       6   ()              \n",
+      "1    FIBERMAP    BinTableHDU     98   50R x 26C    [10A, 20A, 8A, K, K, K, K, 5E, 50A, J, J, J, J, J, J, E, D, D, D, D, D, D, D, D, E, E]   \n"
+     ]
     }
    ],
    "source": [
-    "fibermap[3]"
+    "log.info('Reading fibermap file {}'.format(fiberfile))\n",
+    "hdu = fits.open(fiberfile)\n",
+    "hdu.info()\n",
+    "fibermap = Table(hdu['FIBERMAP'].data)\n",
+    "hdu.close()"
    ]
   },
   {
@@ -358,35 +376,30 @@
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:<ipython-input-13-079a1c11142f>:1:<module>: Reading simspec file /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/simspec-00000000.fits.\n",
-      "Filename: /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/simspec-00000000.fits\n",
-      "No.    Name         Type      Cards   Dimensions   Format\n",
-      "  0  PRIMARY     PrimaryHDU      15   ()      \n",
-      "  1  WAVE        ImageHDU         9   (31901,)   float64   \n",
-      "  2  FLUX        ImageHDU         9   (31901, 50)   float32   \n",
-      "  3  SKYFLUX     ImageHDU         8   (31901,)   float32   \n",
-      "  4  WAVE_B      ImageHDU         9   (12326,)   float64   \n",
-      "  5  PHOT_B      ImageHDU         8   (12326, 50)   float32   \n",
-      "  6  SKYPHOT_B   ImageHDU         7   (12326,)   float32   \n",
-      "  7  WAVE_R      ImageHDU         9   (11205,)   float64   \n",
-      "  8  PHOT_R      ImageHDU         8   (11205, 50)   float32   \n",
-      "  9  SKYPHOT_R   ImageHDU         7   (11205,)   float32   \n",
-      " 10  WAVE_Z      ImageHDU         9   (12765,)   float64   \n",
-      " 11  PHOT_Z      ImageHDU         8   (12765, 50)   float32   \n",
-      " 12  SKYPHOT_Z   ImageHDU         7   (12765,)   float32   \n",
-      " 13  METADATA    BinTableHDU     61   50R x 24C   [10A, 10A, J, K, E, E, 6E, 2E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E]   \n"
-     ]
+     "data": {
+      "text/html": [
+       "&lt;Row index=3&gt;\n",
+       "<table id=\"table4531425856\">\n",
+       "<thead><tr><th>OBJTYPE</th><th>TARGETCAT</th><th>BRICKNAME</th><th>TARGETID</th><th>DESI_TARGET</th><th>BGS_TARGET</th><th>MWS_TARGET</th><th>MAG [5]</th><th>FILTER [5]</th><th>SPECTROID</th><th>POSITIONER</th><th>LOCATION</th><th>DEVICE_LOC</th><th>PETAL_LOC</th><th>FIBER</th><th>LAMBDAREF</th><th>RA_TARGET</th><th>DEC_TARGET</th><th>RA_OBS</th><th>DEC_OBS</th><th>X_TARGET</th><th>Y_TARGET</th><th>X_FVCOBS</th><th>Y_FVCOBS</th><th>Y_FVCERR</th><th>X_FVCERR</th></tr></thead>\n",
+       "<thead><tr><th>str10</th><th>str20</th><th>str8</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>float32</th><th>str10</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>float32</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float32</th><th>float32</th></tr></thead>\n",
+       "<tr><td>SKY</td><td></td><td>3350p205</td><td>4183104322407110374</td><td>4294967296</td><td>0</td><td>0</td><td>0.0 .. 0.0</td><td>..</td><td>0</td><td>82</td><td>82</td><td>82</td><td>0</td><td>3</td><td>5400.0</td><td>335.167583443</td><td>20.5840708185</td><td>335.167583443</td><td>20.5840708185</td><td>-31.5795923296</td><td>-172.635369698</td><td>-31.5795923296</td><td>-172.635369698</td><td>0.0</td><td>0.0</td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Row index=3>\n",
+       "OBJTYPE TARGETCAT BRICKNAME       TARGETID      DESI_TARGET BGS_TARGET MWS_TARGET  MAG [5]   FILTER [5] SPECTROID POSITIONER LOCATION DEVICE_LOC PETAL_LOC FIBER LAMBDAREF   RA_TARGET     DEC_TARGET      RA_OBS       DEC_OBS       X_TARGET       Y_TARGET       X_FVCOBS       Y_FVCOBS    Y_FVCERR X_FVCERR\n",
+       " str10    str20      str8          int64           int64      int64      int64     float32     str10      int32     int32     int32     int32      int32   int32  float32     float64       float64       float64       float64       float64        float64        float64        float64     float32  float32 \n",
+       "------- --------- --------- ------------------- ----------- ---------- ---------- ---------- ---------- --------- ---------- -------- ---------- --------- ----- --------- ------------- ------------- ------------- ------------- -------------- -------------- -------------- -------------- -------- --------\n",
+       "    SKY            3350p205 4183104322407110374  4294967296          0          0 0.0 .. 0.0        ..          0         82       82         82         0     3    5400.0 335.167583443 20.5840708185 335.167583443 20.5840708185 -31.5795923296 -172.635369698 -31.5795923296 -172.635369698      0.0      0.0"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "log.info('Reading simspec file {}.'.format(simspecfile))\n",
-    "hdu = fits.open(simspecfile)\n",
-    "hdu.info()\n",
-    "meta = Table(hdu[13].data)\n",
-    "hdu.close()"
+    "fibermap[3]"
    ]
   },
   {
@@ -397,15 +410,54 @@
    },
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:<ipython-input-14-f05bf983fedc>:1:<module>: Reading simspec file /data/desi/spectro/sim/example/20170615/simspec-00000000.fits.\n",
+      "Filename: /data/desi/spectro/sim/example/20170615/simspec-00000000.fits\n",
+      "No.    Name         Type      Cards   Dimensions   Format\n",
+      "0    PRIMARY     PrimaryHDU      15   ()              \n",
+      "1    WAVE        ImageHDU         9   (31901,)     float64   \n",
+      "2    FLUX        ImageHDU         9   (31901, 50)   float32   \n",
+      "3    SKYFLUX     ImageHDU         8   (31901,)     float32   \n",
+      "4    WAVE_B      ImageHDU         9   (12326,)     float64   \n",
+      "5    PHOT_B      ImageHDU         8   (12326, 50)   float32   \n",
+      "6    SKYPHOT_B   ImageHDU         7   (12326,)     float32   \n",
+      "7    WAVE_R      ImageHDU         9   (11205,)     float64   \n",
+      "8    PHOT_R      ImageHDU         8   (11205, 50)   float32   \n",
+      "9    SKYPHOT_R   ImageHDU         7   (11205,)     float32   \n",
+      "10   WAVE_Z      ImageHDU         9   (12765,)     float64   \n",
+      "11   PHOT_Z      ImageHDU         8   (12765, 50)   float32   \n",
+      "12   SKYPHOT_Z   ImageHDU         7   (12765,)     float32   \n",
+      "13   METADATA    BinTableHDU     61   50R x 24C    [10A, 10A, J, K, E, E, 6E, 2E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E]   \n"
+     ]
+    }
+   ],
+   "source": [
+    "log.info('Reading simspec file {}.'.format(simspecfile))\n",
+    "hdu = fits.open(simspecfile)\n",
+    "hdu.info()\n",
+    "meta = Table(hdu['METADATA'].data)\n",
+    "hdu.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
      "data": {
       "text/html": [
        "&lt;Table length=3&gt;\n",
-       "<table id=\"table4569875568\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<table id=\"table4370546640\" class=\"table-striped table-bordered table-condensed\">\n",
        "<thead><tr><th>OBJTYPE</th><th>SUBTYPE</th><th>TEMPLATEID</th><th>SEED</th><th>REDSHIFT</th><th>MAG</th><th>DECAM_FLUX [6]</th><th>WISE_FLUX [2]</th><th>OIIFLUX</th><th>HBETAFLUX</th><th>EWOII</th><th>EWHBETA</th><th>D4000</th><th>VDISP</th><th>OIIDOUBLET</th><th>OIIIHBETA</th><th>OIIHBETA</th><th>NIIHBETA</th><th>SIIHBETA</th><th>ZMETAL</th><th>AGE</th><th>TEFF</th><th>LOGG</th><th>FEH</th></tr></thead>\n",
        "<thead><tr><th>str10</th><th>str10</th><th>int32</th><th>int64</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th></tr></thead>\n",
-       "<tr><td>SKY</td><td></td><td>-1</td><td>-1</td><td>0.0</td><td>-1.0</td><td>0.0 .. 0.0</td><td>0.0 .. 0.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
-       "<tr><td>ELG</td><td></td><td>6752</td><td>3244113739</td><td>1.53694</td><td>23.2023</td><td>0.233109 .. 1.47868</td><td>4.03679 .. 4.40491</td><td>5.45512e-17</td><td>-1.0</td><td>50.9816</td><td>-1.0</td><td>1.09257</td><td>49.0409</td><td>0.733237</td><td>-0.0850786</td><td>0.275525</td><td>-0.248196</td><td>-0.19466</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
-       "<tr><td>LRG</td><td></td><td>18</td><td>3244113739</td><td>0.877407</td><td>20.256</td><td>0.114243 .. 9.0901</td><td>29.0752 .. 20.158</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>1.50574</td><td>183.679</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>0.0096</td><td>2.81838</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
+       "<tr><td>ELG</td><td></td><td>3512</td><td>3244113739</td><td>1.25838</td><td>22.937</td><td>0.441517 .. 1.32143</td><td>2.19795 .. 1.99019</td><td>8.25246e-17</td><td>-1.0</td><td>73.3845</td><td>-1.0</td><td>1.00652</td><td>68.2661</td><td>0.733237</td><td>-0.0850786</td><td>0.275525</td><td>-0.248196</td><td>-0.19466</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
+       "<tr><td>ELG</td><td></td><td>4951</td><td>3952505139</td><td>0.820804</td><td>22.6349</td><td>0.616534 .. 1.59198</td><td>2.13285 .. 1.34848</td><td>4.69683e-17</td><td>-1.0</td><td>25.1577</td><td>-1.0</td><td>1.03366</td><td>40.1724</td><td>0.757255</td><td>-0.00885063</td><td>0.630011</td><td>-0.265495</td><td>-0.230491</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
+       "<tr><td>ELG</td><td></td><td>6928</td><td>369720621</td><td>1.11619</td><td>21.8746</td><td>1.64478 .. 2.487</td><td>2.91573 .. 2.2421</td><td>1.45983e-16</td><td>-1.0</td><td>48.7059</td><td>-1.0</td><td>0.990213</td><td>40.1724</td><td>0.698619</td><td>-0.00354248</td><td>0.468131</td><td>-0.177077</td><td>-0.244851</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
        "</table>"
       ],
       "text/plain": [
@@ -413,12 +465,12 @@
        "OBJTYPE SUBTYPE TEMPLATEID    SEED    ...   AGE     TEFF    LOGG    FEH  \n",
        " str10   str10    int32      int64    ... float32 float32 float32 float32\n",
        "------- ------- ---------- ---------- ... ------- ------- ------- -------\n",
-       "    SKY                 -1         -1 ...    -1.0    -1.0    -1.0    -1.0\n",
-       "    ELG               6752 3244113739 ...    -1.0    -1.0    -1.0    -1.0\n",
-       "    LRG                 18 3244113739 ... 2.81838    -1.0    -1.0    -1.0"
+       "    ELG               3512 3244113739 ...    -1.0    -1.0    -1.0    -1.0\n",
+       "    ELG               4951 3952505139 ...    -1.0    -1.0    -1.0    -1.0\n",
+       "    ELG               6928  369720621 ...    -1.0    -1.0    -1.0    -1.0"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -436,26 +488,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(-0.2, 1.7113039016723635)"
+       "(-0.2, 1.6220408082008364)"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     },
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAEKCAYAAAARnO4WAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAHYhJREFUeJzt3Xt4FfW1//H3SkABA0IJKEIxeIocL/REjCLo8UCtlBbF\nG4rYWn/qkYqiFouAVUEfterjBS94i7ZFqyJVq7XWG22R1rsSOCpSsSBqIhZEEIJgvKzfHzPBHSQ7\nk2Qme4f5vJ4nT/bMnvnOymay+OY731lj7o6IiGz7CnIdgIiItAwlfBGRlFDCFxFJCSV8EZGUUMIX\nEUkJJXwRkZRQwhcRSQklfBGRlFDCFxFJiTa5DiBTcXGxl5SU5DoMEZFWY/78+R+5e7co2+ZVwi8p\nKeHVV1/NdRgiIq2Gmb0bdVsN6YiIpIQSvohISijhi4ikRF6N4Us6ff7551RWVrJp06ZchyKSt9q1\na0evXr1o27Ztk9tQwpecq6yspGPHjpSUlGBmuQ5HJO+4O6tXr6ayspI+ffo0uR0N6UjObdq0ia5d\nuyrZi9TDzOjatWuz/wpWwpe8oGQvkl0cvyNK+CIiKaExfMk70+csibW9CYfu3uA2hYWF9O/ff/Py\n8ccfz5QpUxgyZAjXXHMNZWVldbZ/+eWXmTRpElVVVXTs2JEePXpw5ZVX1mkjSbcsvCXW9s4oPaPB\nbYqKiqiurq6z7uKLL+aOO+6gW7du1NTUcNFFFzFmzJjN71933XWUl5fTtm1bCgoKOOSQQ7jqqqua\ndeFxa17+07JY29v/8N0ibXf55Zdz3333UVhYSEFBAV26dGHNmjVUV1ezatWqzePtt9xyC4MHD+aj\njz6iR48e3HTTTZx++umb2ykpKaFjx46YGV26dOHuu+9m1113jfVnAiV8EQDat2/PwoULI23773//\nm+OOO4777ruPwYMHA/Dss8+ydOnSFkv4+WTChAlMnDiRt99+m3333ZdRo0bRtm1bbrvtNp5++mle\nfPFFOnfuTE1NDddddx0bN26MPeHnwgsvvMBjjz1GRUUF22+/PR999BE1NTXssssuPPPMM1xzzTU8\n9thjdfZ54IEHOOCAA5g1a1adhA8wd+5ciouLmTZtGpdddhl33HFH7DFrSEekkWbMmMFJJ520OdkD\nHHTQQRx55JE5jCr3+vbtS4cOHVizZg0Q9H5vvfVWOnfuDMB2223HlClT6NSpUy7DjM2KFSsoLi5m\n++23B6C4uJhddtkl6z6zZs3i2muvpaqqisrKyq1uM2jQIKqqqmKPF5TwRQDYuHEjpaWlm79mz55d\n77aLFi1iwIABLRhd61BRUUHfvn3p3r0769ato7q6ullTCPPdsGHDeP/999l9990544wzmDdvXtbt\n33//fVasWMH+++/PcccdV+859uSTTybWeVDCF+HrIZ3ar9GjR0fed+DAgeyxxx6cc845CUaYv6ZP\nn85ee+3FwIEDueCCC7a6zVNPPUVpaSklJSU8//zzLRxhMoqKipg/fz7l5eV069aN0aNHM3PmzHq3\nnz17NscddxwQXCOaNWtWnfeHDh1Kz549eeKJJ+pcB4mTEr5II+21115UVFRsXn7ppZe49NJL+eST\nT3IYVe5MmDCBRYsW8dBDD3HqqaeyadMmOnXqRFFREe+88w4AP/jBD1i4cCF77703NTU1OY44PoWF\nhQwZMoRLLrmEGTNm8NBDD9W77axZs5g5cyYlJSWMHDmS1157jbfffnvz+3PnzuXdd9+ltLSUadOm\nJRKvEr5II5155pnMnDmzTk/1008/zWFE+WHkyJGUlZVx1113AXD++eczbtw41q5dCwR3i25L5TPe\neuutOgl74cKF9c6sWbJkCdXV1VRVVbF8+XKWL1/O+eef/41efps2bbj++uu5++67+fjjj2OPWbN0\nJO9EmUYZt9ox/FrDhw/nyiuvBGDEiBGbZ5UMGjSIBx54gNmzZzN58mSqqqro3r07xcXFTJ06tcXi\njTKNMm6ffvopvXr12rx87rnnfmObqVOncsIJJ3Daaacxbtw4NmzYwMCBA9l+++0pKiriwAMPZJ99\n9ok9tqjTKONUXV3NWWedxdq1a2nTpg3f+c53KC8v3+q2s2bN4qijjqqz7phjjmH06NHfOG969OjB\nmDFjuPnmm7noootijdncPdYGm6OsrMz1AJT0Wbx4MXvssUeuwxDJe1v7XTGz+e5eVs8udWhIR0Qk\nJZTwRURSQglfRCQllPBFRFJCCV9EJCWU8EVEUkLz8CX/zL0i3vaGnt/gJluWR37kkUfo3r07p512\nGq+99hruTufOnbn33ns54ogjAPjwww8pLCykW7duQFAyuX379vTv35/PP/+cNm3a8NOf/pQJEyZQ\nUBBv32rVTTNiba/bWeMjbbdlOeDbb7+dyZMnby4h/c477zBs2DAuu+wyJk+ezIsvvsjOO+8MBDes\n9erVi/PPb/jfQ5KhhC/C1ssjX3HFFey00068/vrrQHBn5c4777x5u4svvpiioiImTpy41XZWrlzJ\nCSecwLp167jkkkta6CdJTn3lgGtVVlYyfPhwrr32WkaOHMmaNWuYOHEi99xzDxUVFfzjH/9g/vz5\nOfwJREM6IvVYsWIFPXv23Lzcr1+/zaVwo+jevTvl5eXMmDGDfLrBsamylQNesWIFw4YN4/LLL2fk\nyJEAjB07lqVLlzJ37lzOPPNMZsyYsU3UwW/NlPBFqFseufYW+FNOOYWrrrqKQYMGceGFF9apmxLV\nbrvtxpdffsnKlSvjDrnFZSsHfNJJJzF+/HhGjRq1eV1BQQG33norxxxzDP369ePggw/ORdiSQQlf\nhLrlkR9++GEASktLWbZsGeeddx4ff/wx++23H4sXL85xpLmTrRzw97//fe65555vFJErLS1l7733\n5owzWr72j3yTxvBFsigqKuLoo4/m6KOPpqCggMcff7xRdX+WLVtGYWEh3bt3TzDKllNbDnjIkCH0\n799/c2XMSZMm8bvf/Y5jjz2WP/7xj7Rp83VqKSgoiP2itTSN/hVE6vHcc89tflxfTU0Nb775ZqMe\nLL1q1SpOP/10xo8fj5klFWaLaagc8PXXX0+nTp049dRTt4lrFtsi9fAl/0SYRtkSli5dyrhx43B3\nvvrqK0aMGMExxxyTdZ/aawG10zJPPPHErZYRbq6o0yjjVF854NpxezPjrrvu4rDDDmPSpElcffXV\nLR6jZJdoeWQzmwD8L+DA68DJ7l7vExBUHjmdVB5ZJJq8LY9sZj2Bs4Eyd98bKASOT+p4IiKSXdJj\n+G2A9mbWBugAfJDw8UREpB6JJXx3rwKuAd4DVgCfuPvTSR1PWjdd5BPJLo7fkQYv2ppZX+AKYE+g\nXcbBsz5E0sy6AEcAfYC1wANm9hN3v2eL7cYCYwF69+7d2PgblKuaIxJdu3btWL16NV27dt0mZrOI\nxM3dWb16Ne3atWt44yyizNL5LTANmA4MBU4m2l8G3wfecfdVAGb2B2AwUCfhu3s5UA7BRdvIkcs2\no1evXlRWVrJq1apchyKSt9q1a1fnIfJNESXht3f3v5qZufu7wMVmNh+Y2sB+7wEHmFkHYCNwCKAp\nOPINbdu2pU+fPrkOQ2SbFyXhf2ZmBcDbZjYeqAKKGtrJ3V8ysweBCuALYAFhT15ERFpelIR/DsEM\nm7OBSwmGdU6K0ri7TyMYDhIRkRzLmvDNrBAY7e4TgWqC8XsREWmFsl58dfcvgYNaKBYREUlQlCGd\nBWb2KPAAsKF2pbv/IbGoREQkdlESfjtgNfC9jHUOKOGLiLQiURL+ne7+XOYKMzswoXhERCQhUW6g\nuiniOhERyWP19vDNbBDBnbHdzCyzoHcngsqXIiLSimQb0tmO4AarNkDHjPXrgFFb3UNERPJWvQnf\n3ecB88xsZlhSQUREWrEoY/h3mlnn2gUz62JmTyUYk4iIJCBKwi9297W1C+6+BuieXEgiIpKEKAn/\nKzPbXKjezHYlmIcvIiKtSJR5+BcAz5rZPMCA/yZ8YImIiLQeDSZ8d3/SzAYAB4Srfu7uHyUbloiI\nxK3BIR0Lnjk3HBjg7o8BHcxs/8QjExGRWEUZw78FGASMCZfXAzcnFpGIiCQiyhj+QHcfYGYLIJil\nY2bbJRyXiIjELErC/zx8EIoDmFk34KtEoxKRJpk+Z0nsbU44dPfY25TciDKkcyPwMLCTmV0OPAv8\nKtGoREQkdlFm6dxrZvOBQ8JVR7r74mTDEhGRuEUZ0oHgIea1wzrtkwtHRESSEmVa5lTgLuBbQDHw\nWzO7MOnAREQkXlF6+D8G/svdNwGY2ZXAQuCyJAMTEZF4Rblo+wHBc21rbQ9UJROOiIgkJUoP/xNg\nkZnNIRjDPxR42cxuBHD3sxOMT0REYhIl4T8cftV6JplQREQkSVGmZd4FYGZtgb2BKndfmXRgIiIS\nr3rH8M3sNjPbK3y9I/B/wN3AAjMbU99+IiKSn7JdtP1vd18Uvj4ZWOLu/YF9gUmJRyYiIrHKlvBr\nMl4fCjwC4O4fJhqRiIgkIlvCX2tmh5nZPsCBwJMAZtYG3W0rItLqZLto+zOCwmk7EzzlqrZnfwjw\n56QDExGReNWb8N19CcGTrrZc/xTwVJJBiYhI/KLcaSsiItsAJXwRkZRQwhcRSYl6x/DN7NxsO7r7\ndQ01bmadgTsJ7tB14BR3f6GxQYqISPNlm6XTMfzeD9gPeDRcPhx4OWL7NwBPuvuo8MHnHZoUpYiI\nNFu2WTqXAJjZ34EB7r4+XL6YCNMyw3IMBwP/L2yvhro3c4mISAuKMoa/E3UTdU24riF9gFUET8ha\nYGZ3mtkOTYhRRERiEKU88t0E9e9rSyQfSfDIwyhtDwDOcveXzOwGYApwUeZGZjYWGAvQu3fvqHGL\niNQxfc6S2NuccOjusbeZSw328N39coLiaWvCr5Pd/VcR2q4EKt39pXD5QYL/ALZsv9zdy9y9rFu3\nbtEjFxGRRok6LbMDsM7dbwAqzaxPQzuEpRjeN7N+4apDgDebFqaIiDRXg0M6ZjYNKCOYrfNboC1w\nD0FBtYacBdwbztBZRvCXgoiI5ECUMfyjgH2ACgB3/8DMOmbfJeDuCwn+sxARkRyLMqRT4+5OcOMU\nmmkjItI6RUn4vzez24HOZnYa8BeCu2dFRKQVifIQ82vM7FBgHcE4/lR3n5N4ZCIiEqsoF22vcvfJ\nwJytrBMRkVYiypDOoVtZ98O4AxERkWRlq5Y5DjgD2M3MXst4qyPwXNKBiYhIvLIN6dwHPAFcQVAS\nodZ6d/840ahERCR22aplfgJ8AowBMLPuQDugyMyK3P29lglRRETi0OAYvpkdbmZvA+8A84DlBD1/\nERFpRaJctL0MOABY4u59CGrivJhoVCIiErsoCf9zd18NFJhZgbvPReUSRERanSi1dNaaWRHwd4JC\naCuBDcmGJSIicYvSwz8C2AhMAJ4ElhI811ZERFqRKKUVMnvzUZ50JSIieSjbjVfrCStkbvkW4O7e\nKbGoREQkdtnm4UeqeS8iIq1DlOJpW32yuG68EhFpXaLM0vlzxut2QB/gLWCvRCISEZFERLlo2z9z\n2cwGEBRVE5FmmD5nSa5DkJSJMi2zDnevAAYmEIuIiCQoyhj+uRmLBcAA4IPEIhIRkUREGcPPnK3z\nBcGY/kPJhCMiIkmJMoZ/SUsEIiIiyYoypFMGXADsmrm9u383wbhERCRmUYZ07gXOA14Hvko2HBER\nSUqUhL/K3R9NPBIREUlUlIQ/zczuBP4KfFa70t3/kFhUIiISuygJ/2TgP4G2fD2k44ASvohIKxIl\n4e/n7v0Sj0RERBIV5U7b581sz8QjERGRREXp4R8ALDSzdwjG8Gvr4WtapohIKxIl4Q9PPAoREUlc\ntidedXL3dcD6FoxHREQSkq2Hfx9wGDCfYFaOZbznwG4JxiUiIjHL9ojDw8LvfVouHBERSUq9s3TM\nbFcz2zFjeaiZ3WBmE8xsu5YJT0RE4pJtWubvgR0AzKwUeAB4DygFbkk+NBERiVO2Mfz27l77oJOf\nAL9x92vNrABYGPUAZlYIvApU1Q4TiYhIy8vWw8+8SPs9glo6uHtjK2aeAyxu5D4iIhKzbAn/b2b2\nezO7AegC/A3AzHoANVEaN7NewAjgzuYGKiIizZNtSOfnwGigB3CQu38ert+Z4IEoUVwPTKLuYxLr\nMLOxwFiA3r17R2y2EZb/I+YGx8fcnkh+mz5nSextTjh099jblIZlm5bpwP1bWb8gSsNmdhiw0t3n\nm9mQLMcpB8oBysrKPErbIiLSeFGKpzXVgcBIM1tO8B/H98zsngSPJyIiWSSW8N39fHfv5e4lwPHA\n39z9J0kdT0REsst249Vfw+9XtVw4IiKSlGwXbXuY2WCCYZn7qTtNE3eviHoQd38GeKYpAYqISDyy\nJfypwEVAL+C6Ld5zgrn5IiLSSmSbpfMg8KCZXeTul7ZgTCIikoAGH4Di7pea2Ujg4HDVM+7+WLJh\niYhI3BqcpWNmVxCUR3gz/DrHzH6VdGAiIhKvKI84HAGU1tbQMbO7gAXAL5MMTERE4hV1Hn7njNc7\n1ruViIjkrSg9/CuABWY2l2Bq5sHAlESjEhGR2EW5aDvLzJ4B9gtXTXb3DxONSkREYhelh4+7rwAe\nTTgWERFJUJLF00REJI8o4YuIpETWhG9mhWb2z5YKRkREkpM14bv7l8BbZpbAo6hERKQlRblo2wVY\nZGYvAxtqV7r7yMSiEhGR2EVJ+BclHoWIiCQuyjz8eWa2K9DX3f9iZh2AwuRDExGROEUpnnYa8CBw\ne7iqJ/BIkkGJiEj8ogzpnAnsD7wE4O5vm1n3RKMSSYGKdbNjb3NAp9Gxtynbjijz8D9z95raBTNr\nQ/DEKxERaUWiJPx5ZvZLoL2ZHQo8APwp2bBERCRuURL+FGAV8DrwM+Bx4MIkgxIRkfhFmaXzVfjQ\nk5cIhnLecncN6YiItDINJnwzGwHcBiwlqIffx8x+5u5PJB2ciIjEJ8osnWuBoe7+LwAz+w/gz4AS\nvohIKxJlDH99bbIPLQPWJxSPiIgkpN4evpkdHb581cweB35PMIZ/LPBKC8QmIiIxyjakc3jG638D\n/xO+XgW0TywiERFJRL0J391PbslAREQkWVFm6fQBzgJKMrdXeWQRkdYlyiydR4BfE9xd+1Wy4YiI\nSFKiJPxN7n5j4pGIiEiioiT8G8xsGvA08FntSnevSCwqERGJXZSE3x84EfgeXw/peLgsIiKtRJSE\nfyywW2aJZBERaX2i3Gn7BtA56UBERCRZUXr4nYF/mtkr1B3D17RMEZFWJErCn9aUhs3s28DdwE4E\nY/7l7n5DU9oSEZHmi1IPf14T2/4C+IW7V5hZR2C+mc1x9zeb2J6IiDRDlDtt1/P1M2y3A9oCG9y9\nU7b93H0FsCJ8vd7MFgM9ASV8EZEciNLD71j72swMOAI4oDEHMbMSYB+Cp2aJiEgORBnD3yx8tOEj\n4Y1YU6LsY2ZFwEPAz9193VbeHwuMBejdu3djwonkjZp9Y21vaKytSRKmz1kSe5sV62bH3qbkv7jP\npQmH7h5re40VZUjn6IzFAqAM2BSlcTNrS5Ds73X3P2xtG3cvB8oBysrK9KxcEZGEROnhZ9bF/wJY\nTjCsk1U4/PNrYLG7X9ek6EREJDZRxvCbWhf/QIKSDK+b2cJw3S/d/fEmticiIs2Q7RGHU7Ps5+5+\nabaG3f1ZwJoamIiIxCtbD3/DVtbtAJwKdAWyJnwREckv2R5xeG3t6/DGqXOAk4H7gWvr209ERPJT\n1jF8M/sWcC7wY+AuYIC7r2mJwEREJF7ZxvCvBo4mmDLZ392rWywqERGJXbbyyL8AdgEuBD4ws3Xh\n13oz+8YNVCIikt+yjeFHqZUvIiKthJK6iEhKKOGLiKSEEr6ISEoo4YuIpIQSvohISijhi4ikhBK+\niEhKKOGLiKSEEr6ISEoo4YuIpIQSvohISkR5pq1IYk58KP7n6AzoNDr2NiVe0+csyXUIqaQevohI\nSijhi4ikhBK+iEhKKOGLiKSEEr6ISEoo4YuIpIQSvohISijhi4ikhBK+iEhKKOGLiKSEEr6ISEoo\n4YuIpIQSvohISijhi4ikhBK+iEhKKOGLiKSEEr6ISEoo4YuIpESiCd/MhpvZW2b2LzObkuSxREQk\nu8QSvpkVAjcDPwT2BMaY2Z5JHU9ERLJLsoe/P/Avd1/m7jXA/cARCR5PRESySDLh9wTez1iuDNeJ\niEgOmLsn07DZKGC4u/9vuHwiMNDdx2+x3VhgbLjYD3grkYAarxj4KNdBRNSaYgXFmzTFm5x8jHVX\nd+8WZcM2CQZRBXw7Y7lXuK4Ody8HyhOMo0nM7FV3L8t1HFG0plhB8SZN8SanNcW6NUkO6bwC9DWz\nPma2HXA88GiCxxMRkSwS6+G7+xdmNh54CigEfuPui5I6noiIZJfkkA7u/jjweJLHSFDeDTNl0Zpi\nBcWbNMWbnNYU6zckdtFWRETyi0oriIikROoSfkPlHixwY/j+a2Y2IOq+OYr3x2Gcr5vZ82b2Xxnv\nLQ/XLzSzV/Mk3iFm9kkY00Izmxp13xzEel5GnG+Y2Zdm9q3wvVx8tr8xs5Vm9kY97+fbudtQvHlz\n7kaINW/O22Zx99R8EVw8XgrsBmwH/B+w5xbb/Ah4AjDgAOClqPvmKN7BQJfw9Q9r4w2XlwPFefb5\nDgEea8q+LR3rFtsfDvwtV59teMyDgQHAG/W8nzfnbsR48+ncbSjWvDhvm/uVth5+lHIPRwB3e+BF\noLOZ9Yi4b4vH6+7Pu/uacPFFgvsdcqU5n1FLf76NPd4YYFaC8TTI3f8OfJxlk3w6dxuMN5/O3Qif\nbX1aVQmZtCX8KOUe6tsmF6UiGnvMUwl6eLUc+IuZzQ/vaE5a1HgHh3/KP2FmezVy37hEPp6ZdQCG\nAw9lrG7pzzaKfDp3GyvX524U+XDeNkui0zKl5ZjZUIJfmoMyVh/k7lVm1h2YY2b/DHsyuVQB9Hb3\najP7EfAI0DfHMTXkcOA5d8/sAebjZ9sqtZJztzWet9+Qth5+lHIP9W0TqVREzCId08y+C9wJHOHu\nq2vXu3tV+H0l8DDBn59JajBed1/n7tXh68eBtmZWHGXflo41w/FsMZyTg882inw6dyPJo3M3qzw6\nb5sn1xcRWvKL4C+aZUAfvr7AstcW24yg7oWvl6Pum6N4ewP/AgZvsX4HoGPG6+cJitnlOt6d+fr+\nj/2B98LPukU/36jHA3YkGNvdIZefbcaxS6j/wmLenLsR482bczdCrHlx3jb3K1VDOl5PuQczOz18\n/zaCO4N/RHAifgqcnG3fPIh3KtAVuMXMAL7woLjTTsDD4bo2wH3u/mQexDsKGGdmXwAbgeM9+C1q\n0c83YqwARwFPu/uGjN1b/LMFMLNZBLNFis2sEpgGtM2IN2/O3Yjx5s25GyHWvDhvm0t32oqIpETa\nxvBFRFJLCV9EJCWU8EVEUkIJX0QkJZTwRURSQglftklhZcvaKpd/MrPOjdz/YjOb2JT3zez5jNdX\nm9mi8PuRZrZnY+IQiZMSvmyrNrp7qbvvTXDj1JktdWB3H5yxOBb4rrufBxwJKOFLzijhSxq8QEZB\nq7DO/SthIaxLMtZfYGZLzOxZoF/G+rPN7M1w+/sz2t3TzJ4xs2VmdnbG9tXh90eBImC+mU0DRgJX\nh395/EdiP61IPVJ1p62kj5kVAocAvw6XhxEUvdqf4Nb4R83sYGADQc2cUoLfiwpgftjMFKCPu3+2\nxdDQfwJDgY7AW2Z2q7t/Xvumu480s2p3Lw2P3YegpvqDif3AIlko4cu2qr2ZLSTo2S8G5oTrh4Vf\nC8LlIoL/ADoCD7v7p7C5d17rNeBeM3uEoEpirT+7+2fAZ2a2kqAkQGVCP49Is2lIR7ZVG8Oe9a4E\nPfnaMXwDrgjH90vd/Tvu/usG2hoB3EzwRKRXzKy2o/RZxjZfog6U5DklfNmmhT32s4FfhIn6KeAU\nMysCMLOeYc31vwNHmll7M+tIUAMfMysAvu3uc4HJBNUzi5oYznqCvyREckI9EtnmufsCM3sNGOPu\nvzOzPYAXwmqM1cBP3L3CzGYTlLddCbwS7l4I3GNmOxL8dXCju68N922s+4E7wgu8o9x9afN+MpHG\nUbVMEZGU0JCOiEhKKOGLiKSEEr6ISEoo4YuIpIQSvohISijhi4ikhBK+iEhKKOGLiKTE/wc7vIMc\nAxGaRAAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaQAAAElCAYAAACroJZIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAMTQAADE0B0s6tTgAAIABJREFUeJzt3XucV1W9//HXZwbioqUoYCgpJ0Xwgs7IMiqh4lKaP1PU\nijypYZRw8hKCpPboaGoe80cOeclLRxQ1OdJR8XghURIvqYlLGDU7ihcQIePiBSJG5bLOH3vP+B0c\n5rtnmP2d/Z39fj4e8/ju69qfzZc9n1l7r72WhRAQERFpbxXtHYCIiAgoIYmISEYoIYmISCYoIYmI\nSCYoIYmISCYoIYmISCYoIYmISCYoIYmISCYoIYmISCYoIYmISCZ0au8AmjJlypTQp0+f9g5DRES2\n08yZM+/y3h+fZNtMJqQ+ffowadKk9g5DRES208yZM99Iuq1u2YmISCYoIYmISCYoIYmISCYoIYmI\nSCZkslGDSEuEEFizZg1btmxp71BEcquiooKePXtiZq0uQwlJyt6aNWvYcccd6datW3uHIpJbdXV1\nrFmzhl69erW6jNQTknPuSOAXRLcHOwFTvfc3p31cyY8tW7YoGYm0s27durFu3brtKiPVZ0jOOQN+\nB4z13lcBRwHXO+c+meZxRUSk/JTill0Ado6nPwW8DXxQguNKTk17aHEq5Z711X1TKTerrqm9JpVy\nf1T1o1TKbW8L7n09lXI/943PplJuFqVaQ/LeB2AMcJdz7g3gT8D3vPcfpnlckfbUr18/BgwYQFVV\nVcPPCy+8QL9+/aitrW1yn9tvv51DDz2U/v3745xj2LBh3HnnnSWOPFua+vcaO3Yse+yxB1VVVQwc\nOJCTTjqJDRs2NKzfuHEjF154IQMHDuSAAw6gurqa0aNHb/PfvaO56667GDx4cMO/z4gRIzjyyCMb\n/h+aGYMGDaKqqophw4Y17Pf6669TUVHBxRdf3Ki8GTNmsNNOO1FVVcWBBx7I8OHDWbw4nT/4IOUa\nknOuE/Az4Djv/WPOuUOBe5xzg7z3awq2mwQ09BVUXV2dZlgiqZs1axZVVVWJtr3hhhv41a9+xV13\n3cX+++8PwMsvv8w999yTZohla8qUKUycOJEPPviAESNGcPXVV/OTn/wEgFNOOYX169fz1FNP0aNH\nDwDmzZvHyy+/nPj7KFdvvfUWp556Ks8++yx77bUXAAsXLqS6urqh5ZuZ8fjjj7Pzzjs32vfGG29k\nxIgR3HTTTfzsZz9r1FJu+PDh3H333QCcffbZTJw4kTlz5qRyDmnfsqsCdvfePwbgvX/GObccqAYe\nqt/Ie18D1NTP19TUhJTjEsmMn//859xwww0NyQhgwIABTJkypR2jyr4uXbowdOhQ3ngj6irtlVde\nYfbs2bz55psNyQhg1KhR7RViSa1cuZLKykp22WWXhmWHHHJI0f02b97MjBkzePDBBznhhBN4+OGH\nGTlyZJPbjhw5kj/84Q9tFvPW0n4x9k2gj3NuPwDn3D7A3sDLKR9XpF2NGTOm0S27urq6JrdbtWoV\nK1asYMiQISWOsPytXbuWRx55hOOPjzqSXrRoEfvss0+jX8h5ctBBBzF06FD22msvjj32WKZOncqK\nFSuK7jd37lz69u3L/vvvz7hx45g+fXqT223ZsoXZs2fzne98p61Db5D2M6SVwKnA751zzwGzgdO9\n98vSPK5Ie5s1axa1tbUNPy1plj58+HAGDRrEgAEDUoywfE2dOpWDDjqI3Xbbjb59+zJ8+PAmt3vt\ntdeoqqpiwIABnHLKKSWOsvQqKiq48847efLJJzniiCN44oknOOCAA3j11Veb3W/69Ol8//vfB+C7\n3/0uc+bM4d13321YP3/+fKqqqujZsycPP/wwP/pReo1SUu86yHv/X977Qd77g+PPmWkfU6Rc9O7d\nmz322IMFCxY0LJs/fz733nsvK1eubMfIsmvKlCk8//zzLF68GO891113HRA9e3711Vcbfpnuvffe\n1NbWct555zX6BdvRDRw4kPHjx3P33Xfz+c9/vtlnkatXr+b+++/n4osvpl+/fgwePJiNGzdy2223\nNWwzfPhwamtrWb58Ofvuu295JyQRad7555/PWWedxUsvvdSw7J///Gc7RlQe9txzT6666iouuugi\n6urq6N+/P8cccwzjxo3jvffea9guL/+WK1as4IknnmiYf/fdd1myZAl77733Nve55ZZbGD16NG++\n+SZLly5l6dKl3HHHHU3etuvevTs33HADc+bMYdGiRamcg7oOkg4nC+8LjRkzptFtumnTpgFw+OGH\n07lz54blf/7znzn11FPZYYcdOPHEE1m7di29evWia9eu/OY3vyl53IWy8L7Q1v9eAwcObNRa7uij\nj2batGlcc801TJ48mRkzZnDJJZcwZMgQOnXqRI8ePejVqxfnnHNO6rG29/tCmzZt4qKLLmLJkiV0\n796dTZs28b3vfY9jjjlmm/tMnz6dyy67rNGyr371q4wdO5aFCxd+bPvdd9+ds88+m/PPP5977723\nzc/BQsheg7aampqgEWMlqZUrV7Lbbru1dxgiudfUteicm+a9T/QLXbfsREQkE5SQREQkE5SQREQk\nE5SQREQkE5SQREQkE5SQREQkE/QeknQ88y9Np9zh5yXarF+/fnTp0qXhPSTnHBdccAGnnXYaS5Ys\nAaCyspKamhoWL17c0NPAsmXL6NatW8MQ0NOmTePmm2/moYceonfv3qxfv57ddtuN8ePHc9JJJ6Vw\ngo2tvurqVMrtdcbpibe96667uOSSS9i8eTPvv/8+u+++O/PmzWPEiBFMnDiR0aNHs2XLFk477TRe\nfPFFJk+ezJQpU6itraV79+4A/P73v+fSSy9lwYIFjd5pkuxRQhJJwdbDTxx11FGMHDmyoRuXNWvW\nsGHDBkaMGMGECROAaKyfqqoqJk6c2LDfzTff3DDcAkBtbS1jxoxh9erVdPR39bY1nELh0AgbN27k\n5JNPZv369cydO5du3boxd+5czj33XK688kpWrVrFpEmTeOCBB5SMyoBu2YmUwPLly9ljjz0a5nv2\n7Mmee+7Z4nKqqqq44ooruOyyy8jiS+1taVvDKdQnpLq6OkaPHk1lZSWzZ89uqJFOnTqVBx54gEcf\nfZQJEyZw5plncuCBB7bLOUjLKCGJpKBw+InZs2dzzjnnMG7cOA477DAmT57MY4891uqyhwwZwqpV\nq1i9enUbRpw9xYZTOOOMM9h555259dZb6dTpo5s9O+ywAzfddBPHHXccq1at4uyzz26P8KUVlJBE\nUlA4/MSxxx7LCSecwLJly5g8eTIAxxxzDFOnTm1V2R29ZlSv2HAKhx9+OA8//DAvvPDCx/Y97LDD\n2H///TnrrLOoqNCvuXKhb0qkRHr06MFxxx3H5ZdfzrXXXsutt97aqnKeeeYZevfuTe/evds4wmza\n1nAK3/rWt7jiiiv42te+Rm1t7cf2q6yspLKystThynZQQhIpgfvuu48NGzYAUQ1n0aJFzQ4LsC3P\nP/88EydOLEnv1e0tyXAK3/72t7n66qs54ogjUhsSQUpHrexESuDRRx9lypQpdOrUiRACAwYM4Oqr\nkzWrnjp1KjNmzGDDhg307t2b8847j5NPPjnliNtfc8Mp1A/nAfDNb36TiooKjjjiCObMmcPgwYPb\nMWrZHhp+Qsqehp8QyQYNPyEiIh2CEpKIiGRCqs+QnHO7An8sWNQd+CzQ23v/TprHFhGR8pJqQvLe\nvw009J/inDsb+LKSkYiIbK3Ut+zGAdNLfEzp4CoqKqirq2vvMERyra6ubrtfQk5UQzKzbsAZRLWd\nrvXLQwjHJT2Qc+6LQA/gvibWTQIaWmFUV1cnLVaEnj17smbNGtatW9feoUjOLf77P9o7hFbZ99Of\n3O4yKioq6Nmz53aVkfSW3X8C64AvApcDY4GWdsY1DrjFe79p6xXe+xqgpn6+pqYme23RJbPMrGHI\nBpH2NPP5te0dQqsMOzgbr00kTUgHhxAGmdnzIYSrzGwGcH/SgzjndgS+DRzaihhFRCQHkt7wq79B\nv8nMdggh/ANoyZ+kY4DnvPcvtSg6ERHJjaQ1pHfMrAcwB5hrZmuA5S04zjii234iIiJNSpqQ/l8I\nYbOZ/Tvwr0SNE25JehDv/RdbE5yIiORH0YRkZpXAXGBUiDq+uy31qEREJHeKPkMKIWwGupuZuhkS\nEZHUJL1l9wxwn5n9DlhfvzCEcE8qUYmISO4kTUgHxZ8/LFgWACUkERFpE4kSUghheNqBiIhIviV6\nLmRmC5IsExERaa2kDRUa1aTMrDOw/Z0fiYiIxJpNSGZ2jpm9Cwwys3fqf4j6tWtpX3YiIiLbVOwZ\n0nXALOBaYELB8nUhhHdTi0pERHKn2YQUQlgLrDWz8cCqEML7AGbW1cw+E0J4sxRBiohIx5f0GdId\nW81bE8tERERaLWlC+kR97QgghFAHdEknJBERyaOkCSmYWe/6GTP7NFEtSUREpE0k7anhSuApM7s1\nnj8RuDCdkEREJI+S9tRwk5ktAY6MF50SQng8vbBERCRvktaQAJ4A3gwhvJZWMCIikl9Juw76CvAG\nMD+ePzTu+VtERKRNJG3U8EtgGPA2QAjhGaA6raBERCR/kiakyiZu1X3Y1sGIiEh+JU1I75vZjkRj\nIGFmg4C61KISEZHcSdqo4WLgQaBv/OxoFPCvSXZ0znUBLgcOB94HnvPen9iKWEVEpANL2uz7QTN7\nBTiC6IXYC1rQ2u6XRDWrfb33wTn36daFKiIiHVlLmn2vAl4gSi5/T7KDc24HYBzQ13sfALz3ifYV\nEZF8SZSQzGwkMBNYQVRD6mNmJ4QQ5hfZdW/gHeCnzrlRRM+dfu69/2PhRs65ScCk+vnqajXgExHJ\nm6SNGn4NHB1COCSEUA0cTdSdUDGdgL2Av3rvHXAmMMs5t1vhRt77Gu993/qf/fbbrwWnICIiHUHS\nhLQlhPB0/UwIYQGwOcF+y4AtwG0A3vtFwBJgUAvjFBGRDi5pQnrQzMbaR04manXXLO/9GuCPRC3s\ncM79C/AvwP+2NmAREemYkjZq+AGwE3B9PN+ZaCTZHwIhhLBLM/tOAKY75y4jqi2N996vaG3AIiLS\nMSVNSFWtPYD3/nVgeGv3FxGRfEj6HtIbAGbWCTiQqNfvt9MMTERE8qXZZ0hmdlncTRBm1hV4mqjH\n76VmdlQJ4hMRkZwo1qjhG8CL8fQJRM+AdgOGAuenGJeIiORMsYT0QQhhSzz9FeD2EMKHIYTnaFkv\nDyIiIs0qlpA6mdkn4umhRKPG1uuaTkgiIpJHxWo5/w3MN7N3iHrqfhrAzD4LrE05NhERyZFmE1II\n4SIzexHoS3S7LsSregAXpB2ciIjkR9HnQCGEO5tY9mw64YiISF4l7TpIREQkVUpIIiKSCUpIIiKS\nCc0+QzKzLzW3PoTwWNuGIyIieVWsUcPl8WclUQerrxMNYb43UAsckl5oIiKSJ83esgshHBpCOJQo\n+RweQtgnhNAf+BqwsBQBiohIPiR9huRCCA/Vz4QQ5gGHphOSiIjkUdKEtNnMGsY0MrMvE3W0KiIi\n0iaSdpB6GnC7mW0s2G9MOiGJiEgeJR2g70kz2xsYGC96KYSwsbl9REREWqIl7yEdDXwjhPAC0Kt+\n4D4REZG2kKiGZGYXETVi2Bv4D6Km39cDXyy2r3NuKfABUBcvutR7P6s1wYqISMeV9BnSMUTvHHmA\nEMJbZrZjC44zxntf29LgREQkP5LesqsLIWzeapm1dTAiIpJfSWtIb5jZMCCYWWfgp0QvyyZ1q3MO\nYAFwrvd+dcvCFBGRji5pQjoTuBkYBPwTmA+cmHDfL3nvlznnOgO/iMs5snAD59wkYFL9fHV1dcKi\nRaQ9THtocWpln/XVfVMrO824Zfslbfa9EjjCzLoDFkL4Z9IDeO+XxZ8bnXO/Bj72P8J7XwPU1M/X\n1NSErbcREZGOLdEzJDNbABBC2FCfjOqXNcc5t4NzbueCRScAi1oTqIiIdGxJb9k12i5+jvTJBPvt\nBtzpnKskagTxOnByiyIUEZFcKDYe0jnAucCOZvZOwapuwC3FCvfevw7ogZCIiBRVrIZ0HTALuBaY\nULB8XQjh3dSiEhGR3Gk2IYUQ1gJrga+XJhwREcmrpF0H9QYuBA4GutYvDyFoxFgREWkTSXtqmA4s\nBXoCFwB/A+5PKSYREcmhpAnpMyGEy4APQgj3AscBo9ILS0RE8iZpQvow/nzfzHYFNhHVlkRERNpE\n0veQFseJ6HfA08A64NnUohIRkdxJ2nVQfb91V5jZs8DOwAOpRSUiIrmTtIbUIITwpzQCERGRfCvW\nU8O7RKPDfmwVEEIIu6QSlYiI5E6xGlJVSaIQEZHcK9ZTwxulCkRERPItaU8NS2ji1l0I4bNtHpGI\niORS0kYNRxVMdwVOAt5u+3BERCSvkjb7fnGrRc+a2ZPAxW0fkoiI5FHSnhoaiV+S/XQbxyIiIjmW\n9BnSIj56hlQJ7AX8/7SCEhGR/En6DGliwfQm4PUQwlspxCMiIjmV9BnSo2kHIiIi+Zb0lt3+ROMg\n9S/cJ4RwUEpxiYhIziS9ZXc7cAvwG2Bzaw7knDsFuBE41nt/d2vKEBGRjitpQtocQvhVaw/inOsH\n/BD4c2vLEBGRji1ps+/5Zval1hzAOVcB3ACcAXzQmjJERKTjS5qQ7gDuN7O/mdnrZrbEzF5PuO8k\n4AnvvQb0ExGRbUp6y+4m4MeApwXPkJxzBwLHA83Wrpxzk4gSFwDV1dVJD9Eqq6+6OrWye51xempl\nS8cy7aHFqZbfpde8FEsflVrJaf+7SHYlTUjrQwg3tqL8YUA/4BXnHES9O/zWOdfHe39t/Ube+xqg\npn6+pqamqTGYRESkA0uakO43s2+EEO5tSeFx0mlIPM65R4Bfq5WdiIhsLWlCOgPYyczqiBomaMRY\nERFpU0kTUpuMHOu9/0pblCMiIh1P0q6DNHKsiIikqtmEZGb/FUI4YavevhuEEA5JLTIREcmVYjWk\n+t4ZJja7lYiIyHZqNiGFEJ6NPxt6+zaznUMI76UdmIiI5EuzPTWY2UQz2y+erjCze4F3zGy1mX2h\nJBGKiEguFOs66AfAa/H0t4B9gD7AWOCy9MISEZG8KZaQNoUQPoynRwK3hhBWhhDuBz6ZbmgiIpIn\nxRJSJzOzePow4MmCdZ3TCUlERPKoWCu7PwKzzGwVUY3oTwBm9mk0lISIiLShYjWkycDTwEbgiBDC\npnh5fwo6QxUREdlexZp9bwIub2L546lFJCIiuZR0gD4REZFUKSGJiEgmFHsx9qvx56dKE46IiORV\nsRrSL+PPR1KOQ0REcq5Ys+/OZnYO0NvMztx6ZQjhynTCEhGRvCmWkH4IfA/oBlRvte5jw1GIiIi0\nVrFm308DT5vZGyEE9V0nIiKpSTpi7GVm9jlgVLzowRCCTy8sERHJm0TNvs3sVOAOoDfQC7jTzH6Q\nZmAiIpIviWpIwOnA4BDCagAz+w+ifu5uKLajc+5B4NPAFuAfwJne+0WtC1dERDqqpAmJ+mRUP/1R\nJ+BFfdt7/x6Ac+5YYAZwcAtiFBGRHEjaU8MrZnaJme0Z/1wMvJJkx/pkFNsJtc4TEZEmJK0hTQCu\nAhYSJZR5wL8lPYhz7hZgeDx7ZBPrJwGT6uerq7duYS4iIh1d0lZ2q4HvtPYg3vuTAZxz3yMa+vzI\nrdbXUDCcRU1NjWpRIiI5U9LOVb33NwPDnXO7lvK4IiKSfakmJOfczs653QvmRwNvA++keVwRESk/\niVvZtdJOwH8757oRNfteDRzlvdctORERaaRoQjKzSmBuCGFUsW235r1/A/hcawITEZF8KXrLLoSw\nGehuZhrMT0REUpP0lt0zwH1m9jtgff3CEMI9qUQlIiK5kzQhHRR//rBgWQCUkEREpE0kfQ9pePGt\nREREWi9pb9+dzGyymV0Tz+9tZiPSDU1ERPIk6S27q4FKYGg8/zYwC3BpBCUiIvmTNCF9PoRQZWaL\nAEII75lZ5xTjEhGRnEnalPv9wpn43SQ1AxcRkTaTNKk8b2YnAhVmtg9wHfBIalGJiEjuJE1Ik4Bh\nRCO/PknUDdA5aQUlIiL5k7TZ93pgfPwjIiLS5hIlJDPrApwFjCJ6IfYh4IoQwgcpxiYiIjmStJXd\ndcCuRKPGApwCDAS+n0ZQIiKSP0kT0heA/UIIAcDM7gNeTC0qERHJnaSNGt4GuhXMdwHWtH04IiKS\nV83WkMzszHjyJeBpM/t9PP9Noh7ARURE2kSxW3bVBdMe+Gw8vZCoKyEREZE20WxCCiGcUqpAREQk\n35I2asDMvg70L9wnhFCTRlAiIpI/Sd9DmgnsBywCNseLQ1pBiYhI/iStIR0CHBBC2Fx0ywLOua7A\n7cD+QB2wCvg37/2rLYpSREQ6vKTNvpcSNfVujd8CA7z3BwP/A9zQynJERKQDS1pDmgzMM7NHKBiK\nIoRwUXM7ee/fB+YULPozcHYLYxQRkRxImpAuBT4EugLbMzDfj4lqSY045yYR9SgOQHV19dabtK2l\nj6dY+Okpli2ldtKdF7d3CK32hV67tncIIi2SNCENCCEM2J4DOed+CuwDjNx6nfe+BmhosVdTU6MG\nEyIiOZP0GdLLZvap1h7EOXc2cBzwde/9htaWIyIiHVfSGlIdsNDMHqTxM6RJ294lEt+OOwEY5b1/\nr1VRiohIh5c0If01/mkR51xf4HLgdWC+cw7gA+/9kJaWJSIiHVvSEWMvbE3h3vvlgLVmXxERyZek\nPTWc39TyYs2+RUREkkp6y+6TBdNdgSOBp9o+HBERyaukt+ymFM6b2c+BGSnEIyIiOZW02XcjIYS3\n+WhsJBERke2W9BnSmQWzlcDngL+nEpGIiORS0mdIhX35bAJqiTpNFRERaRNJnyFp5FgREUlVswnJ\nzL7U3PoQwmNtG46IiORVsRrS5U0sC8DuQB+i50kiIiLbrdmEFEI4tHDezHYBfgacCFyQYlwiIpIz\niZp9m1lXMzuPj/qz2y+E8Iv0whIRkbxpNiGZWYWZnQq8AgwEhoQQJsXvIYmIiLSZYs+Q/gJ0AX4K\nPAfsZGYH1a8MITyfYmwiIpIjxRJSd6JGDE11ohpQbw0iItJGijVq6FeiOEREJOda1ZediIhIW1NC\nEhGRTFBCEhGRTFBCEhGRTEja23erOeeuBI4G9gKqvfe1aR9TRETKTylqSHcAQ4E3SnAsEREpU6nX\nkLz3jwE459I+lIiIlDE9QxIRkUxIvYaUhHNuEjCpfr66urqZrbffXz4cnFrZw1MrWaRlnnotvS4n\nD/lUakVLjmUiIXnva4Ca+vmamprQjuGIiEg70C07ERHJhNQTknPueufccqAvMNc592raxxQRkfJT\nilZ249M+hoiIlD/dshMRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIR\nkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQ\nQhIRkUxQQhIRkUxQQhIRkUzolPYBnHP9gZuBnsBaYKz3/sW0jysiIuWlFDWk64Hfeu/3BS4DZpTg\nmCIiUmZSTUjOud6AA34XL7oT+Ixzbp80jysiIuUn7RrSZ4C3vPebALz3AVgG7JnycUVEpMyk/gwp\nCefcJGBSwaIXZs6cOa+94knoEGDhx5a635c+ku3X9LmUJ51LCfwv/9PSXTJ7Lq3Q4c7ltvNSPcZe\nSTe0EEJqUcS37F4FdvHeb3LOGfAWMNR7/2pqBy4B59xy733f9o6jLehcsknnkk06l/SkesvOe7+K\n6C+JE+NFxwPLyz0ZiYhI2yvFLbvxwAzn3E+BdcApJTimiIiUmdQTkvf+ZeALaR+nHdS0dwBtSOeS\nTTqXbNK5pCTVZ0giIiJJqesgERHJBCUkERHJhEy8h5QVSfvdc84dBfwKqAReiLdbF68bAvwW6AYs\nB07y3q8ozRk0irHouTjnBgG/AXoDm4AFwGne+7p4fQD+AmyOdznDe/94ac6gsYTn0w94jeg7qXe8\n9/61eH05fTeHE3W1Va838Hfv/SHx+nb/bpxzVwJHE71nUu29r93GduVwvRQ9l3K5XhKeSz8yeK2o\nhtRY0X73nHM7AtOB0d77/sDfgH+P11UAtwET4zLmAL8uTegfk6QPwfeB0733A4GDgR2Ac7baZpj3\nvir+aZdkFEvaJ+I/CuKtKrjAyuq78d7PLTwPotcnbttqs/b+bu4AhgJvbGuDMrpeip4L5XO9JDkX\nyOC1ooQUa0G/e18HFnnvX4rnrwFOiKcHA5u89/Pj+euBbzjnuqYX+cclPRfv/Sve++fj6c3AM0C/\nEoaaSBv1iVhW381W++wOjARuTT/C5Lz3j3nvlxfZLPPXCyQ7l3K5XhJ+L81pt+9FCekjSfvd25PG\nf3ksBfo45zptvc57/w+id692Ty/sJrW4D0Hn3A7AD+BjfcLMd84955yribdpDy05nx2cc8865xY6\n5853zlXGy8v2uwHGAnPiF80LZeG7KaYcrpcWy/j1klTmrhUlJME59wlgFvCg9352waq9vPfVwBeB\nXsDU9oivBd4C9vDeDwZGAcOAye0b0vaJu9v6PtFtr0Ll9t10GB3kesnktaKE9JE3+egvt/pfBHsS\n/fVaaBmNOwvsx0d/8TZa55z7JLAT0X3zUkp6LjjnOhNdXG8BPy5c571fFn/+k+hWy7B0w96mROfj\nvf+gvhbhvX8HuJGPYi677yb2ZaArMLdwYYa+m2LK4XpJrEyul6Kyeq0oIcVa0O/eA8AhzrmB8fyP\ngNvj6WeBzs654fH8eOBe7/376UX+cUnPJf6leDvwDnBqfPuofl0P51z3eLoCGAMsKkH4H9OC8+kd\n/8LAOdcFOI6PYi6r76bAOGBG/MwCyNZ3k0Dmr5ekyuV6SSKr14oSUmPjgfHOucXAucT97jnnLnLO\nTYCG+6k/AO52zr0K9AUujtdtIfpFc0VcxlHAWSU/i0jRcyG6aI4jesi+yDlX65z7TbxuIPBn59xz\nRE1DdwWw548yAAACvElEQVQmlvIEtpLkfIYSncdzRL/0/w5cAmX53eCc24no+7lxq/0z8d045653\nzi0nugbmxtdDWV4vSc6FMrleEp5LJq8VdR0kIiKZoBqSiIhkghKSiIhkghKSiIhkghKSiIhkghKS\niIhkghKSSBFmttTMXjaz2vjz3FaUcZSZPVJkm5+bWZOdWJrZ0WY2rWD+QjN7ycyeNrN+Zjahqf1E\nyomGnxBJZkwIodbM9gD+amYPhxAWlOrgIYR7gHsKFv0E+GwI4S0z+wowAbiuVPGIpEE1JJEWCCGs\nAF4i7lrFzE6KaykLzewxMzs4Xt7ZzK4xs1fMbAFQ/9Y7ZtbfzJ4ws+fM7AUz+0XBIfqY2b1m9lcz\ne9jMdon3GWtmd8fTTxJ1J/SgmV1JlIgGxDW4wqQlUlZUQxJpATMbSPQW/iNmdhjRUApfCiF8YGbD\ngJnAAcCpwIB4Ghr3RXc6cF8I4dK4zF0K1g0BBocQ3jaz24l6dbi0MIYQwhfNLADDQgjvxTWkX4cQ\nqtr4dEVKSglJJJlZZraFKMmcFUJYbWZTiAZqe9rM6rfbxcy6EY1fdEsI4UMAM7uRqF86gMeAqWa2\nI/AoMK/gOA+EEN6Op58CBqV5UiJZolt2IsmMCSHsB3wN+KWZDQIMuDmEUFXw0yeEUNfE/g19dIUQ\n7gQOA14mri0VbFfYgeVm9Eej5IgSkkgLhBDmAdcCvyBqZHCime0JYGYVZubiTefF6zqb2SeIO1CN\nt+sPrAwh3ELUOOHz2xnWOqLhAUTKmhKSSMtdTNRb8gaihDLbzJ4DXgS+E2/zn8ArwF+BPwG1Bft/\nE3jBzBYRja2zvU22nwdeNLO/qFGDlDP19i0iIpmgGpKIiGSCEpKIiGSCEpKIiGSCEpKIiGSCEpKI\niGSCEpKIiGSCEpKIiGSCEpKIiGSCEpKIiGTC/wHoYrJHE2foTAAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x1106222e8>"
+       "<matplotlib.figure.Figure at 0x111604f28>"
       ]
      },
      "metadata": {},
@@ -481,17 +534,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Simulating spectra using quickgen.\n",
+    "## Setting up a production directory ##\n",
     "\n",
-    "We're now ready to simulate DESI spectra using *quickgen*!  Since we're calling *quickgen* from within this notebook (rather than from the command line in a terminal) we have to parse the *simspec* and *fibermap* filename inputs first.\n",
+    "Before proceeding with simulating noisy output spectra, we will call `desi_pipe`\n",
+    "to setup a production directory hierarchy.  We'll tell it to skip several\n",
+    "of the initial steps since we will use `quickgen` to directly simulate\n",
+    "extracted and calibrated spectra instead of generating pixel-level raw data.\n",
     "\n",
-    "*quickgen* generates four types of files and writes them to the *\\$DESI_SPECTRO_REDUX/\\$SPECPROD/exposures* directory: *calib*, *sky*, *cframe*, and *frame* files.  We will use the *cframe*, or calibrated frame files, which contain the flux-calibrated and sky-subtracted DESI spectra.  The data model and the other files and their contents are documented here:  \n",
-    "http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_REDUX/PRODNAME/exposures/NIGHT/EXPID/index.html"
+    "The following code is equivalent to calling the command line\n",
+    "```\n",
+    "desi_pipe --fakeboot --fakepsf --fakepix\n",
+    "```"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false
    },
@@ -500,15 +558,112 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:quickgen.py:242:main: Reading fibermap file /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/fibermap-00000000.fits\n",
+      "Working with production /data/desi/spectro/redux/example :\n",
+      "  Updating plans ...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/sbailey/anaconda/envs/desi/lib/python3.5/site-packages/matplotlib/__init__.py:1401: UserWarning:  This call to matplotlib.use() has no effect\n",
+      "because the backend has already been chosen;\n",
+      "matplotlib.use() must be called *before* pylab, matplotlib.pyplot,\n",
+      "or matplotlib.backends is imported for the first time.\n",
+      "\n",
+      "  warnings.warn(_use_error_msg)\n"
+     ]
+    },
+    {
+     "ename": "KeyError",
+     "evalue": "'r0'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-17-6319d2d14e00>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mdesispec\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mscripts\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mpipe_prod\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0margs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpipe_prod\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparse\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'--fakeboot'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'--fakepsf'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'--fakepix'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mpipe_prod\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmain\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/Users/sbailey/desi/git/desispec/py/desispec/scripts/pipe_prod.py\u001b[0m in \u001b[0;36mmain\u001b[0;34m(args)\u001b[0m\n\u001b[1;32m    326\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"  Updating plans ...\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    327\u001b[0m     expnightcount, allpix = pipe.create_prod(nightstr=args.nights, \n\u001b[0;32m--> 328\u001b[0;31m         extra=extra, specs=specs, fakepix=args.fakepix, hpxnside=args.nside)\n\u001b[0m\u001b[1;32m    329\u001b[0m     \u001b[0mtotcount\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m{\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    330\u001b[0m     \u001b[0mtotcount\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"flat\"\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/sbailey/desi/git/desispec/py/desispec/pipeline/plan.py\u001b[0m in \u001b[0;36mcreate_prod\u001b[0;34m(nightstr, extra, specs, fakepix, hpxnside)\u001b[0m\n\u001b[1;32m    182\u001b[0m             \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmakedirs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnlog\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    183\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 184\u001b[0;31m         \u001b[0mgrph\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mexpcount\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnpix\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mgraph_night\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnt\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mspecs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfakepix\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mhpxnside\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    185\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    186\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0mpix\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mnpix\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/Users/sbailey/desi/git/desispec/py/desispec/pipeline/plan.py\u001b[0m in \u001b[0;36mgraph_night\u001b[0;34m(rawnight, specs, fakepix, hpxnside)\u001b[0m\n\u001b[1;32m    505\u001b[0m         \u001b[0mcam\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"{}{}\"\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mband\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mspec\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    506\u001b[0m         \u001b[0mflatid\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 507\u001b[0;31m         \u001b[0;32mfor\u001b[0m \u001b[0mfid\u001b[0m \u001b[0;32min\u001b[0m \u001b[0msorted\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mflatexpid\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mcam\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    508\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mflatid\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    509\u001b[0m                 \u001b[0mflatid\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfid\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'r0'"
+     ]
+    }
+   ],
+   "source": [
+    "from desispec.scripts import pipe_prod\n",
+    "args = pipe_prod.parse(['--fakeboot', '--fakepsf', '--fakepix'])\n",
+    "pipe_prod.main(args)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DESI_SPECTRO_DATA=/data/desi/spectro/sim/example/\n",
+      "DESI_SPECTRO_REDUX=/data/desi/spectro/redux\n",
+      "SPECPROD=example\n",
+      "/data/desi/spectro/sim/example/\r\n",
+      "/data/desi/spectro/sim/example//20170615\r\n",
+      "/data/desi/spectro/sim/example//20170615/fibermap-00000000.fits\r\n",
+      "/data/desi/spectro/sim/example//20170615/simspec-00000000.fits\r\n",
+      "/data/desi/spectro/sim/example//etc\r\n",
+      "/data/desi/spectro/sim/example//etc/obslog.sqlite\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "#- What went wrong?  Check environments and files\n",
+    "for var in ['DESI_SPECTRO_DATA', 'DESI_SPECTRO_REDUX', 'SPECPROD']:\n",
+    "    print('{}={}'.format(var, os.getenv(var)))\n",
+    "\n",
+    "rawdir = os.path.join(os.getenv('DESI_SPECTRO_DATA'))\n",
+    "!find $rawdir | sort"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simulating spectra using quickgen.\n",
+    "\n",
+    "We're now ready to simulate DESI spectra using *quickgen*!  Since we're calling *quickgen* from within this notebook (rather than from the command line in a terminal) we have to parse the *simspec* and *fibermap* filename inputs first.\n",
+    "\n",
+    "*quickgen* generates four types of files and writes them to the *\\$DESI_SPECTRO_REDUX/\\$SPECPROD/exposures* directory: *calib*, *sky*, *cframe*, and *frame* files.  We will use the *cframe*, or calibrated frame files, which contain the flux-calibrated and sky-subtracted DESI spectra.  The data model and the other files and their contents are documented here:  \n",
+    "http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_REDUX/PRODNAME/exposures/NIGHT/EXPID/index.html\n",
+    "\n",
+    "The following code calls the equivalent of the command line:\n",
+    "```\n",
+    "quickgen --simspec {simspecfile} --fibermap {fiberfile}\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:quickgen.py:242:main: Reading fibermap file /data/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
       "INFO:quickgen.py:275:main: Initializing SpecSim with config desi\n",
-      "INFO:quickgen.py:281:main: Reading input file /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/simspec-00000000.fits\n",
+      "INFO:quickgen.py:281:main: Reading input file /data/desi/spectro/sim/example/20170615/simspec-00000000.fits\n",
       "INFO:quickgen.py:310:main: Only 50 spectra in input file\n",
       "INFO:quickgen.py:672:main: Writing files for channel:b, spectrograph:0, spectra:0 to 50\n",
-      "INFO:quickgen.py:699:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-b0-00000000.fits\n",
-      "INFO:quickgen.py:717:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\n",
-      "INFO:quickgen.py:732:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-b0-00000000.fits\n",
-      "INFO:quickgen.py:753:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-b0-00000000.fits\n",
+      "INFO:quickgen.py:699:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/frame-b0-00000000.fits\n",
+      "INFO:quickgen.py:717:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\n",
+      "INFO:quickgen.py:732:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/sky-b0-00000000.fits\n",
+      "INFO:quickgen.py:753:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/calib-b0-00000000.fits\n",
       "INFO:quickgen.py:672:main: Writing files for channel:r, spectrograph:0, spectra:0 to 50\n"
      ]
     },
@@ -523,15 +678,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:quickgen.py:699:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-r0-00000000.fits\n",
-      "INFO:quickgen.py:717:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-r0-00000000.fits\n",
-      "INFO:quickgen.py:732:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-r0-00000000.fits\n",
-      "INFO:quickgen.py:753:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-r0-00000000.fits\n",
+      "INFO:quickgen.py:699:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/frame-r0-00000000.fits\n",
+      "INFO:quickgen.py:717:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-r0-00000000.fits\n",
+      "INFO:quickgen.py:732:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/sky-r0-00000000.fits\n",
+      "INFO:quickgen.py:753:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/calib-r0-00000000.fits\n",
       "INFO:quickgen.py:672:main: Writing files for channel:z, spectrograph:0, spectra:0 to 50\n",
-      "INFO:quickgen.py:699:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-z0-00000000.fits\n",
-      "INFO:quickgen.py:717:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-z0-00000000.fits\n",
-      "INFO:quickgen.py:732:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-z0-00000000.fits\n",
-      "INFO:quickgen.py:753:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-z0-00000000.fits\n"
+      "INFO:quickgen.py:699:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/frame-z0-00000000.fits\n",
+      "INFO:quickgen.py:717:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-z0-00000000.fits\n",
+      "INFO:quickgen.py:732:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/sky-z0-00000000.fits\n",
+      "INFO:quickgen.py:753:main: Wrote file /data/desi/spectro/redux/example/exposures/20170615/00000000/calib-z0-00000000.fits\n"
      ]
     }
    ],
@@ -547,114 +702,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, let's combine and reorganize the individual *cframe* files into *bricks*.  You can read all about the *brick* data model here  \n",
-    "http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_REDUX/PRODNAME/bricks/BRICKNAME/index.html  \n",
-    "and in this TechNote:  \n",
-    "https://desi.lbl.gov/DocDB/cgi-bin/private/ShowDocument?docid=1056"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CRITICAL:makebricks.py:88:main: Non-existent night 20170615\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "-2"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "args = makebricks.parse(['--night', night, '--specprod', simdir, '--verbose'])\n",
-    "makebricks.main(args)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/Users/ioannis/research/projects/desi/spectro/redux/example'"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "os.path.join( os.getenv('DESI_SPECTRO_REDUX'), os.getenv('SPECPROD') )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/Users/ioannis/research/projects/desi/spectro/redux/example/20170615\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(simdir)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'/Users/ioannis/research/projects/desi/spectro/data/20170615/fibermap-00000000.fits'"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "desispec.io.findfile(filetype='fibermap', night=night, expid=expid, specprod_dir=simdir)"
+    "Next, let's combine and reorganize the individual *cframe* files into *spectra* files grouped on the sky.\n",
+    "\n",
+    "**TODO**: Add the spectra files to the desidatamodel\n",
+    "\n",
+    "**TODO**: Proceed with calling desi_group_spectra, but first we need to production generation above."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
+    "collapsed": true
    },
    "outputs": [],
    "source": []
@@ -663,7 +722,7 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [default]",
    "language": "python",
    "name": "python3"
   },

--- a/doc/nb/simulating-desi-spectra.ipynb
+++ b/doc/nb/simulating-desi-spectra.ipynb
@@ -1,0 +1,743 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Simulating DESI Spectra\n",
+    "\n",
+    "The goal of this notebook is to demonstrate how to generate some simple DESI spectra using the *quickgen* utility.\n",
+    "\n",
+    "For additional (albeit somewhat outdated) information and documentation about *quickgen* see  \n",
+    "https://desi.lbl.gov/DocDB/cgi-bin/private/ShowDocument?docid=1429\n",
+    "\n",
+    "If you identify any errors or have requests for additional functionality please create a new issue on  \n",
+    "https://github.com/desihub/desisim/issues\n",
+    "or send a note to <desi-data@desi.lbl.gov>."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Getting started.\n",
+    "\n",
+    "First, import all the package dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from astropy.io import fits\n",
+    "from astropy.table import Table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Populating the interactive namespace from numpy and matplotlib\n"
+     ]
+    }
+   ],
+   "source": [
+    "%pylab inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import desispec.io\n",
+    "import desisim.io\n",
+    "from desisim.obs import new_exposure\n",
+    "from desisim.scripts import quickgen\n",
+    "\n",
+    "from desiutil.log import get_logger\n",
+    "log = get_logger()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make sure we have all the right environment variables set (assuming the bash shell).  If any of these environment variables are missing please set them in your *.bashrc* file (and then restart this notebook) or create them for just this notebook session using the *%env* magic command, as we demonstrate below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "def check_env():\n",
+    "    for env in ('DESIMODEL', 'DESI_ROOT', 'DESI_SPECTRO_SIM', 'DESI_SPECTRO_DATA', \n",
+    "            'DESI_SPECTRO_REDUX', 'SPECPROD', 'PIXPROD'):\n",
+    "        if env in os.environ:\n",
+    "            print('{} environment set to {}'.format(env, os.getenv(env)))\n",
+    "        else:\n",
+    "            print('Required environment variable {} not set!'.format(env))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DESIMODEL environment set to /Users/ioannis/repos/desihub/desimodel\n",
+      "DESI_ROOT environment set to /Users/ioannis/research/projects/desi\n",
+      "DESI_SPECTRO_SIM environment set to /Users/ioannis/research/projects/desi/spectro/sim\n",
+      "DESI_SPECTRO_DATA environment set to /Users/ioannis/research/projects/desi/spectro/data\n",
+      "DESI_SPECTRO_REDUX environment set to /Users/ioannis/research/projects/desi/spectro/redux\n",
+      "SPECPROD environment set to example\n",
+      "PIXPROD environment set to example\n"
+     ]
+    }
+   ],
+   "source": [
+    "check_env()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's reassign the *SPECPROD* and *PIXPROD* environments to something other than \"dailytest\" so that we don't conflict with the outputs of the standard DESI integration test."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "env: SPECPROD=example\n",
+      "env: PIXPROD=example\n"
+     ]
+    }
+   ],
+   "source": [
+    "%env SPECPROD=example\n",
+    "%env PIXPROD=example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Specify the parameters of the simulation.\n",
+    "\n",
+    "Next, specify the number and spectral type distribution of spectra we want to simulate, and the random seed.  Setting the seed here (which can be any number at all!) ensures that your simulations are reproducible.  Let's also explicitly set the *night* of the \"observations\" (the default is to use the current date) and the *expid* or exposure ID number (which would allow you to simulate more than one DESI exposure).\n",
+    "\n",
+    "The *flavor* option is used to choose the correct sky-brightness model and it also determines the distribution of targets for a given flavor.  For example, *flavor='dark'* returns the right relative sampling density of ELGs, LRGs, and QSOs.  The other available (science target) options for *flavor* are 'dark', 'gray', 'grey', 'bright', 'bgs', 'mws', 'lrg', 'elg', 'qso', and 'std'.  (You can also set flavor to either 'arc' or 'flat' but that would be boring!)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "nspec = 50\n",
+    "seed = 555\n",
+    "flavor = 'dark'\n",
+    "night = '20170615'\n",
+    "expid = 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 99,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/ioannis/research/projects/desi/spectro/sim/example/20170615\n"
+     ]
+    }
+   ],
+   "source": [
+    "simdir = desisim.io.simdir(night=night)\n",
+    "print(simdir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate the fibermap and truth tables.\n",
+    "\n",
+    "The first step is to generate the *fibermap* and *simspec* files needed by *quickgen*.  The *fibermap* table contains (simulated) information about the position of each target in the DESI focal plane, while the *simspec* table holds the \"truth\" spectra and the intrinsic properties of each object (redshift, noiseless photometry, [OII] flux, etc.).\n",
+    "\n",
+    "Note that the *tileid* and *exptime* (exposure time) optional inputs are shown here for demonstration purposes but do not need to be explicitly set.  In particular, the default exposure time is based on the value specified in the *$DESIMODEL/data/desi.yaml* parameter file.\n",
+    "\n",
+    "The *fibermap* object is an astropy Table with lots of goodies while the *truth* object is a dictionary that we won't use anymore (we'll instead use the *simspec* table; see below).  The fibermap data model is described at  \n",
+    "http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_DATA/NIGHT/fibermap-EXPID.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "INFO:obs.py:226:new_exposure: skyfile /Users/ioannis/repos/desihub/desimodel/data/spectra/spec-sky.dat\n",
+      "INFO:obs.py:297:new_exposure: Wrote /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
+      "INFO:obs.py:305:new_exposure: Wrote /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits\n"
+     ]
+    }
+   ],
+   "source": [
+    "fibermap, truth = new_exposure(flavor=flavor, nspec=nspec, seed=seed, night=night, \n",
+    "                               expid=expid, tileid=None, exptime=None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, even though we have the *fibermap* table in hand, the code below demonstrates how it and the *simspec* table can be read from on-disk.  The *simspec* data model is described at  \n",
+    "http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_SIM/PIXPROD/NIGHT/simspec-EXPID.html\n",
+    "In particular, HDU=13 contains an extensive (and useful!) metadata table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "fiberfile = desispec.io.meta.findfile('fibermap', night=night, expid=expid, outdir=simdir)\n",
+    "simspecfile = desisim.io.findfile('simspec', night=night, expid=expid, outdir=simdir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 108,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:<ipython-input-108-59b7db187c0a>:1:<module>: Reading fibermap file /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
+      "Filename: /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
+      "No.    Name         Type      Cards   Dimensions   Format\n",
+      "  0  PRIMARY     PrimaryHDU       6   ()      \n",
+      "  1  FIBERMAP    BinTableHDU     98   50R x 26C   [10A, 20A, 8A, K, K, K, K, 5E, 50A, J, K, J, J, J, J, E, D, D, D, D, D, D, D, D, E, E]   \n"
+     ]
+    }
+   ],
+   "source": [
+    "log.info('Reading fibermap file {}'.format(fiberfile))\n",
+    "hdu = fits.open(fiberfile)\n",
+    "hdu.info()\n",
+    "fibermap = Table(hdu[1].data)\n",
+    "hdu.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 109,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "&lt;Row index=3&gt;\n",
+       "<table id=\"table4800756592\">\n",
+       "<thead><tr><th>OBJTYPE</th><th>TARGETCAT</th><th>BRICKNAME</th><th>TARGETID</th><th>DESI_TARGET</th><th>BGS_TARGET</th><th>MWS_TARGET</th><th>MAG [5]</th><th>FILTER [5]</th><th>SPECTROID</th><th>POSITIONER</th><th>LOCATION</th><th>DEVICE_LOC</th><th>PETAL_LOC</th><th>FIBER</th><th>LAMBDAREF</th><th>RA_TARGET</th><th>DEC_TARGET</th><th>RA_OBS</th><th>DEC_OBS</th><th>X_TARGET</th><th>Y_TARGET</th><th>X_FVCOBS</th><th>Y_FVCOBS</th><th>Y_FVCERR</th><th>X_FVCERR</th></tr></thead>\n",
+       "<thead><tr><th>str10</th><th>str20</th><th>str8</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>float32</th><th>str10</th><th>int32</th><th>int64</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>float32</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float32</th><th>float32</th></tr></thead>\n",
+       "<tr><td>ELG</td><td></td><td>3350p205</td><td>3561499325993422263</td><td>2</td><td>0</td><td>0</td><td>23.2547 .. 22.5634</td><td>DECAM_G .. WISE_W2</td><td>0</td><td>82</td><td>82</td><td>82</td><td>0</td><td>3</td><td>5400.0</td><td>335.167583443</td><td>20.5840708185</td><td>335.167583443</td><td>20.5840708185</td><td>-31.5795923296</td><td>-172.635369698</td><td>-31.5795923296</td><td>-172.635369698</td><td>0.0</td><td>0.0</td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Row index=3>\n",
+       "OBJTYPE TARGETCAT BRICKNAME       TARGETID      DESI_TARGET BGS_TARGET MWS_TARGET      MAG [5]           FILTER [5]     SPECTROID POSITIONER LOCATION DEVICE_LOC PETAL_LOC FIBER LAMBDAREF   RA_TARGET     DEC_TARGET      RA_OBS       DEC_OBS       X_TARGET       Y_TARGET       X_FVCOBS       Y_FVCOBS    Y_FVCERR X_FVCERR\n",
+       " str10    str20      str8          int64           int64      int64      int64         float32             str10          int32     int64     int32     int32      int32   int32  float32     float64       float64       float64       float64       float64        float64        float64        float64     float32  float32 \n",
+       "------- --------- --------- ------------------- ----------- ---------- ---------- ------------------ ------------------ --------- ---------- -------- ---------- --------- ----- --------- ------------- ------------- ------------- ------------- -------------- -------------- -------------- -------------- -------- --------\n",
+       "    ELG            3350p205 3561499325993422263           2          0          0 23.2547 .. 22.5634 DECAM_G .. WISE_W2         0         82       82         82         0     3    5400.0 335.167583443 20.5840708185 335.167583443 20.5840708185 -31.5795923296 -172.635369698 -31.5795923296 -172.635369698      0.0      0.0"
+      ]
+     },
+     "execution_count": 109,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fibermap[3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 110,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:<ipython-input-110-079a1c11142f>:1:<module>: Reading simspec file /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits.\n",
+      "Filename: /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits\n",
+      "No.    Name         Type      Cards   Dimensions   Format\n",
+      "  0  PRIMARY     PrimaryHDU      15   ()      \n",
+      "  1  WAVE        ImageHDU         9   (31901,)   float64   \n",
+      "  2  FLUX        ImageHDU         9   (31901, 50)   float32   \n",
+      "  3  SKYFLUX     ImageHDU         8   (31901,)   float32   \n",
+      "  4  WAVE_B      ImageHDU         9   (12326,)   float64   \n",
+      "  5  PHOT_B      ImageHDU         8   (12326, 50)   float32   \n",
+      "  6  SKYPHOT_B   ImageHDU         7   (12326,)   float32   \n",
+      "  7  WAVE_R      ImageHDU         9   (11205,)   float64   \n",
+      "  8  PHOT_R      ImageHDU         8   (11205, 50)   float32   \n",
+      "  9  SKYPHOT_R   ImageHDU         7   (11205,)   float32   \n",
+      " 10  WAVE_Z      ImageHDU         9   (12765,)   float64   \n",
+      " 11  PHOT_Z      ImageHDU         8   (12765, 50)   float32   \n",
+      " 12  SKYPHOT_Z   ImageHDU         7   (12765,)   float32   \n",
+      " 13  METADATA    BinTableHDU     61   50R x 24C   [10A, 10A, J, K, E, E, 6E, 2E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E, E]   \n"
+     ]
+    }
+   ],
+   "source": [
+    "log.info('Reading simspec file {}.'.format(simspecfile))\n",
+    "hdu = fits.open(simspecfile)\n",
+    "hdu.info()\n",
+    "meta = Table(hdu[13].data)\n",
+    "hdu.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 111,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "&lt;Table length=3&gt;\n",
+       "<table id=\"table4797028000\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>OBJTYPE</th><th>SUBTYPE</th><th>TEMPLATEID</th><th>SEED</th><th>REDSHIFT</th><th>MAG</th><th>DECAM_FLUX [6]</th><th>WISE_FLUX [2]</th><th>OIIFLUX</th><th>HBETAFLUX</th><th>EWOII</th><th>EWHBETA</th><th>D4000</th><th>VDISP</th><th>OIIDOUBLET</th><th>OIIIHBETA</th><th>OIIHBETA</th><th>NIIHBETA</th><th>SIIHBETA</th><th>ZMETAL</th><th>AGE</th><th>TEFF</th><th>LOGG</th><th>FEH</th></tr></thead>\n",
+       "<thead><tr><th>str10</th><th>str10</th><th>int32</th><th>int64</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th></tr></thead>\n",
+       "<tr><td>SKY</td><td></td><td>-1</td><td>-1</td><td>0.0</td><td>-1.0</td><td>0.0 .. 0.0</td><td>0.0 .. 0.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
+       "<tr><td>ELG</td><td></td><td>6752</td><td>3244113739</td><td>1.53694</td><td>23.2023</td><td>0.233109 .. 1.47868</td><td>4.03679 .. 4.40491</td><td>5.45512e-17</td><td>-1.0</td><td>50.9816</td><td>-1.0</td><td>1.09257</td><td>49.0409</td><td>0.733237</td><td>-0.0850786</td><td>0.275525</td><td>-0.248196</td><td>-0.19466</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
+       "<tr><td>LRG</td><td></td><td>18</td><td>3244113739</td><td>0.877407</td><td>20.256</td><td>0.114243 .. 9.0901</td><td>29.0752 .. 20.158</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>1.50574</td><td>183.679</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>0.0096</td><td>2.81838</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Table length=3>\n",
+       "OBJTYPE SUBTYPE TEMPLATEID    SEED    ...   AGE     TEFF    LOGG    FEH  \n",
+       " str10   str10    int32      int64    ... float32 float32 float32 float32\n",
+       "------- ------- ---------- ---------- ... ------- ------- ------- -------\n",
+       "    SKY                 -1         -1 ...    -1.0    -1.0    -1.0    -1.0\n",
+       "    ELG               6752 3244113739 ...    -1.0    -1.0    -1.0    -1.0\n",
+       "    LRG                 18 3244113739 ... 2.81838    -1.0    -1.0    -1.0"
+      ]
+     },
+     "execution_count": 111,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "meta[:3]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here's a fun simple plot of the redshift histogram distributions.  Now you try!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 86,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(-0.2, 1.7113039016723635)"
+      ]
+     },
+     "execution_count": 86,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAEKCAYAAAARnO4WAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAHYhJREFUeJzt3Xt4FfW1//H3SkABA0IJKEIxeIocL/REjCLo8UCtlBbF\nG4rYWn/qkYqiFouAVUEfterjBS94i7ZFqyJVq7XWG22R1rsSOCpSsSBqIhZEEIJgvKzfHzPBHSQ7\nk2Qme4f5vJ4nT/bMnvnOymay+OY731lj7o6IiGz7CnIdgIiItAwlfBGRlFDCFxFJCSV8EZGUUMIX\nEUkJJXwRkZRQwhcRSQklfBGRlFDCFxFJiTa5DiBTcXGxl5SU5DoMEZFWY/78+R+5e7co2+ZVwi8p\nKeHVV1/NdRgiIq2Gmb0bdVsN6YiIpIQSvohISijhi4ikRF6N4Us6ff7551RWVrJp06ZchyKSt9q1\na0evXr1o27Ztk9tQwpecq6yspGPHjpSUlGBmuQ5HJO+4O6tXr6ayspI+ffo0uR0N6UjObdq0ia5d\nuyrZi9TDzOjatWuz/wpWwpe8oGQvkl0cvyNK+CIiKaExfMk70+csibW9CYfu3uA2hYWF9O/ff/Py\n8ccfz5QpUxgyZAjXXHMNZWVldbZ/+eWXmTRpElVVVXTs2JEePXpw5ZVX1mkjSbcsvCXW9s4oPaPB\nbYqKiqiurq6z7uKLL+aOO+6gW7du1NTUcNFFFzFmzJjN71933XWUl5fTtm1bCgoKOOSQQ7jqqqua\ndeFxa17+07JY29v/8N0ibXf55Zdz3333UVhYSEFBAV26dGHNmjVUV1ezatWqzePtt9xyC4MHD+aj\njz6iR48e3HTTTZx++umb2ykpKaFjx46YGV26dOHuu+9m1113jfVnAiV8EQDat2/PwoULI23773//\nm+OOO4777ruPwYMHA/Dss8+ydOnSFkv4+WTChAlMnDiRt99+m3333ZdRo0bRtm1bbrvtNp5++mle\nfPFFOnfuTE1NDddddx0bN26MPeHnwgsvvMBjjz1GRUUF22+/PR999BE1NTXssssuPPPMM1xzzTU8\n9thjdfZ54IEHOOCAA5g1a1adhA8wd+5ciouLmTZtGpdddhl33HFH7DFrSEekkWbMmMFJJ520OdkD\nHHTQQRx55JE5jCr3+vbtS4cOHVizZg0Q9H5vvfVWOnfuDMB2223HlClT6NSpUy7DjM2KFSsoLi5m\n++23B6C4uJhddtkl6z6zZs3i2muvpaqqisrKyq1uM2jQIKqqqmKPF5TwRQDYuHEjpaWlm79mz55d\n77aLFi1iwIABLRhd61BRUUHfvn3p3r0769ato7q6ullTCPPdsGHDeP/999l9990544wzmDdvXtbt\n33//fVasWMH+++/PcccdV+859uSTTybWeVDCF+HrIZ3ar9GjR0fed+DAgeyxxx6cc845CUaYv6ZP\nn85ee+3FwIEDueCCC7a6zVNPPUVpaSklJSU8//zzLRxhMoqKipg/fz7l5eV069aN0aNHM3PmzHq3\nnz17NscddxwQXCOaNWtWnfeHDh1Kz549eeKJJ+pcB4mTEr5II+21115UVFRsXn7ppZe49NJL+eST\nT3IYVe5MmDCBRYsW8dBDD3HqqaeyadMmOnXqRFFREe+88w4AP/jBD1i4cCF77703NTU1OY44PoWF\nhQwZMoRLLrmEGTNm8NBDD9W77axZs5g5cyYlJSWMHDmS1157jbfffnvz+3PnzuXdd9+ltLSUadOm\nJRKvEr5II5155pnMnDmzTk/1008/zWFE+WHkyJGUlZVx1113AXD++eczbtw41q5dCwR3i25L5TPe\neuutOgl74cKF9c6sWbJkCdXV1VRVVbF8+XKWL1/O+eef/41efps2bbj++uu5++67+fjjj2OPWbN0\nJO9EmUYZt9ox/FrDhw/nyiuvBGDEiBGbZ5UMGjSIBx54gNmzZzN58mSqqqro3r07xcXFTJ06tcXi\njTKNMm6ffvopvXr12rx87rnnfmObqVOncsIJJ3Daaacxbtw4NmzYwMCBA9l+++0pKiriwAMPZJ99\n9ok9tqjTKONUXV3NWWedxdq1a2nTpg3f+c53KC8v3+q2s2bN4qijjqqz7phjjmH06NHfOG969OjB\nmDFjuPnmm7noootijdncPdYGm6OsrMz1AJT0Wbx4MXvssUeuwxDJe1v7XTGz+e5eVs8udWhIR0Qk\nJZTwRURSQglfRCQllPBFRFJCCV9EJCWU8EVEUkLz8CX/zL0i3vaGnt/gJluWR37kkUfo3r07p512\nGq+99hruTufOnbn33ns54ogjAPjwww8pLCykW7duQFAyuX379vTv35/PP/+cNm3a8NOf/pQJEyZQ\nUBBv32rVTTNiba/bWeMjbbdlOeDbb7+dyZMnby4h/c477zBs2DAuu+wyJk+ezIsvvsjOO+8MBDes\n9erVi/PPb/jfQ5KhhC/C1ssjX3HFFey00068/vrrQHBn5c4777x5u4svvpiioiImTpy41XZWrlzJ\nCSecwLp167jkkkta6CdJTn3lgGtVVlYyfPhwrr32WkaOHMmaNWuYOHEi99xzDxUVFfzjH/9g/vz5\nOfwJREM6IvVYsWIFPXv23Lzcr1+/zaVwo+jevTvl5eXMmDGDfLrBsamylQNesWIFw4YN4/LLL2fk\nyJEAjB07lqVLlzJ37lzOPPNMZsyYsU3UwW/NlPBFqFseufYW+FNOOYWrrrqKQYMGceGFF9apmxLV\nbrvtxpdffsnKlSvjDrnFZSsHfNJJJzF+/HhGjRq1eV1BQQG33norxxxzDP369ePggw/ORdiSQQlf\nhLrlkR9++GEASktLWbZsGeeddx4ff/wx++23H4sXL85xpLmTrRzw97//fe65555vFJErLS1l7733\n5owzWr72j3yTxvBFsigqKuLoo4/m6KOPpqCggMcff7xRdX+WLVtGYWEh3bt3TzDKllNbDnjIkCH0\n799/c2XMSZMm8bvf/Y5jjz2WP/7xj7Rp83VqKSgoiP2itTSN/hVE6vHcc89tflxfTU0Nb775ZqMe\nLL1q1SpOP/10xo8fj5klFWaLaagc8PXXX0+nTp049dRTt4lrFtsi9fAl/0SYRtkSli5dyrhx43B3\nvvrqK0aMGMExxxyTdZ/aawG10zJPPPHErZYRbq6o0yjjVF854NpxezPjrrvu4rDDDmPSpElcffXV\nLR6jZJdoeWQzmwD8L+DA68DJ7l7vExBUHjmdVB5ZJJq8LY9sZj2Bs4Eyd98bKASOT+p4IiKSXdJj\n+G2A9mbWBugAfJDw8UREpB6JJXx3rwKuAd4DVgCfuPvTSR1PWjdd5BPJLo7fkQYv2ppZX+AKYE+g\nXcbBsz5E0sy6AEcAfYC1wANm9hN3v2eL7cYCYwF69+7d2PgblKuaIxJdu3btWL16NV27dt0mZrOI\nxM3dWb16Ne3atWt44yyizNL5LTANmA4MBU4m2l8G3wfecfdVAGb2B2AwUCfhu3s5UA7BRdvIkcs2\no1evXlRWVrJq1apchyKSt9q1a1fnIfJNESXht3f3v5qZufu7wMVmNh+Y2sB+7wEHmFkHYCNwCKAp\nOPINbdu2pU+fPrkOQ2SbFyXhf2ZmBcDbZjYeqAKKGtrJ3V8ysweBCuALYAFhT15ERFpelIR/DsEM\nm7OBSwmGdU6K0ri7TyMYDhIRkRzLmvDNrBAY7e4TgWqC8XsREWmFsl58dfcvgYNaKBYREUlQlCGd\nBWb2KPAAsKF2pbv/IbGoREQkdlESfjtgNfC9jHUOKOGLiLQiURL+ne7+XOYKMzswoXhERCQhUW6g\nuiniOhERyWP19vDNbBDBnbHdzCyzoHcngsqXIiLSimQb0tmO4AarNkDHjPXrgFFb3UNERPJWvQnf\n3ecB88xsZlhSQUREWrEoY/h3mlnn2gUz62JmTyUYk4iIJCBKwi9297W1C+6+BuieXEgiIpKEKAn/\nKzPbXKjezHYlmIcvIiKtSJR5+BcAz5rZPMCA/yZ8YImIiLQeDSZ8d3/SzAYAB4Srfu7uHyUbloiI\nxK3BIR0Lnjk3HBjg7o8BHcxs/8QjExGRWEUZw78FGASMCZfXAzcnFpGIiCQiyhj+QHcfYGYLIJil\nY2bbJRyXiIjELErC/zx8EIoDmFk34KtEoxKRJpk+Z0nsbU44dPfY25TciDKkcyPwMLCTmV0OPAv8\nKtGoREQkdlFm6dxrZvOBQ8JVR7r74mTDEhGRuEUZ0oHgIea1wzrtkwtHRESSEmVa5lTgLuBbQDHw\nWzO7MOnAREQkXlF6+D8G/svdNwGY2ZXAQuCyJAMTEZF4Rblo+wHBc21rbQ9UJROOiIgkJUoP/xNg\nkZnNIRjDPxR42cxuBHD3sxOMT0REYhIl4T8cftV6JplQREQkSVGmZd4FYGZtgb2BKndfmXRgIiIS\nr3rH8M3sNjPbK3y9I/B/wN3AAjMbU99+IiKSn7JdtP1vd18Uvj4ZWOLu/YF9gUmJRyYiIrHKlvBr\nMl4fCjwC4O4fJhqRiIgkIlvCX2tmh5nZPsCBwJMAZtYG3W0rItLqZLto+zOCwmk7EzzlqrZnfwjw\n56QDExGReNWb8N19CcGTrrZc/xTwVJJBiYhI/KLcaSsiItsAJXwRkZRQwhcRSYl6x/DN7NxsO7r7\ndQ01bmadgTsJ7tB14BR3f6GxQYqISPNlm6XTMfzeD9gPeDRcPhx4OWL7NwBPuvuo8MHnHZoUpYiI\nNFu2WTqXAJjZ34EB7r4+XL6YCNMyw3IMBwP/L2yvhro3c4mISAuKMoa/E3UTdU24riF9gFUET8ha\nYGZ3mtkOTYhRRERiEKU88t0E9e9rSyQfSfDIwyhtDwDOcveXzOwGYApwUeZGZjYWGAvQu3fvqHGL\niNQxfc6S2NuccOjusbeZSw328N39coLiaWvCr5Pd/VcR2q4EKt39pXD5QYL/ALZsv9zdy9y9rFu3\nbtEjFxGRRok6LbMDsM7dbwAqzaxPQzuEpRjeN7N+4apDgDebFqaIiDRXg0M6ZjYNKCOYrfNboC1w\nD0FBtYacBdwbztBZRvCXgoiI5ECUMfyjgH2ACgB3/8DMOmbfJeDuCwn+sxARkRyLMqRT4+5OcOMU\nmmkjItI6RUn4vzez24HOZnYa8BeCu2dFRKQVifIQ82vM7FBgHcE4/lR3n5N4ZCIiEqsoF22vcvfJ\nwJytrBMRkVYiypDOoVtZ98O4AxERkWRlq5Y5DjgD2M3MXst4qyPwXNKBiYhIvLIN6dwHPAFcQVAS\nodZ6d/840ahERCR22aplfgJ8AowBMLPuQDugyMyK3P29lglRRETi0OAYvpkdbmZvA+8A84DlBD1/\nERFpRaJctL0MOABY4u59CGrivJhoVCIiErsoCf9zd18NFJhZgbvPReUSRERanSi1dNaaWRHwd4JC\naCuBDcmGJSIicYvSwz8C2AhMAJ4ElhI811ZERFqRKKUVMnvzUZ50JSIieSjbjVfrCStkbvkW4O7e\nKbGoREQkdtnm4UeqeS8iIq1DlOJpW32yuG68EhFpXaLM0vlzxut2QB/gLWCvRCISEZFERLlo2z9z\n2cwGEBRVE5FmmD5nSa5DkJSJMi2zDnevAAYmEIuIiCQoyhj+uRmLBcAA4IPEIhIRkUREGcPPnK3z\nBcGY/kPJhCMiIkmJMoZ/SUsEIiIiyYoypFMGXADsmrm9u383wbhERCRmUYZ07gXOA14Hvko2HBER\nSUqUhL/K3R9NPBIREUlUlIQ/zczuBP4KfFa70t3/kFhUIiISuygJ/2TgP4G2fD2k44ASvohIKxIl\n4e/n7v0Sj0RERBIV5U7b581sz8QjERGRREXp4R8ALDSzdwjG8Gvr4WtapohIKxIl4Q9PPAoREUlc\ntidedXL3dcD6FoxHREQSkq2Hfx9wGDCfYFaOZbznwG4JxiUiIjHL9ojDw8LvfVouHBERSUq9s3TM\nbFcz2zFjeaiZ3WBmE8xsu5YJT0RE4pJtWubvgR0AzKwUeAB4DygFbkk+NBERiVO2Mfz27l77oJOf\nAL9x92vNrABYGPUAZlYIvApU1Q4TiYhIy8vWw8+8SPs9glo6uHtjK2aeAyxu5D4iIhKzbAn/b2b2\nezO7AegC/A3AzHoANVEaN7NewAjgzuYGKiIizZNtSOfnwGigB3CQu38ert+Z4IEoUVwPTKLuYxLr\nMLOxwFiA3r17R2y2EZb/I+YGx8fcnkh+mz5nSextTjh099jblIZlm5bpwP1bWb8gSsNmdhiw0t3n\nm9mQLMcpB8oBysrKPErbIiLSeFGKpzXVgcBIM1tO8B/H98zsngSPJyIiWSSW8N39fHfv5e4lwPHA\n39z9J0kdT0REsst249Vfw+9XtVw4IiKSlGwXbXuY2WCCYZn7qTtNE3eviHoQd38GeKYpAYqISDyy\nJfypwEVAL+C6Ld5zgrn5IiLSSmSbpfMg8KCZXeTul7ZgTCIikoAGH4Di7pea2Ujg4HDVM+7+WLJh\niYhI3BqcpWNmVxCUR3gz/DrHzH6VdGAiIhKvKI84HAGU1tbQMbO7gAXAL5MMTERE4hV1Hn7njNc7\n1ruViIjkrSg9/CuABWY2l2Bq5sHAlESjEhGR2EW5aDvLzJ4B9gtXTXb3DxONSkREYhelh4+7rwAe\nTTgWERFJUJLF00REJI8o4YuIpETWhG9mhWb2z5YKRkREkpM14bv7l8BbZpbAo6hERKQlRblo2wVY\nZGYvAxtqV7r7yMSiEhGR2EVJ+BclHoWIiCQuyjz8eWa2K9DX3f9iZh2AwuRDExGROEUpnnYa8CBw\ne7iqJ/BIkkGJiEj8ogzpnAnsD7wE4O5vm1n3RKMSSYGKdbNjb3NAp9Gxtynbjijz8D9z95raBTNr\nQ/DEKxERaUWiJPx5ZvZLoL2ZHQo8APwp2bBERCRuURL+FGAV8DrwM+Bx4MIkgxIRkfhFmaXzVfjQ\nk5cIhnLecncN6YiItDINJnwzGwHcBiwlqIffx8x+5u5PJB2ciIjEJ8osnWuBoe7+LwAz+w/gz4AS\nvohIKxJlDH99bbIPLQPWJxSPiIgkpN4evpkdHb581cweB35PMIZ/LPBKC8QmIiIxyjakc3jG638D\n/xO+XgW0TywiERFJRL0J391PbslAREQkWVFm6fQBzgJKMrdXeWQRkdYlyiydR4BfE9xd+1Wy4YiI\nSFKiJPxN7n5j4pGIiEiioiT8G8xsGvA08FntSnevSCwqERGJXZSE3x84EfgeXw/peLgsIiKtRJSE\nfyywW2aJZBERaX2i3Gn7BtA56UBERCRZUXr4nYF/mtkr1B3D17RMEZFWJErCn9aUhs3s28DdwE4E\nY/7l7n5DU9oSEZHmi1IPf14T2/4C+IW7V5hZR2C+mc1x9zeb2J6IiDRDlDtt1/P1M2y3A9oCG9y9\nU7b93H0FsCJ8vd7MFgM9ASV8EZEciNLD71j72swMOAI4oDEHMbMSYB+Cp2aJiEgORBnD3yx8tOEj\n4Y1YU6LsY2ZFwEPAz9193VbeHwuMBejdu3djwonkjZp9Y21vaKytSRKmz1kSe5sV62bH3qbkv7jP\npQmH7h5re40VZUjn6IzFAqAM2BSlcTNrS5Ds73X3P2xtG3cvB8oBysrK9KxcEZGEROnhZ9bF/wJY\nTjCsk1U4/PNrYLG7X9ek6EREJDZRxvCbWhf/QIKSDK+b2cJw3S/d/fEmticiIs2Q7RGHU7Ps5+5+\nabaG3f1ZwJoamIiIxCtbD3/DVtbtAJwKdAWyJnwREckv2R5xeG3t6/DGqXOAk4H7gWvr209ERPJT\n1jF8M/sWcC7wY+AuYIC7r2mJwEREJF7ZxvCvBo4mmDLZ392rWywqERGJXbbyyL8AdgEuBD4ws3Xh\n13oz+8YNVCIikt+yjeFHqZUvIiKthJK6iEhKKOGLiKSEEr6ISEoo4YuIpIQSvohISijhi4ikhBK+\niEhKKOGLiKSEEr6ISEoo4YuIpIQSvohISkR5pq1IYk58KP7n6AzoNDr2NiVe0+csyXUIqaQevohI\nSijhi4ikhBK+iEhKKOGLiKSEEr6ISEoo4YuIpIQSvohISijhi4ikhBK+iEhKKOGLiKSEEr6ISEoo\n4YuIpIQSvohISijhi4ikhBK+iEhKKOGLiKSEEr6ISEoo4YuIpESiCd/MhpvZW2b2LzObkuSxREQk\nu8QSvpkVAjcDPwT2BMaY2Z5JHU9ERLJLsoe/P/Avd1/m7jXA/cARCR5PRESySDLh9wTez1iuDNeJ\niEgOmLsn07DZKGC4u/9vuHwiMNDdx2+x3VhgbLjYD3grkYAarxj4KNdBRNSaYgXFmzTFm5x8jHVX\nd+8WZcM2CQZRBXw7Y7lXuK4Ody8HyhOMo0nM7FV3L8t1HFG0plhB8SZN8SanNcW6NUkO6bwC9DWz\nPma2HXA88GiCxxMRkSwS6+G7+xdmNh54CigEfuPui5I6noiIZJfkkA7u/jjweJLHSFDeDTNl0Zpi\nBcWbNMWbnNYU6zckdtFWRETyi0oriIikROoSfkPlHixwY/j+a2Y2IOq+OYr3x2Gcr5vZ82b2Xxnv\nLQ/XLzSzV/Mk3iFm9kkY00Izmxp13xzEel5GnG+Y2Zdm9q3wvVx8tr8xs5Vm9kY97+fbudtQvHlz\n7kaINW/O22Zx99R8EVw8XgrsBmwH/B+w5xbb/Ah4AjDgAOClqPvmKN7BQJfw9Q9r4w2XlwPFefb5\nDgEea8q+LR3rFtsfDvwtV59teMyDgQHAG/W8nzfnbsR48+ncbSjWvDhvm/uVth5+lHIPRwB3e+BF\noLOZ9Yi4b4vH6+7Pu/uacPFFgvsdcqU5n1FLf76NPd4YYFaC8TTI3f8OfJxlk3w6dxuMN5/O3Qif\nbX1aVQmZtCX8KOUe6tsmF6UiGnvMUwl6eLUc+IuZzQ/vaE5a1HgHh3/KP2FmezVy37hEPp6ZdQCG\nAw9lrG7pzzaKfDp3GyvX524U+XDeNkui0zKl5ZjZUIJfmoMyVh/k7lVm1h2YY2b/DHsyuVQB9Hb3\najP7EfAI0DfHMTXkcOA5d8/sAebjZ9sqtZJztzWet9+Qth5+lHIP9W0TqVREzCId08y+C9wJHOHu\nq2vXu3tV+H0l8DDBn59JajBed1/n7tXh68eBtmZWHGXflo41w/FsMZyTg882inw6dyPJo3M3qzw6\nb5sn1xcRWvKL4C+aZUAfvr7AstcW24yg7oWvl6Pum6N4ewP/AgZvsX4HoGPG6+cJitnlOt6d+fr+\nj/2B98LPukU/36jHA3YkGNvdIZefbcaxS6j/wmLenLsR482bczdCrHlx3jb3K1VDOl5PuQczOz18\n/zaCO4N/RHAifgqcnG3fPIh3KtAVuMXMAL7woLjTTsDD4bo2wH3u/mQexDsKGGdmXwAbgeM9+C1q\n0c83YqwARwFPu/uGjN1b/LMFMLNZBLNFis2sEpgGtM2IN2/O3Yjx5s25GyHWvDhvm0t32oqIpETa\nxvBFRFJLCV9EJCWU8EVEUkIJX0QkJZTwRURSQglftklhZcvaKpd/MrPOjdz/YjOb2JT3zez5jNdX\nm9mi8PuRZrZnY+IQiZMSvmyrNrp7qbvvTXDj1JktdWB3H5yxOBb4rrufBxwJKOFLzijhSxq8QEZB\nq7DO/SthIaxLMtZfYGZLzOxZoF/G+rPN7M1w+/sz2t3TzJ4xs2VmdnbG9tXh90eBImC+mU0DRgJX\nh395/EdiP61IPVJ1p62kj5kVAocAvw6XhxEUvdqf4Nb4R83sYGADQc2cUoLfiwpgftjMFKCPu3+2\nxdDQfwJDgY7AW2Z2q7t/Xvumu480s2p3Lw2P3YegpvqDif3AIlko4cu2qr2ZLSTo2S8G5oTrh4Vf\nC8LlIoL/ADoCD7v7p7C5d17rNeBeM3uEoEpirT+7+2fAZ2a2kqAkQGVCP49Is2lIR7ZVG8Oe9a4E\nPfnaMXwDrgjH90vd/Tvu/usG2hoB3EzwRKRXzKy2o/RZxjZfog6U5DklfNmmhT32s4FfhIn6KeAU\nMysCMLOeYc31vwNHmll7M+tIUAMfMysAvu3uc4HJBNUzi5oYznqCvyREckI9EtnmufsCM3sNGOPu\nvzOzPYAXwmqM1cBP3L3CzGYTlLddCbwS7l4I3GNmOxL8dXCju68N922s+4E7wgu8o9x9afN+MpHG\nUbVMEZGU0JCOiEhKKOGLiKSEEr6ISEoo4YuIpIQSvohISijhi4ikhBK+iEhKKOGLiKTE/wc7vIMc\nAxGaRAAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x11eb1b4a8>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "allobjtype = meta['OBJTYPE']\n",
+    "redlim = (-0.2, 1.1*meta['REDSHIFT'].max())\n",
+    "fig, ax = plt.subplots()\n",
+    "for objtype in sorted(set(allobjtype)):\n",
+    "    indx = objtype == allobjtype\n",
+    "    hh = ax.hist(meta['REDSHIFT'][indx], bins=nspec//3, \n",
+    "                 label=objtype, alpha=0.5, range=redlim)\n",
+    "ax.set_xlabel('Redshift')\n",
+    "ax.set_ylabel('Number of Simulated Spectra')\n",
+    "ax.legend(loc='upper right', ncol=3)\n",
+    "ax.margins(0.2)\n",
+    "ax.set_xlim(redlim)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simulating spectra using quickgen.\n",
+    "\n",
+    "We're now ready to simulate DESI spectra using *quickgen*.  Since we're calling *quickgen* from within the notebook (rather than from the command line in a terminal) we have to parse the *simspec* and *fibermap* inputs first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 113,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:log.py:19:get_logger: desispec.log is deprecated, please use desiutil.log.\n",
+      "Namespace(add_SNeIa=False, airmass=1.25, brickname=None, config='desi', exptime=None, fibermap='/Users/ioannis/research/projects/desi/spectro/data/20170615/fibermap-00000000.fits', frameonly=False, moon_angle=None, moon_phase=None, moon_zenith=None, nspec=100, nstart=0, objtype=None, outdir='.', outdir_truth=None, rmagrange_bgs=(15.0, 19.5), seed=0, simspec='/Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits', sne_rfluxratiorange=(0.1, 1.0), spectrograph=None, verbose=False, zrange_bgs=(0.01, 0.4), zrange_elg=(0.6, 1.6), zrange_lrg=(0.5, 1.1), zrange_qso=(0.5, 4.0))\n"
+     ]
+    }
+   ],
+   "source": [
+    "args = quickgen.parse([\n",
+    "    '--simspec', simspecfile,\n",
+    "    '--fibermap', fiberfile\n",
+    "])\n",
+    "print(args)\n",
+    "#quickgen.main(args)    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "# Generate fibermap and simspec files.\n",
+    "lensdir = priors['LENSDIR']\n",
+    "for ii in range(nexp):\n",
+    "    fibermap, truth = new_lensing_exposure(priors, exptime=priors['EXPTIME'][ii], night=priors['NIGHT'],\n",
+    "                                           tileid=priors['TILEID'], expid=priors['EXPID'][ii], seed=seed, \n",
+    "                                           outdir=lensdir)\n",
+    "    # Write out truth table of the source.\n",
+    "    metafile = os.path.join(lensdir, priors['NIGHT'], 'meta-source-{:08d}.fits'.format(priors['EXPID'][ii]))\n",
+    "    truth['META_SOURCE'].write(metafile, overwrite=True)\n",
+    "    \n",
+    "    metafile = os.path.join(lensdir, priors['NIGHT'], 'meta-lens-{:08d}.fits'.format(priors['EXPID'][ii]))\n",
+    "    truth['META'].write(metafile, overwrite=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run quickgen\n",
+    "lensdir = priors['LENSDIR']\n",
+    "night = priors['NIGHT']\n",
+    "for ii in range(nexp):\n",
+    "    expid = priors['EXPID'][ii]\n",
+    "    quickgen.main(quickgen.parse([\n",
+    "        '--simspec', os.path.join(lensdir, night, 'simspec-{:08d}.fits'.format(expid)), \n",
+    "        '--fibermap', os.path.join(lensdir, night, 'fibermap-{:08d}.fits'.format(expid))\n",
+    "    ]))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "# Make bricks from cframe files.\n",
+    "from desispec.scripts import makebricks\n",
+    "makebricks.main(makebricks.parse(['--night', priors['NIGHT'], '--verbose']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from glob import glob\n",
+    "\n",
+    "# Get the list of bricks\n",
+    "bricks = glob(os.path.join(lensdir, 'bricks', '*'))\n",
+    "print(bricks)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "# Figure out redshift fitting.\n",
+    "from desispec.scripts import zfind\n",
+    "from glob import glob\n",
+    "\n",
+    "# Get the list of bricks\n",
+    "bricks = glob(os.path.join(lensdir, 'bricks', '*'))\n",
+    "print(bricks)\n",
+    "\n",
+    "nproc = 4\n",
+    "zrange = [0.4, 0.6]\n",
+    "\n",
+    "for bb in list(set(bricks)):\n",
+    "    print(bb)\n",
+    "    #brickfiles = [os.path.join(lensdir, 'bricks', bb, 'brick-{}-{}.fits'.format(ch, bb)) for ch in ['b', 'r', 'z']]\n",
+    "    #print(brickfiles)\n",
+    "    zargs = zfind.parse([\n",
+    "        '--brick', bb, \n",
+    "        '--nproc', '{}'.format(nproc),\n",
+    "        '--zrange-galaxy', '{}'.format(zrange[0]), '{}'.format(zrange[1]), \n",
+    "        #'--zspec', \n",
+    "        #'--qafile', os.path.join(lensdir, 'bricks', bb, 'qa-zbest-{}.pdf'.format(bb)),\n",
+    "        #'--outfile', os.path.join(lensdir, 'zbest-{}.fits'.format(exp))\n",
+    "        '--objtype', 'LRG'])\n",
+    "    zfind.main(zargs)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "#set the brick name and take the zbest file for the specified brick\n",
+    "thisbrick = '3587m005'\n",
+    "zfile = os.path.join(lensdir, 'bricks', thisbrick, 'zbest-{}.fits'.format(thisbrick))\n",
+    "zbest = Table(fitsio.read(zfile, ext=1))\n",
+    "print(zbest)\n",
+    "\n",
+    "#Create the table for the set brick \n",
+    "simfile = os.path.join(lensdir, priors['NIGHT'], 'simspec-{:08d}.fits'.format(priors['EXPID'][0]))\n",
+    "sim1 = read_simspec(simfile)\n",
+    "print(Table(sim1.metadata))\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "# Below here requires hacking....\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true,
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Read the simspec file to get trueflux.\n",
+    "simfile = os.path.join(lensdir, 'simspec-{:08d}.fits'.format(0))\n",
+    "sim = read_simspec(simfile)\n",
+    "\n",
+    "simfile1 = os.path.join(lensdir, 'simspec-{:08d}.fits'.format(1))\n",
+    "sim1 = read_simspec(simfile1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": [
+    "#ploting the lens for the three color cuts: blue, red, and near infrared \n",
+    "for channel in ('b', 'r', 'z'):\n",
+    "    ff = desispec.io.read_frame(os.path.join(lensdir, 'cframe-{}0-{:08d}.fits'.format(channel, 0)))\n",
+    "    plt.plot(ff.wave, ff.flux[0, :])\n",
+    "    \n",
+    "    ff_test = desispec.io.read_frame(os.path.join(lensdir, 'cframe-{}0-{:08d}.fits'.format(channel, 1)))\n",
+    "    plt.plot(ff_test.wave, ff_test.flux[0, :])\n",
+    "\n",
+    "plt.plot(sim.wave['brz'], sim.flux[0, :], color='k')\n",
+    "plt.ylim(-4, 10)    \n",
+    "plt.show()\n",
+    "\n",
+    "for channel in ('b', 'r', 'z'):\n",
+    "    ff = desispec.io.read_frame(os.path.join(lensdir, 'cframe-{}0-{:08d}.fits'.format(channel, 0)))\n",
+    "    ff_test = desispec.io.read_frame(os.path.join(lensdir, 'cframe-{}0-{:08d}.fits'.format(channel, 1)))\n",
+    "    plt.plot(ff.wave, ff.flux[0, :] * np.sqrt(ff.ivar[0, :]))\n",
+    "    plt.plot(ff_test.wave, ff_test.flux[0, :] * np.sqrt(ff_test.ivar[0, :]))\n",
+    "plt.xlim(6000, 7000)\n",
+    "plt.ylim(0, 25)\n",
+    "plt.show()\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true,
+    "deletable": true,
+    "editable": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/doc/nb/simulating-desi-spectra.ipynb
+++ b/doc/nb/simulating-desi-spectra.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Simulating DESI Spectra\n",
     "\n",
-    "The goal of this notebook is to demonstrate how to generate some simple DESI spectra using the *quickgen* utility.\n",
+    "The goal of this notebook is to demonstrate how to generate some simple DESI spectra using the *quickgen* utility.  For simplicity we will only generate 1D spectra and skip the more computationally intensive (yet still instructive!) step of extracting 1D spectra from simulated 2D spectra (i.e., so-called \"pixel-level simulations\").\n",
     "\n",
     "For additional (albeit somewhat outdated) information and documentation about *quickgen* see  \n",
     "https://desi.lbl.gov/DocDB/cgi-bin/private/ShowDocument?docid=1429\n",
@@ -27,7 +27,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -64,16 +64,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:log.py:19:get_logger: desispec.log is deprecated, please use desiutil.log.\n",
+      "WARNING:log.py:19:get_logger: desispec.log is deprecated, please use desiutil.log.\n",
+      "WARNING:log.py:19:get_logger: desispec.log is deprecated, please use desiutil.log.\n"
+     ]
+    }
+   ],
    "source": [
     "import desispec.io\n",
     "import desisim.io\n",
     "from desisim.obs import new_exposure\n",
     "from desisim.scripts import quickgen\n",
+    "from desispec.scripts import makebricks\n",
     "\n",
     "from desiutil.log import get_logger\n",
     "log = get_logger()"
@@ -83,12 +94,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Make sure we have all the right environment variables set (assuming the bash shell).  If any of these environment variables are missing please set them in your *.bashrc* file (and then restart this notebook) or create them for just this notebook session using the *%env* magic command, as we demonstrate below."
+    "Make sure we have all the right environment variables set (assuming the bash shell).  If any of these environment variables are missing please set them in your *.bashrc* file (and then restart this notebook) or create them for just this notebook session using the *%set_env* magic command, as we demonstrate below."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -105,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -119,8 +130,8 @@
       "DESI_SPECTRO_SIM environment set to /Users/ioannis/research/projects/desi/spectro/sim\n",
       "DESI_SPECTRO_DATA environment set to /Users/ioannis/research/projects/desi/spectro/data\n",
       "DESI_SPECTRO_REDUX environment set to /Users/ioannis/research/projects/desi/spectro/redux\n",
-      "SPECPROD environment set to example\n",
-      "PIXPROD environment set to example\n"
+      "SPECPROD environment set to dailytest\n",
+      "PIXPROD environment set to dailytest\n"
      ]
     }
    ],
@@ -132,7 +143,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's reassign the *SPECPROD* and *PIXPROD* environments to something other than \"dailytest\" so that we don't conflict with the outputs of the standard DESI integration test."
+    "Let's reassign the *SPECPROD* environment to something other than \"dailytest\" so that we don't conflict with the outputs of the standard DESI integration test.  In addition, we are going to make the *\\$DESI_SPECTRO_SIM* path point to *\\$DESI_SPECTRO_DATA*, in order to simplify some of the file-finding below."
    ]
   },
   {
@@ -147,13 +158,17 @@
      "output_type": "stream",
      "text": [
       "env: SPECPROD=example\n",
-      "env: PIXPROD=example\n"
+      "env: PIXPROD=example\n",
+      "env: DESI_SPECTRO_SIM=/Users/ioannis/research/projects/desi/spectro/redux\n"
      ]
     }
    ],
    "source": [
-    "%env SPECPROD=example\n",
-    "%env PIXPROD=example"
+    "specprod_dir, pixprod_dir = 'example', 'example'\n",
+    "desi_spectro_data_dir = os.getenv('DESI_SPECTRO_REDUX')\n",
+    "%set_env SPECPROD=$specprod_dir\n",
+    "%set_env PIXPROD=$pixprod_dir\n",
+    "%set_env DESI_SPECTRO_SIM=$desi_spectro_data_dir"
    ]
   },
   {
@@ -169,7 +184,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 7,
    "metadata": {
     "collapsed": true
    },
@@ -184,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -193,7 +208,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/Users/ioannis/research/projects/desi/spectro/sim/example/20170615\n"
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/20170615\n"
      ]
     }
    ],
@@ -218,7 +233,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -228,23 +243,23 @@
      "output_type": "stream",
      "text": [
       "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
       "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
       "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
       "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
       "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
       "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
       "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /Users/ioannis/research/projects/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
       "INFO:obs.py:226:new_exposure: skyfile /Users/ioannis/repos/desihub/desimodel/data/spectra/spec-sky.dat\n",
-      "INFO:obs.py:297:new_exposure: Wrote /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
-      "INFO:obs.py:305:new_exposure: Wrote /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits\n"
+      "INFO:obs.py:297:new_exposure: Wrote /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/fibermap-00000000.fits\n",
+      "INFO:obs.py:305:new_exposure: Wrote /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/simspec-00000000.fits\n"
      ]
     }
    ],
@@ -264,7 +279,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -276,7 +291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 108,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -285,8 +300,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:<ipython-input-108-59b7db187c0a>:1:<module>: Reading fibermap file /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
-      "Filename: /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
+      "INFO:<ipython-input-11-59b7db187c0a>:1:<module>: Reading fibermap file /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/fibermap-00000000.fits\n",
+      "Filename: /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/fibermap-00000000.fits\n",
       "No.    Name         Type      Cards   Dimensions   Format\n",
       "  0  PRIMARY     PrimaryHDU       6   ()      \n",
       "  1  FIBERMAP    BinTableHDU     98   50R x 26C   [10A, 20A, 8A, K, K, K, K, 5E, 50A, J, K, J, J, J, J, E, D, D, D, D, D, D, D, D, E, E]   \n"
@@ -303,7 +318,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 109,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -312,10 +327,10 @@
      "data": {
       "text/html": [
        "&lt;Row index=3&gt;\n",
-       "<table id=\"table4800756592\">\n",
+       "<table id=\"table4569910632\">\n",
        "<thead><tr><th>OBJTYPE</th><th>TARGETCAT</th><th>BRICKNAME</th><th>TARGETID</th><th>DESI_TARGET</th><th>BGS_TARGET</th><th>MWS_TARGET</th><th>MAG [5]</th><th>FILTER [5]</th><th>SPECTROID</th><th>POSITIONER</th><th>LOCATION</th><th>DEVICE_LOC</th><th>PETAL_LOC</th><th>FIBER</th><th>LAMBDAREF</th><th>RA_TARGET</th><th>DEC_TARGET</th><th>RA_OBS</th><th>DEC_OBS</th><th>X_TARGET</th><th>Y_TARGET</th><th>X_FVCOBS</th><th>Y_FVCOBS</th><th>Y_FVCERR</th><th>X_FVCERR</th></tr></thead>\n",
        "<thead><tr><th>str10</th><th>str20</th><th>str8</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>float32</th><th>str10</th><th>int32</th><th>int64</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>float32</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float32</th><th>float32</th></tr></thead>\n",
-       "<tr><td>ELG</td><td></td><td>3350p205</td><td>3561499325993422263</td><td>2</td><td>0</td><td>0</td><td>23.2547 .. 22.5634</td><td>DECAM_G .. WISE_W2</td><td>0</td><td>82</td><td>82</td><td>82</td><td>0</td><td>3</td><td>5400.0</td><td>335.167583443</td><td>20.5840708185</td><td>335.167583443</td><td>20.5840708185</td><td>-31.5795923296</td><td>-172.635369698</td><td>-31.5795923296</td><td>-172.635369698</td><td>0.0</td><td>0.0</td></tr>\n",
+       "<tr><td>ELG</td><td></td><td>3334p155</td><td>3561499325993422263</td><td>2</td><td>0</td><td>0</td><td>23.2547 .. 22.5634</td><td>DECAM_G .. WISE_W2</td><td>0</td><td>82</td><td>82</td><td>82</td><td>0</td><td>3</td><td>5400.0</td><td>333.353689493</td><td>15.5440849197</td><td>333.353689493</td><td>15.5440849197</td><td>-31.5795923296</td><td>-172.635369698</td><td>-31.5795923296</td><td>-172.635369698</td><td>0.0</td><td>0.0</td></tr>\n",
        "</table>"
       ],
       "text/plain": [
@@ -323,10 +338,10 @@
        "OBJTYPE TARGETCAT BRICKNAME       TARGETID      DESI_TARGET BGS_TARGET MWS_TARGET      MAG [5]           FILTER [5]     SPECTROID POSITIONER LOCATION DEVICE_LOC PETAL_LOC FIBER LAMBDAREF   RA_TARGET     DEC_TARGET      RA_OBS       DEC_OBS       X_TARGET       Y_TARGET       X_FVCOBS       Y_FVCOBS    Y_FVCERR X_FVCERR\n",
        " str10    str20      str8          int64           int64      int64      int64         float32             str10          int32     int64     int32     int32      int32   int32  float32     float64       float64       float64       float64       float64        float64        float64        float64     float32  float32 \n",
        "------- --------- --------- ------------------- ----------- ---------- ---------- ------------------ ------------------ --------- ---------- -------- ---------- --------- ----- --------- ------------- ------------- ------------- ------------- -------------- -------------- -------------- -------------- -------- --------\n",
-       "    ELG            3350p205 3561499325993422263           2          0          0 23.2547 .. 22.5634 DECAM_G .. WISE_W2         0         82       82         82         0     3    5400.0 335.167583443 20.5840708185 335.167583443 20.5840708185 -31.5795923296 -172.635369698 -31.5795923296 -172.635369698      0.0      0.0"
+       "    ELG            3334p155 3561499325993422263           2          0          0 23.2547 .. 22.5634 DECAM_G .. WISE_W2         0         82       82         82         0     3    5400.0 333.353689493 15.5440849197 333.353689493 15.5440849197 -31.5795923296 -172.635369698 -31.5795923296 -172.635369698      0.0      0.0"
       ]
      },
-     "execution_count": 109,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -337,7 +352,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 110,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -346,8 +361,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:<ipython-input-110-079a1c11142f>:1:<module>: Reading simspec file /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits.\n",
-      "Filename: /Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits\n",
+      "INFO:<ipython-input-13-079a1c11142f>:1:<module>: Reading simspec file /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/simspec-00000000.fits.\n",
+      "Filename: /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/simspec-00000000.fits\n",
       "No.    Name         Type      Cards   Dimensions   Format\n",
       "  0  PRIMARY     PrimaryHDU      15   ()      \n",
       "  1  WAVE        ImageHDU         9   (31901,)   float64   \n",
@@ -376,7 +391,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 111,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -385,7 +400,7 @@
      "data": {
       "text/html": [
        "&lt;Table length=3&gt;\n",
-       "<table id=\"table4797028000\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<table id=\"table4569875568\" class=\"table-striped table-bordered table-condensed\">\n",
        "<thead><tr><th>OBJTYPE</th><th>SUBTYPE</th><th>TEMPLATEID</th><th>SEED</th><th>REDSHIFT</th><th>MAG</th><th>DECAM_FLUX [6]</th><th>WISE_FLUX [2]</th><th>OIIFLUX</th><th>HBETAFLUX</th><th>EWOII</th><th>EWHBETA</th><th>D4000</th><th>VDISP</th><th>OIIDOUBLET</th><th>OIIIHBETA</th><th>OIIHBETA</th><th>NIIHBETA</th><th>SIIHBETA</th><th>ZMETAL</th><th>AGE</th><th>TEFF</th><th>LOGG</th><th>FEH</th></tr></thead>\n",
        "<thead><tr><th>str10</th><th>str10</th><th>int32</th><th>int64</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th></tr></thead>\n",
        "<tr><td>SKY</td><td></td><td>-1</td><td>-1</td><td>0.0</td><td>-1.0</td><td>0.0 .. 0.0</td><td>0.0 .. 0.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
@@ -403,7 +418,7 @@
        "    LRG                 18 3244113739 ... 2.81838    -1.0    -1.0    -1.0"
       ]
      },
-     "execution_count": 111,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -421,7 +436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 86,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
@@ -432,7 +447,7 @@
        "(-0.2, 1.7113039016723635)"
       ]
      },
-     "execution_count": 86,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -440,7 +455,7 @@
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXwAAAEKCAYAAAARnO4WAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAHYhJREFUeJzt3Xt4FfW1//H3SkABA0IJKEIxeIocL/REjCLo8UCtlBbF\nG4rYWn/qkYqiFouAVUEfterjBS94i7ZFqyJVq7XWG22R1rsSOCpSsSBqIhZEEIJgvKzfHzPBHSQ7\nk2Qme4f5vJ4nT/bMnvnOymay+OY731lj7o6IiGz7CnIdgIiItAwlfBGRlFDCFxFJCSV8EZGUUMIX\nEUkJJXwRkZRQwhcRSQklfBGRlFDCFxFJiTa5DiBTcXGxl5SU5DoMEZFWY/78+R+5e7co2+ZVwi8p\nKeHVV1/NdRgiIq2Gmb0bdVsN6YiIpIQSvohISijhi4ikRF6N4Us6ff7551RWVrJp06ZchyKSt9q1\na0evXr1o27Ztk9tQwpecq6yspGPHjpSUlGBmuQ5HJO+4O6tXr6ayspI+ffo0uR0N6UjObdq0ia5d\nuyrZi9TDzOjatWuz/wpWwpe8oGQvkl0cvyNK+CIiKaExfMk70+csibW9CYfu3uA2hYWF9O/ff/Py\n8ccfz5QpUxgyZAjXXHMNZWVldbZ/+eWXmTRpElVVVXTs2JEePXpw5ZVX1mkjSbcsvCXW9s4oPaPB\nbYqKiqiurq6z7uKLL+aOO+6gW7du1NTUcNFFFzFmzJjN71933XWUl5fTtm1bCgoKOOSQQ7jqqqua\ndeFxa17+07JY29v/8N0ibXf55Zdz3333UVhYSEFBAV26dGHNmjVUV1ezatWqzePtt9xyC4MHD+aj\njz6iR48e3HTTTZx++umb2ykpKaFjx46YGV26dOHuu+9m1113jfVnAiV8EQDat2/PwoULI23773//\nm+OOO4777ruPwYMHA/Dss8+ydOnSFkv4+WTChAlMnDiRt99+m3333ZdRo0bRtm1bbrvtNp5++mle\nfPFFOnfuTE1NDddddx0bN26MPeHnwgsvvMBjjz1GRUUF22+/PR999BE1NTXssssuPPPMM1xzzTU8\n9thjdfZ54IEHOOCAA5g1a1adhA8wd+5ciouLmTZtGpdddhl33HFH7DFrSEekkWbMmMFJJ520OdkD\nHHTQQRx55JE5jCr3+vbtS4cOHVizZg0Q9H5vvfVWOnfuDMB2223HlClT6NSpUy7DjM2KFSsoLi5m\n++23B6C4uJhddtkl6z6zZs3i2muvpaqqisrKyq1uM2jQIKqqqmKPF5TwRQDYuHEjpaWlm79mz55d\n77aLFi1iwIABLRhd61BRUUHfvn3p3r0769ato7q6ullTCPPdsGHDeP/999l9990544wzmDdvXtbt\n33//fVasWMH+++/PcccdV+859uSTTybWeVDCF+HrIZ3ar9GjR0fed+DAgeyxxx6cc845CUaYv6ZP\nn85ee+3FwIEDueCCC7a6zVNPPUVpaSklJSU8//zzLRxhMoqKipg/fz7l5eV069aN0aNHM3PmzHq3\nnz17NscddxwQXCOaNWtWnfeHDh1Kz549eeKJJ+pcB4mTEr5II+21115UVFRsXn7ppZe49NJL+eST\nT3IYVe5MmDCBRYsW8dBDD3HqqaeyadMmOnXqRFFREe+88w4AP/jBD1i4cCF77703NTU1OY44PoWF\nhQwZMoRLLrmEGTNm8NBDD9W77axZs5g5cyYlJSWMHDmS1157jbfffnvz+3PnzuXdd9+ltLSUadOm\nJRKvEr5II5155pnMnDmzTk/1008/zWFE+WHkyJGUlZVx1113AXD++eczbtw41q5dCwR3i25L5TPe\neuutOgl74cKF9c6sWbJkCdXV1VRVVbF8+XKWL1/O+eef/41efps2bbj++uu5++67+fjjj2OPWbN0\nJO9EmUYZt9ox/FrDhw/nyiuvBGDEiBGbZ5UMGjSIBx54gNmzZzN58mSqqqro3r07xcXFTJ06tcXi\njTKNMm6ffvopvXr12rx87rnnfmObqVOncsIJJ3Daaacxbtw4NmzYwMCBA9l+++0pKiriwAMPZJ99\n9ok9tqjTKONUXV3NWWedxdq1a2nTpg3f+c53KC8v3+q2s2bN4qijjqqz7phjjmH06NHfOG969OjB\nmDFjuPnmm7noootijdncPdYGm6OsrMz1AJT0Wbx4MXvssUeuwxDJe1v7XTGz+e5eVs8udWhIR0Qk\nJZTwRURSQglfRCQllPBFRFJCCV9EJCWU8EVEUkLz8CX/zL0i3vaGnt/gJluWR37kkUfo3r07p512\nGq+99hruTufOnbn33ns54ogjAPjwww8pLCykW7duQFAyuX379vTv35/PP/+cNm3a8NOf/pQJEyZQ\nUBBv32rVTTNiba/bWeMjbbdlOeDbb7+dyZMnby4h/c477zBs2DAuu+wyJk+ezIsvvsjOO+8MBDes\n9erVi/PPb/jfQ5KhhC/C1ssjX3HFFey00068/vrrQHBn5c4777x5u4svvpiioiImTpy41XZWrlzJ\nCSecwLp167jkkkta6CdJTn3lgGtVVlYyfPhwrr32WkaOHMmaNWuYOHEi99xzDxUVFfzjH/9g/vz5\nOfwJREM6IvVYsWIFPXv23Lzcr1+/zaVwo+jevTvl5eXMmDGDfLrBsamylQNesWIFw4YN4/LLL2fk\nyJEAjB07lqVLlzJ37lzOPPNMZsyYsU3UwW/NlPBFqFseufYW+FNOOYWrrrqKQYMGceGFF9apmxLV\nbrvtxpdffsnKlSvjDrnFZSsHfNJJJzF+/HhGjRq1eV1BQQG33norxxxzDP369ePggw/ORdiSQQlf\nhLrlkR9++GEASktLWbZsGeeddx4ff/wx++23H4sXL85xpLmTrRzw97//fe65555vFJErLS1l7733\n5owzWr72j3yTxvBFsigqKuLoo4/m6KOPpqCggMcff7xRdX+WLVtGYWEh3bt3TzDKllNbDnjIkCH0\n799/c2XMSZMm8bvf/Y5jjz2WP/7xj7Rp83VqKSgoiP2itTSN/hVE6vHcc89tflxfTU0Nb775ZqMe\nLL1q1SpOP/10xo8fj5klFWaLaagc8PXXX0+nTp049dRTt4lrFtsi9fAl/0SYRtkSli5dyrhx43B3\nvvrqK0aMGMExxxyTdZ/aawG10zJPPPHErZYRbq6o0yjjVF854NpxezPjrrvu4rDDDmPSpElcffXV\nLR6jZJdoeWQzmwD8L+DA68DJ7l7vExBUHjmdVB5ZJJq8LY9sZj2Bs4Eyd98bKASOT+p4IiKSXdJj\n+G2A9mbWBugAfJDw8UREpB6JJXx3rwKuAd4DVgCfuPvTSR1PWjdd5BPJLo7fkQYv2ppZX+AKYE+g\nXcbBsz5E0sy6AEcAfYC1wANm9hN3v2eL7cYCYwF69+7d2PgblKuaIxJdu3btWL16NV27dt0mZrOI\nxM3dWb16Ne3atWt44yyizNL5LTANmA4MBU4m2l8G3wfecfdVAGb2B2AwUCfhu3s5UA7BRdvIkcs2\no1evXlRWVrJq1apchyKSt9q1a1fnIfJNESXht3f3v5qZufu7wMVmNh+Y2sB+7wEHmFkHYCNwCKAp\nOPINbdu2pU+fPrkOQ2SbFyXhf2ZmBcDbZjYeqAKKGtrJ3V8ysweBCuALYAFhT15ERFpelIR/DsEM\nm7OBSwmGdU6K0ri7TyMYDhIRkRzLmvDNrBAY7e4TgWqC8XsREWmFsl58dfcvgYNaKBYREUlQlCGd\nBWb2KPAAsKF2pbv/IbGoREQkdlESfjtgNfC9jHUOKOGLiLQiURL+ne7+XOYKMzswoXhERCQhUW6g\nuiniOhERyWP19vDNbBDBnbHdzCyzoHcngsqXIiLSimQb0tmO4AarNkDHjPXrgFFb3UNERPJWvQnf\n3ecB88xsZlhSQUREWrEoY/h3mlnn2gUz62JmTyUYk4iIJCBKwi9297W1C+6+BuieXEgiIpKEKAn/\nKzPbXKjezHYlmIcvIiKtSJR5+BcAz5rZPMCA/yZ8YImIiLQeDSZ8d3/SzAYAB4Srfu7uHyUbloiI\nxK3BIR0Lnjk3HBjg7o8BHcxs/8QjExGRWEUZw78FGASMCZfXAzcnFpGIiCQiyhj+QHcfYGYLIJil\nY2bbJRyXiIjELErC/zx8EIoDmFk34KtEoxKRJpk+Z0nsbU44dPfY25TciDKkcyPwMLCTmV0OPAv8\nKtGoREQkdlFm6dxrZvOBQ8JVR7r74mTDEhGRuEUZ0oHgIea1wzrtkwtHRESSEmVa5lTgLuBbQDHw\nWzO7MOnAREQkXlF6+D8G/svdNwGY2ZXAQuCyJAMTEZF4Rblo+wHBc21rbQ9UJROOiIgkJUoP/xNg\nkZnNIRjDPxR42cxuBHD3sxOMT0REYhIl4T8cftV6JplQREQkSVGmZd4FYGZtgb2BKndfmXRgIiIS\nr3rH8M3sNjPbK3y9I/B/wN3AAjMbU99+IiKSn7JdtP1vd18Uvj4ZWOLu/YF9gUmJRyYiIrHKlvBr\nMl4fCjwC4O4fJhqRiIgkIlvCX2tmh5nZPsCBwJMAZtYG3W0rItLqZLto+zOCwmk7EzzlqrZnfwjw\n56QDExGReNWb8N19CcGTrrZc/xTwVJJBiYhI/KLcaSsiItsAJXwRkZRQwhcRSYl6x/DN7NxsO7r7\ndQ01bmadgTsJ7tB14BR3f6GxQYqISPNlm6XTMfzeD9gPeDRcPhx4OWL7NwBPuvuo8MHnHZoUpYiI\nNFu2WTqXAJjZ34EB7r4+XL6YCNMyw3IMBwP/L2yvhro3c4mISAuKMoa/E3UTdU24riF9gFUET8ha\nYGZ3mtkOTYhRRERiEKU88t0E9e9rSyQfSfDIwyhtDwDOcveXzOwGYApwUeZGZjYWGAvQu3fvqHGL\niNQxfc6S2NuccOjusbeZSw328N39coLiaWvCr5Pd/VcR2q4EKt39pXD5QYL/ALZsv9zdy9y9rFu3\nbtEjFxGRRok6LbMDsM7dbwAqzaxPQzuEpRjeN7N+4apDgDebFqaIiDRXg0M6ZjYNKCOYrfNboC1w\nD0FBtYacBdwbztBZRvCXgoiI5ECUMfyjgH2ACgB3/8DMOmbfJeDuCwn+sxARkRyLMqRT4+5OcOMU\nmmkjItI6RUn4vzez24HOZnYa8BeCu2dFRKQVifIQ82vM7FBgHcE4/lR3n5N4ZCIiEqsoF22vcvfJ\nwJytrBMRkVYiypDOoVtZ98O4AxERkWRlq5Y5DjgD2M3MXst4qyPwXNKBiYhIvLIN6dwHPAFcQVAS\nodZ6d/840ahERCR22aplfgJ8AowBMLPuQDugyMyK3P29lglRRETi0OAYvpkdbmZvA+8A84DlBD1/\nERFpRaJctL0MOABY4u59CGrivJhoVCIiErsoCf9zd18NFJhZgbvPReUSRERanSi1dNaaWRHwd4JC\naCuBDcmGJSIicYvSwz8C2AhMAJ4ElhI811ZERFqRKKUVMnvzUZ50JSIieSjbjVfrCStkbvkW4O7e\nKbGoREQkdtnm4UeqeS8iIq1DlOJpW32yuG68EhFpXaLM0vlzxut2QB/gLWCvRCISEZFERLlo2z9z\n2cwGEBRVE5FmmD5nSa5DkJSJMi2zDnevAAYmEIuIiCQoyhj+uRmLBcAA4IPEIhIRkUREGcPPnK3z\nBcGY/kPJhCMiIkmJMoZ/SUsEIiIiyYoypFMGXADsmrm9u383wbhERCRmUYZ07gXOA14Hvko2HBER\nSUqUhL/K3R9NPBIREUlUlIQ/zczuBP4KfFa70t3/kFhUIiISuygJ/2TgP4G2fD2k44ASvohIKxIl\n4e/n7v0Sj0RERBIV5U7b581sz8QjERGRREXp4R8ALDSzdwjG8Gvr4WtapohIKxIl4Q9PPAoREUlc\ntidedXL3dcD6FoxHREQSkq2Hfx9wGDCfYFaOZbznwG4JxiUiIjHL9ojDw8LvfVouHBERSUq9s3TM\nbFcz2zFjeaiZ3WBmE8xsu5YJT0RE4pJtWubvgR0AzKwUeAB4DygFbkk+NBERiVO2Mfz27l77oJOf\nAL9x92vNrABYGPUAZlYIvApU1Q4TiYhIy8vWw8+8SPs9glo6uHtjK2aeAyxu5D4iIhKzbAn/b2b2\nezO7AegC/A3AzHoANVEaN7NewAjgzuYGKiIizZNtSOfnwGigB3CQu38ert+Z4IEoUVwPTKLuYxLr\nMLOxwFiA3r17R2y2EZb/I+YGx8fcnkh+mz5nSextTjh099jblIZlm5bpwP1bWb8gSsNmdhiw0t3n\nm9mQLMcpB8oBysrKPErbIiLSeFGKpzXVgcBIM1tO8B/H98zsngSPJyIiWSSW8N39fHfv5e4lwPHA\n39z9J0kdT0REsst249Vfw+9XtVw4IiKSlGwXbXuY2WCCYZn7qTtNE3eviHoQd38GeKYpAYqISDyy\nJfypwEVAL+C6Ld5zgrn5IiLSSmSbpfMg8KCZXeTul7ZgTCIikoAGH4Di7pea2Ujg4HDVM+7+WLJh\niYhI3BqcpWNmVxCUR3gz/DrHzH6VdGAiIhKvKI84HAGU1tbQMbO7gAXAL5MMTERE4hV1Hn7njNc7\n1ruViIjkrSg9/CuABWY2l2Bq5sHAlESjEhGR2EW5aDvLzJ4B9gtXTXb3DxONSkREYhelh4+7rwAe\nTTgWERFJUJLF00REJI8o4YuIpETWhG9mhWb2z5YKRkREkpM14bv7l8BbZpbAo6hERKQlRblo2wVY\nZGYvAxtqV7r7yMSiEhGR2EVJ+BclHoWIiCQuyjz8eWa2K9DX3f9iZh2AwuRDExGROEUpnnYa8CBw\ne7iqJ/BIkkGJiEj8ogzpnAnsD7wE4O5vm1n3RKMSSYGKdbNjb3NAp9Gxtynbjijz8D9z95raBTNr\nQ/DEKxERaUWiJPx5ZvZLoL2ZHQo8APwp2bBERCRuURL+FGAV8DrwM+Bx4MIkgxIRkfhFmaXzVfjQ\nk5cIhnLecncN6YiItDINJnwzGwHcBiwlqIffx8x+5u5PJB2ciIjEJ8osnWuBoe7+LwAz+w/gz4AS\nvohIKxJlDH99bbIPLQPWJxSPiIgkpN4evpkdHb581cweB35PMIZ/LPBKC8QmIiIxyjakc3jG638D\n/xO+XgW0TywiERFJRL0J391PbslAREQkWVFm6fQBzgJKMrdXeWQRkdYlyiydR4BfE9xd+1Wy4YiI\nSFKiJPxN7n5j4pGIiEiioiT8G8xsGvA08FntSnevSCwqERGJXZSE3x84EfgeXw/peLgsIiKtRJSE\nfyywW2aJZBERaX2i3Gn7BtA56UBERCRZUXr4nYF/mtkr1B3D17RMEZFWJErCn9aUhs3s28DdwE4E\nY/7l7n5DU9oSEZHmi1IPf14T2/4C+IW7V5hZR2C+mc1x9zeb2J6IiDRDlDtt1/P1M2y3A9oCG9y9\nU7b93H0FsCJ8vd7MFgM9ASV8EZEciNLD71j72swMOAI4oDEHMbMSYB+Cp2aJiEgORBnD3yx8tOEj\n4Y1YU6LsY2ZFwEPAz9193VbeHwuMBejdu3djwonkjZp9Y21vaKytSRKmz1kSe5sV62bH3qbkv7jP\npQmH7h5re40VZUjn6IzFAqAM2BSlcTNrS5Ds73X3P2xtG3cvB8oBysrK9KxcEZGEROnhZ9bF/wJY\nTjCsk1U4/PNrYLG7X9ek6EREJDZRxvCbWhf/QIKSDK+b2cJw3S/d/fEmticiIs2Q7RGHU7Ps5+5+\nabaG3f1ZwJoamIiIxCtbD3/DVtbtAJwKdAWyJnwREckv2R5xeG3t6/DGqXOAk4H7gWvr209ERPJT\n1jF8M/sWcC7wY+AuYIC7r2mJwEREJF7ZxvCvBo4mmDLZ392rWywqERGJXbbyyL8AdgEuBD4ws3Xh\n13oz+8YNVCIikt+yjeFHqZUvIiKthJK6iEhKKOGLiKSEEr6ISEoo4YuIpIQSvohISijhi4ikhBK+\niEhKKOGLiKSEEr6ISEoo4YuIpIQSvohISkR5pq1IYk58KP7n6AzoNDr2NiVe0+csyXUIqaQevohI\nSijhi4ikhBK+iEhKKOGLiKSEEr6ISEoo4YuIpIQSvohISijhi4ikhBK+iEhKKOGLiKSEEr6ISEoo\n4YuIpIQSvohISijhi4ikhBK+iEhKKOGLiKSEEr6ISEoo4YuIpESiCd/MhpvZW2b2LzObkuSxREQk\nu8QSvpkVAjcDPwT2BMaY2Z5JHU9ERLJLsoe/P/Avd1/m7jXA/cARCR5PRESySDLh9wTez1iuDNeJ\niEgOmLsn07DZKGC4u/9vuHwiMNDdx2+x3VhgbLjYD3grkYAarxj4KNdBRNSaYgXFmzTFm5x8jHVX\nd+8WZcM2CQZRBXw7Y7lXuK4Ody8HyhOMo0nM7FV3L8t1HFG0plhB8SZN8SanNcW6NUkO6bwC9DWz\nPma2HXA88GiCxxMRkSwS6+G7+xdmNh54CigEfuPui5I6noiIZJfkkA7u/jjweJLHSFDeDTNl0Zpi\nBcWbNMWbnNYU6zckdtFWRETyi0oriIikROoSfkPlHixwY/j+a2Y2IOq+OYr3x2Gcr5vZ82b2Xxnv\nLQ/XLzSzV/Mk3iFm9kkY00Izmxp13xzEel5GnG+Y2Zdm9q3wvVx8tr8xs5Vm9kY97+fbudtQvHlz\n7kaINW/O22Zx99R8EVw8XgrsBmwH/B+w5xbb/Ah4AjDgAOClqPvmKN7BQJfw9Q9r4w2XlwPFefb5\nDgEea8q+LR3rFtsfDvwtV59teMyDgQHAG/W8nzfnbsR48+ncbSjWvDhvm/uVth5+lHIPRwB3e+BF\noLOZ9Yi4b4vH6+7Pu/uacPFFgvsdcqU5n1FLf76NPd4YYFaC8TTI3f8OfJxlk3w6dxuMN5/O3Qif\nbX1aVQmZtCX8KOUe6tsmF6UiGnvMUwl6eLUc+IuZzQ/vaE5a1HgHh3/KP2FmezVy37hEPp6ZdQCG\nAw9lrG7pzzaKfDp3GyvX524U+XDeNkui0zKl5ZjZUIJfmoMyVh/k7lVm1h2YY2b/DHsyuVQB9Hb3\najP7EfAI0DfHMTXkcOA5d8/sAebjZ9sqtZJztzWet9+Qth5+lHIP9W0TqVREzCId08y+C9wJHOHu\nq2vXu3tV+H0l8DDBn59JajBed1/n7tXh68eBtmZWHGXflo41w/FsMZyTg882inw6dyPJo3M3qzw6\nb5sn1xcRWvKL4C+aZUAfvr7AstcW24yg7oWvl6Pum6N4ewP/AgZvsX4HoGPG6+cJitnlOt6d+fr+\nj/2B98LPukU/36jHA3YkGNvdIZefbcaxS6j/wmLenLsR482bczdCrHlx3jb3K1VDOl5PuQczOz18\n/zaCO4N/RHAifgqcnG3fPIh3KtAVuMXMAL7woLjTTsDD4bo2wH3u/mQexDsKGGdmXwAbgeM9+C1q\n0c83YqwARwFPu/uGjN1b/LMFMLNZBLNFis2sEpgGtM2IN2/O3Yjx5s25GyHWvDhvm0t32oqIpETa\nxvBFRFJLCV9EJCWU8EVEUkIJX0QkJZTwRURSQglftklhZcvaKpd/MrPOjdz/YjOb2JT3zez5jNdX\nm9mi8PuRZrZnY+IQiZMSvmyrNrp7qbvvTXDj1JktdWB3H5yxOBb4rrufBxwJKOFLzijhSxq8QEZB\nq7DO/SthIaxLMtZfYGZLzOxZoF/G+rPN7M1w+/sz2t3TzJ4xs2VmdnbG9tXh90eBImC+mU0DRgJX\nh395/EdiP61IPVJ1p62kj5kVAocAvw6XhxEUvdqf4Nb4R83sYGADQc2cUoLfiwpgftjMFKCPu3+2\nxdDQfwJDgY7AW2Z2q7t/Xvumu480s2p3Lw2P3YegpvqDif3AIlko4cu2qr2ZLSTo2S8G5oTrh4Vf\nC8LlIoL/ADoCD7v7p7C5d17rNeBeM3uEoEpirT+7+2fAZ2a2kqAkQGVCP49Is2lIR7ZVG8Oe9a4E\nPfnaMXwDrgjH90vd/Tvu/usG2hoB3EzwRKRXzKy2o/RZxjZfog6U5DklfNmmhT32s4FfhIn6KeAU\nMysCMLOeYc31vwNHmll7M+tIUAMfMysAvu3uc4HJBNUzi5oYznqCvyREckI9EtnmufsCM3sNGOPu\nvzOzPYAXwmqM1cBP3L3CzGYTlLddCbwS7l4I3GNmOxL8dXCju68N922s+4E7wgu8o9x9afN+MpHG\nUbVMEZGU0JCOiEhKKOGLiKSEEr6ISEoo4YuIpIQSvohISijhi4ikhBK+iEhKKOGLiKTE/wc7vIMc\nAxGaRAAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x11eb1b4a8>"
+       "<matplotlib.figure.Figure at 0x1106222e8>"
       ]
      },
      "metadata": {},
@@ -468,12 +483,15 @@
    "source": [
     "## Simulating spectra using quickgen.\n",
     "\n",
-    "We're now ready to simulate DESI spectra using *quickgen*.  Since we're calling *quickgen* from within the notebook (rather than from the command line in a terminal) we have to parse the *simspec* and *fibermap* inputs first."
+    "We're now ready to simulate DESI spectra using *quickgen*!  Since we're calling *quickgen* from within this notebook (rather than from the command line in a terminal) we have to parse the *simspec* and *fibermap* filename inputs first.\n",
+    "\n",
+    "*quickgen* generates four types of files and writes them to the *\\$DESI_SPECTRO_REDUX/\\$SPECPROD/exposures* directory: *calib*, *sky*, *cframe*, and *frame* files.  We will use the *cframe*, or calibrated frame files, which contain the flux-calibrated and sky-subtracted DESI spectra.  The data model and the other files and their contents are documented here:  \n",
+    "http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_REDUX/PRODNAME/exposures/NIGHT/EXPID/index.html"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 113,
+   "execution_count": 16,
    "metadata": {
     "collapsed": false
    },
@@ -482,8 +500,38 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "WARNING:log.py:19:get_logger: desispec.log is deprecated, please use desiutil.log.\n",
-      "Namespace(add_SNeIa=False, airmass=1.25, brickname=None, config='desi', exptime=None, fibermap='/Users/ioannis/research/projects/desi/spectro/data/20170615/fibermap-00000000.fits', frameonly=False, moon_angle=None, moon_phase=None, moon_zenith=None, nspec=100, nstart=0, objtype=None, outdir='.', outdir_truth=None, rmagrange_bgs=(15.0, 19.5), seed=0, simspec='/Users/ioannis/research/projects/desi/spectro/sim/example/20170615/simspec-00000000.fits', sne_rfluxratiorange=(0.1, 1.0), spectrograph=None, verbose=False, zrange_bgs=(0.01, 0.4), zrange_elg=(0.6, 1.6), zrange_lrg=(0.5, 1.1), zrange_qso=(0.5, 4.0))\n"
+      "INFO:quickgen.py:242:main: Reading fibermap file /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/fibermap-00000000.fits\n",
+      "INFO:quickgen.py:275:main: Initializing SpecSim with config desi\n",
+      "INFO:quickgen.py:281:main: Reading input file /Users/ioannis/research/projects/desi/spectro/redux/example/20170615/simspec-00000000.fits\n",
+      "INFO:quickgen.py:310:main: Only 50 spectra in input file\n",
+      "INFO:quickgen.py:672:main: Writing files for channel:b, spectrograph:0, spectra:0 to 50\n",
+      "INFO:quickgen.py:699:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-b0-00000000.fits\n",
+      "INFO:quickgen.py:717:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\n",
+      "INFO:quickgen.py:732:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-b0-00000000.fits\n",
+      "INFO:quickgen.py:753:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-b0-00000000.fits\n",
+      "INFO:quickgen.py:672:main: Writing files for channel:r, spectrograph:0, spectra:0 to 50\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: VerifyWarning: Card is too long, comment will be truncated. [astropy.io.fits.card]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:quickgen.py:699:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-r0-00000000.fits\n",
+      "INFO:quickgen.py:717:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-r0-00000000.fits\n",
+      "INFO:quickgen.py:732:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-r0-00000000.fits\n",
+      "INFO:quickgen.py:753:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-r0-00000000.fits\n",
+      "INFO:quickgen.py:672:main: Writing files for channel:z, spectrograph:0, spectra:0 to 50\n",
+      "INFO:quickgen.py:699:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/frame-z0-00000000.fits\n",
+      "INFO:quickgen.py:717:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/cframe-z0-00000000.fits\n",
+      "INFO:quickgen.py:732:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/sky-z0-00000000.fits\n",
+      "INFO:quickgen.py:753:main: Wrote file /Users/ioannis/research/projects/desi/spectro/redux/example/exposures/20170615/00000000/calib-z0-00000000.fits\n"
      ]
     }
    ],
@@ -492,218 +540,112 @@
     "    '--simspec', simspecfile,\n",
     "    '--fibermap', fiberfile\n",
     "])\n",
-    "print(args)\n",
-    "#quickgen.main(args)    "
+    "quickgen.main(args)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, let's combine and reorganize the individual *cframe* files into *bricks*.  You can read all about the *brick* data model here  \n",
+    "http://desidatamodel.readthedocs.io/en/latest/DESI_SPECTRO_REDUX/PRODNAME/bricks/BRICKNAME/index.html  \n",
+    "and in this TechNote:  \n",
+    "https://desi.lbl.gov/DocDB/cgi-bin/private/ShowDocument?docid=1056"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false,
     "deletable": true,
     "editable": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CRITICAL:makebricks.py:88:main: Non-existent night 20170615\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "-2"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "# Generate fibermap and simspec files.\n",
-    "lensdir = priors['LENSDIR']\n",
-    "for ii in range(nexp):\n",
-    "    fibermap, truth = new_lensing_exposure(priors, exptime=priors['EXPTIME'][ii], night=priors['NIGHT'],\n",
-    "                                           tileid=priors['TILEID'], expid=priors['EXPID'][ii], seed=seed, \n",
-    "                                           outdir=lensdir)\n",
-    "    # Write out truth table of the source.\n",
-    "    metafile = os.path.join(lensdir, priors['NIGHT'], 'meta-source-{:08d}.fits'.format(priors['EXPID'][ii]))\n",
-    "    truth['META_SOURCE'].write(metafile, overwrite=True)\n",
-    "    \n",
-    "    metafile = os.path.join(lensdir, priors['NIGHT'], 'meta-lens-{:08d}.fits'.format(priors['EXPID'][ii]))\n",
-    "    truth['META'].write(metafile, overwrite=True)"
+    "args = makebricks.parse(['--night', night, '--specprod', simdir, '--verbose'])\n",
+    "makebricks.main(args)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "# Run quickgen\n",
-    "lensdir = priors['LENSDIR']\n",
-    "night = priors['NIGHT']\n",
-    "for ii in range(nexp):\n",
-    "    expid = priors['EXPID'][ii]\n",
-    "    quickgen.main(quickgen.parse([\n",
-    "        '--simspec', os.path.join(lensdir, night, 'simspec-{:08d}.fits'.format(expid)), \n",
-    "        '--fibermap', os.path.join(lensdir, night, 'fibermap-{:08d}.fits'.format(expid))\n",
-    "    ]))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "# Make bricks from cframe files.\n",
-    "from desispec.scripts import makebricks\n",
-    "makebricks.main(makebricks.parse(['--night', priors['NIGHT'], '--verbose']))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/Users/ioannis/research/projects/desi/spectro/redux/example'"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "from glob import glob\n",
-    "\n",
-    "# Get the list of bricks\n",
-    "bricks = glob(os.path.join(lensdir, 'bricks', '*'))\n",
-    "print(bricks)\n"
+    "os.path.join( os.getenv('DESI_SPECTRO_REDUX'), os.getenv('SPECPROD') )"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/ioannis/research/projects/desi/spectro/redux/example/20170615\n"
+     ]
+    }
+   ],
    "source": [
-    "# Figure out redshift fitting.\n",
-    "from desispec.scripts import zfind\n",
-    "from glob import glob\n",
-    "\n",
-    "# Get the list of bricks\n",
-    "bricks = glob(os.path.join(lensdir, 'bricks', '*'))\n",
-    "print(bricks)\n",
-    "\n",
-    "nproc = 4\n",
-    "zrange = [0.4, 0.6]\n",
-    "\n",
-    "for bb in list(set(bricks)):\n",
-    "    print(bb)\n",
-    "    #brickfiles = [os.path.join(lensdir, 'bricks', bb, 'brick-{}-{}.fits'.format(ch, bb)) for ch in ['b', 'r', 'z']]\n",
-    "    #print(brickfiles)\n",
-    "    zargs = zfind.parse([\n",
-    "        '--brick', bb, \n",
-    "        '--nproc', '{}'.format(nproc),\n",
-    "        '--zrange-galaxy', '{}'.format(zrange[0]), '{}'.format(zrange[1]), \n",
-    "        #'--zspec', \n",
-    "        #'--qafile', os.path.join(lensdir, 'bricks', bb, 'qa-zbest-{}.pdf'.format(bb)),\n",
-    "        #'--outfile', os.path.join(lensdir, 'zbest-{}.fits'.format(exp))\n",
-    "        '--objtype', 'LRG'])\n",
-    "    zfind.main(zargs)\n"
+    "print(simdir)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
+    "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/Users/ioannis/research/projects/desi/spectro/data/20170615/fibermap-00000000.fits'"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "#set the brick name and take the zbest file for the specified brick\n",
-    "thisbrick = '3587m005'\n",
-    "zfile = os.path.join(lensdir, 'bricks', thisbrick, 'zbest-{}.fits'.format(thisbrick))\n",
-    "zbest = Table(fitsio.read(zfile, ext=1))\n",
-    "print(zbest)\n",
-    "\n",
-    "#Create the table for the set brick \n",
-    "simfile = os.path.join(lensdir, priors['NIGHT'], 'simspec-{:08d}.fits'.format(priors['EXPID'][0]))\n",
-    "sim1 = read_simspec(simfile)\n",
-    "print(Table(sim1.metadata))\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "# Below here requires hacking....\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "# Read the simspec file to get trueflux.\n",
-    "simfile = os.path.join(lensdir, 'simspec-{:08d}.fits'.format(0))\n",
-    "sim = read_simspec(simfile)\n",
-    "\n",
-    "simfile1 = os.path.join(lensdir, 'simspec-{:08d}.fits'.format(1))\n",
-    "sim1 = read_simspec(simfile1)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [],
-   "source": [
-    "#ploting the lens for the three color cuts: blue, red, and near infrared \n",
-    "for channel in ('b', 'r', 'z'):\n",
-    "    ff = desispec.io.read_frame(os.path.join(lensdir, 'cframe-{}0-{:08d}.fits'.format(channel, 0)))\n",
-    "    plt.plot(ff.wave, ff.flux[0, :])\n",
-    "    \n",
-    "    ff_test = desispec.io.read_frame(os.path.join(lensdir, 'cframe-{}0-{:08d}.fits'.format(channel, 1)))\n",
-    "    plt.plot(ff_test.wave, ff_test.flux[0, :])\n",
-    "\n",
-    "plt.plot(sim.wave['brz'], sim.flux[0, :], color='k')\n",
-    "plt.ylim(-4, 10)    \n",
-    "plt.show()\n",
-    "\n",
-    "for channel in ('b', 'r', 'z'):\n",
-    "    ff = desispec.io.read_frame(os.path.join(lensdir, 'cframe-{}0-{:08d}.fits'.format(channel, 0)))\n",
-    "    ff_test = desispec.io.read_frame(os.path.join(lensdir, 'cframe-{}0-{:08d}.fits'.format(channel, 1)))\n",
-    "    plt.plot(ff.wave, ff.flux[0, :] * np.sqrt(ff.ivar[0, :]))\n",
-    "    plt.plot(ff_test.wave, ff_test.flux[0, :] * np.sqrt(ff_test.ivar[0, :]))\n",
-    "plt.xlim(6000, 7000)\n",
-    "plt.ylim(0, 25)\n",
-    "plt.show()\n",
-    "\n"
+    "desispec.io.findfile(filetype='fibermap', night=night, expid=expid, specprod_dir=simdir)"
    ]
   },
   {

--- a/doc/nb/simulating-desi-spectra.ipynb
+++ b/doc/nb/simulating-desi-spectra.ipynb
@@ -250,13 +250,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
-      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
       "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
       "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/elg_templates_v2.0.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/star_templates_v2.1.fits\n",
+      "INFO:io.py:625:read_basis_templates: Reading /data/desi/spectro/templates/basis_templates/v2.3/lrg_templates_v1.3.fits\n",
       "INFO:obs.py:226:new_exposure: skyfile /Users/sbailey/desi/git/desimodel/svn/trunk/data/spectra/spec-sky.dat\n",
       "INFO:obs.py:297:new_exposure: Wrote /data/desi/spectro/sim/example/20170615/fibermap-00000000.fits\n",
       "INFO:obs.py:305:new_exposure: Wrote /data/desi/spectro/sim/example/20170615/simspec-00000000.fits\n"
@@ -304,7 +304,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Generating your own spectra ##\n",
+    "## Generating your own spectra. ##\n",
     "\n",
     "`new_exposure` is a convenience function for generating random typical exposures of various types for testing, but it isn't intended for every possible analysis.  If you want to use your own mix of objects, you just need to write your own fibermap and simspec files following that format instead of calling `new_exposure`.\n",
     "\n",
@@ -321,6 +321,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Reading the input spectra metadata ##\n",
+    "\n",
     "Finally, even though we have the *fibermap* table in hand, the code below demonstrates how it and the *simspec* table can be read from on-disk.  In particular, the simspec METADATA HDU contains an extensive (and useful!) metadata table.\n",
     "\n",
     "In general code should not generate filepaths by hand, but rather call `desispec.io.findfile` to find the file it needs.  If you\n",
@@ -379,7 +381,7 @@
      "data": {
       "text/html": [
        "&lt;Row index=3&gt;\n",
-       "<table id=\"table4531425856\">\n",
+       "<table id=\"table4468786120\">\n",
        "<thead><tr><th>OBJTYPE</th><th>TARGETCAT</th><th>BRICKNAME</th><th>TARGETID</th><th>DESI_TARGET</th><th>BGS_TARGET</th><th>MWS_TARGET</th><th>MAG [5]</th><th>FILTER [5]</th><th>SPECTROID</th><th>POSITIONER</th><th>LOCATION</th><th>DEVICE_LOC</th><th>PETAL_LOC</th><th>FIBER</th><th>LAMBDAREF</th><th>RA_TARGET</th><th>DEC_TARGET</th><th>RA_OBS</th><th>DEC_OBS</th><th>X_TARGET</th><th>Y_TARGET</th><th>X_FVCOBS</th><th>Y_FVCOBS</th><th>Y_FVCERR</th><th>X_FVCERR</th></tr></thead>\n",
        "<thead><tr><th>str10</th><th>str20</th><th>str8</th><th>int64</th><th>int64</th><th>int64</th><th>int64</th><th>float32</th><th>str10</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>int32</th><th>float32</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float64</th><th>float32</th><th>float32</th></tr></thead>\n",
        "<tr><td>SKY</td><td></td><td>3350p205</td><td>4183104322407110374</td><td>4294967296</td><td>0</td><td>0</td><td>0.0 .. 0.0</td><td>..</td><td>0</td><td>82</td><td>82</td><td>82</td><td>0</td><td>3</td><td>5400.0</td><td>335.167583443</td><td>20.5840708185</td><td>335.167583443</td><td>20.5840708185</td><td>-31.5795923296</td><td>-172.635369698</td><td>-31.5795923296</td><td>-172.635369698</td><td>0.0</td><td>0.0</td></tr>\n",
@@ -452,7 +454,7 @@
      "data": {
       "text/html": [
        "&lt;Table length=3&gt;\n",
-       "<table id=\"table4370546640\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<table id=\"table4490940368\" class=\"table-striped table-bordered table-condensed\">\n",
        "<thead><tr><th>OBJTYPE</th><th>SUBTYPE</th><th>TEMPLATEID</th><th>SEED</th><th>REDSHIFT</th><th>MAG</th><th>DECAM_FLUX [6]</th><th>WISE_FLUX [2]</th><th>OIIFLUX</th><th>HBETAFLUX</th><th>EWOII</th><th>EWHBETA</th><th>D4000</th><th>VDISP</th><th>OIIDOUBLET</th><th>OIIIHBETA</th><th>OIIHBETA</th><th>NIIHBETA</th><th>SIIHBETA</th><th>ZMETAL</th><th>AGE</th><th>TEFF</th><th>LOGG</th><th>FEH</th></tr></thead>\n",
        "<thead><tr><th>str10</th><th>str10</th><th>int32</th><th>int64</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th></tr></thead>\n",
        "<tr><td>ELG</td><td></td><td>3512</td><td>3244113739</td><td>1.25838</td><td>22.937</td><td>0.441517 .. 1.32143</td><td>2.19795 .. 1.99019</td><td>8.25246e-17</td><td>-1.0</td><td>73.3845</td><td>-1.0</td><td>1.00652</td><td>68.2661</td><td>0.733237</td><td>-0.0850786</td><td>0.275525</td><td>-0.248196</td><td>-0.19466</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td></tr>\n",
@@ -508,7 +510,7 @@
      "data": {
       "image/png": "iVBORw0KGgoAAAANSUhEUgAAAaQAAAElCAYAAACroJZIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAMTQAADE0B0s6tTgAAIABJREFUeJzt3XucV1W9//HXZwbioqUoYCgpJ0Xwgs7IMiqh4lKaP1PU\nijypYZRw8hKCpPboaGoe80cOeclLRxQ1OdJR8XghURIvqYlLGDU7ihcQIePiBSJG5bLOH3vP+B0c\n5rtnmP2d/Z39fj4e8/ju69qfzZc9n1l7r72WhRAQERFpbxXtHYCIiAgoIYmISEYoIYmISCYoIYmI\nSCYoIYmISCYoIYmISCYoIYmISCYoIYmISCYoIYmISCYoIYmISCZ0au8AmjJlypTQp0+f9g5DRES2\n08yZM+/y3h+fZNtMJqQ+ffowadKk9g5DRES208yZM99Iuq1u2YmISCYoIYmISCYoIYmISCYoIYmI\nSCZkslGDSEuEEFizZg1btmxp71BEcquiooKePXtiZq0uQwlJyt6aNWvYcccd6datW3uHIpJbdXV1\nrFmzhl69erW6jNQTknPuSOAXRLcHOwFTvfc3p31cyY8tW7YoGYm0s27durFu3brtKiPVZ0jOOQN+\nB4z13lcBRwHXO+c+meZxRUSk/JTill0Ado6nPwW8DXxQguNKTk17aHEq5Z711X1TKTerrqm9JpVy\nf1T1o1TKbW8L7n09lXI/943PplJuFqVaQ/LeB2AMcJdz7g3gT8D3vPcfpnlckfbUr18/BgwYQFVV\nVcPPCy+8QL9+/aitrW1yn9tvv51DDz2U/v3745xj2LBh3HnnnSWOPFua+vcaO3Yse+yxB1VVVQwc\nOJCTTjqJDRs2NKzfuHEjF154IQMHDuSAAw6gurqa0aNHb/PfvaO56667GDx4cMO/z4gRIzjyyCMb\n/h+aGYMGDaKqqophw4Y17Pf6669TUVHBxRdf3Ki8GTNmsNNOO1FVVcWBBx7I8OHDWbw4nT/4IOUa\nknOuE/Az4Djv/WPOuUOBe5xzg7z3awq2mwQ09BVUXV2dZlgiqZs1axZVVVWJtr3hhhv41a9+xV13\n3cX+++8PwMsvv8w999yTZohla8qUKUycOJEPPviAESNGcPXVV/OTn/wEgFNOOYX169fz1FNP0aNH\nDwDmzZvHyy+/nPj7KFdvvfUWp556Ks8++yx77bUXAAsXLqS6urqh5ZuZ8fjjj7Pzzjs32vfGG29k\nxIgR3HTTTfzsZz9r1FJu+PDh3H333QCcffbZTJw4kTlz5qRyDmnfsqsCdvfePwbgvX/GObccqAYe\nqt/Ie18D1NTP19TUhJTjEsmMn//859xwww0NyQhgwIABTJkypR2jyr4uXbowdOhQ3ngj6irtlVde\nYfbs2bz55psNyQhg1KhR7RViSa1cuZLKykp22WWXhmWHHHJI0f02b97MjBkzePDBBznhhBN4+OGH\nGTlyZJPbjhw5kj/84Q9tFvPW0n4x9k2gj3NuPwDn3D7A3sDLKR9XpF2NGTOm0S27urq6JrdbtWoV\nK1asYMiQISWOsPytXbuWRx55hOOPjzqSXrRoEfvss0+jX8h5ctBBBzF06FD22msvjj32WKZOncqK\nFSuK7jd37lz69u3L/vvvz7hx45g+fXqT223ZsoXZs2fzne98p61Db5D2M6SVwKnA751zzwGzgdO9\n98vSPK5Ie5s1axa1tbUNPy1plj58+HAGDRrEgAEDUoywfE2dOpWDDjqI3Xbbjb59+zJ8+PAmt3vt\ntdeoqqpiwIABnHLKKSWOsvQqKiq48847efLJJzniiCN44oknOOCAA3j11Veb3W/69Ol8//vfB+C7\n3/0uc+bM4d13321YP3/+fKqqqujZsycPP/wwP/pReo1SUu86yHv/X977Qd77g+PPmWkfU6Rc9O7d\nmz322IMFCxY0LJs/fz733nsvK1eubMfIsmvKlCk8//zzLF68GO891113HRA9e3711Vcbfpnuvffe\n1NbWct555zX6BdvRDRw4kPHjx3P33Xfz+c9/vtlnkatXr+b+++/n4osvpl+/fgwePJiNGzdy2223\nNWwzfPhwamtrWb58Ofvuu295JyQRad7555/PWWedxUsvvdSw7J///Gc7RlQe9txzT6666iouuugi\n6urq6N+/P8cccwzjxo3jvffea9guL/+WK1as4IknnmiYf/fdd1myZAl77733Nve55ZZbGD16NG++\n+SZLly5l6dKl3HHHHU3etuvevTs33HADc+bMYdGiRamcg7oOkg4nC+8LjRkzptFtumnTpgFw+OGH\n07lz54blf/7znzn11FPZYYcdOPHEE1m7di29evWia9eu/OY3vyl53IWy8L7Q1v9eAwcObNRa7uij\nj2batGlcc801TJ48mRkzZnDJJZcwZMgQOnXqRI8ePejVqxfnnHNO6rG29/tCmzZt4qKLLmLJkiV0\n796dTZs28b3vfY9jjjlmm/tMnz6dyy67rNGyr371q4wdO5aFCxd+bPvdd9+ds88+m/PPP5977723\nzc/BQsheg7aampqgEWMlqZUrV7Lbbru1dxgiudfUteicm+a9T/QLXbfsREQkE5SQREQkE5SQREQk\nE5SQREQkE5SQREQkE5SQREQkE/QeknQ88y9Np9zh5yXarF+/fnTp0qXhPSTnHBdccAGnnXYaS5Ys\nAaCyspKamhoWL17c0NPAsmXL6NatW8MQ0NOmTePmm2/moYceonfv3qxfv57ddtuN8ePHc9JJJ6Vw\ngo2tvurqVMrtdcbpibe96667uOSSS9i8eTPvv/8+u+++O/PmzWPEiBFMnDiR0aNHs2XLFk477TRe\nfPFFJk+ezJQpU6itraV79+4A/P73v+fSSy9lwYIFjd5pkuxRQhJJwdbDTxx11FGMHDmyoRuXNWvW\nsGHDBkaMGMGECROAaKyfqqoqJk6c2LDfzTff3DDcAkBtbS1jxoxh9erVdPR39bY1nELh0AgbN27k\n5JNPZv369cydO5du3boxd+5czj33XK688kpWrVrFpEmTeOCBB5SMyoBu2YmUwPLly9ljjz0a5nv2\n7Mmee+7Z4nKqqqq44ooruOyyy8jiS+1taVvDKdQnpLq6OkaPHk1lZSWzZ89uqJFOnTqVBx54gEcf\nfZQJEyZw5plncuCBB7bLOUjLKCGJpKBw+InZs2dzzjnnMG7cOA477DAmT57MY4891uqyhwwZwqpV\nq1i9enUbRpw9xYZTOOOMM9h555259dZb6dTpo5s9O+ywAzfddBPHHXccq1at4uyzz26P8KUVlJBE\nUlA4/MSxxx7LCSecwLJly5g8eTIAxxxzDFOnTm1V2R29ZlSv2HAKhx9+OA8//DAvvPDCx/Y97LDD\n2H///TnrrLOoqNCvuXKhb0qkRHr06MFxxx3H5ZdfzrXXXsutt97aqnKeeeYZevfuTe/evds4wmza\n1nAK3/rWt7jiiiv42te+Rm1t7cf2q6yspLKystThynZQQhIpgfvuu48NGzYAUQ1n0aJFzQ4LsC3P\nP/88EydOLEnv1e0tyXAK3/72t7n66qs54ogjUhsSQUpHrexESuDRRx9lypQpdOrUiRACAwYM4Oqr\nkzWrnjp1KjNmzGDDhg307t2b8847j5NPPjnliNtfc8Mp1A/nAfDNb36TiooKjjjiCObMmcPgwYPb\nMWrZHhp+Qsqehp8QyQYNPyEiIh2CEpKIiGRCqs+QnHO7An8sWNQd+CzQ23v/TprHFhGR8pJqQvLe\nvw009J/inDsb+LKSkYiIbK3Ut+zGAdNLfEzp4CoqKqirq2vvMERyra6ubrtfQk5UQzKzbsAZRLWd\nrvXLQwjHJT2Qc+6LQA/gvibWTQIaWmFUV1cnLVaEnj17smbNGtatW9feoUjOLf77P9o7hFbZ99Of\n3O4yKioq6Nmz53aVkfSW3X8C64AvApcDY4GWdsY1DrjFe79p6xXe+xqgpn6+pqYme23RJbPMrGHI\nBpH2NPP5te0dQqsMOzgbr00kTUgHhxAGmdnzIYSrzGwGcH/SgzjndgS+DRzaihhFRCQHkt7wq79B\nv8nMdggh/ANoyZ+kY4DnvPcvtSg6ERHJjaQ1pHfMrAcwB5hrZmuA5S04zjii234iIiJNSpqQ/l8I\nYbOZ/Tvwr0SNE25JehDv/RdbE5yIiORH0YRkZpXAXGBUiDq+uy31qEREJHeKPkMKIWwGupuZuhkS\nEZHUJL1l9wxwn5n9DlhfvzCEcE8qUYmISO4kTUgHxZ8/LFgWACUkERFpE4kSUghheNqBiIhIviV6\nLmRmC5IsExERaa2kDRUa1aTMrDOw/Z0fiYiIxJpNSGZ2jpm9Cwwys3fqf4j6tWtpX3YiIiLbVOwZ\n0nXALOBaYELB8nUhhHdTi0pERHKn2YQUQlgLrDWz8cCqEML7AGbW1cw+E0J4sxRBiohIx5f0GdId\nW81bE8tERERaLWlC+kR97QgghFAHdEknJBERyaOkCSmYWe/6GTP7NFEtSUREpE0k7anhSuApM7s1\nnj8RuDCdkEREJI+S9tRwk5ktAY6MF50SQng8vbBERCRvktaQAJ4A3gwhvJZWMCIikl9Juw76CvAG\nMD+ePzTu+VtERKRNJG3U8EtgGPA2QAjhGaA6raBERCR/kiakyiZu1X3Y1sGIiEh+JU1I75vZjkRj\nIGFmg4C61KISEZHcSdqo4WLgQaBv/OxoFPCvSXZ0znUBLgcOB94HnvPen9iKWEVEpANL2uz7QTN7\nBTiC6IXYC1rQ2u6XRDWrfb33wTn36daFKiIiHVlLmn2vAl4gSi5/T7KDc24HYBzQ13sfALz3ifYV\nEZF8SZSQzGwkMBNYQVRD6mNmJ4QQ5hfZdW/gHeCnzrlRRM+dfu69/2PhRs65ScCk+vnqajXgExHJ\nm6SNGn4NHB1COCSEUA0cTdSdUDGdgL2Av3rvHXAmMMs5t1vhRt77Gu993/qf/fbbrwWnICIiHUHS\nhLQlhPB0/UwIYQGwOcF+y4AtwG0A3vtFwBJgUAvjFBGRDi5pQnrQzMbaR04manXXLO/9GuCPRC3s\ncM79C/AvwP+2NmAREemYkjZq+AGwE3B9PN+ZaCTZHwIhhLBLM/tOAKY75y4jqi2N996vaG3AIiLS\nMSVNSFWtPYD3/nVgeGv3FxGRfEj6HtIbAGbWCTiQqNfvt9MMTERE8qXZZ0hmdlncTRBm1hV4mqjH\n76VmdlQJ4hMRkZwo1qjhG8CL8fQJRM+AdgOGAuenGJeIiORMsYT0QQhhSzz9FeD2EMKHIYTnaFkv\nDyIiIs0qlpA6mdkn4umhRKPG1uuaTkgiIpJHxWo5/w3MN7N3iHrqfhrAzD4LrE05NhERyZFmE1II\n4SIzexHoS3S7LsSregAXpB2ciIjkR9HnQCGEO5tY9mw64YiISF4l7TpIREQkVUpIIiKSCUpIIiKS\nCc0+QzKzLzW3PoTwWNuGIyIieVWsUcPl8WclUQerrxMNYb43UAsckl5oIiKSJ83esgshHBpCOJQo\n+RweQtgnhNAf+BqwsBQBiohIPiR9huRCCA/Vz4QQ5gGHphOSiIjkUdKEtNnMGsY0MrMvE3W0KiIi\n0iaSdpB6GnC7mW0s2G9MOiGJiEgeJR2g70kz2xsYGC96KYSwsbl9REREWqIl7yEdDXwjhPAC0Kt+\n4D4REZG2kKiGZGYXETVi2Bv4D6Km39cDXyy2r3NuKfABUBcvutR7P6s1wYqISMeV9BnSMUTvHHmA\nEMJbZrZjC44zxntf29LgREQkP5LesqsLIWzeapm1dTAiIpJfSWtIb5jZMCCYWWfgp0QvyyZ1q3MO\nYAFwrvd+dcvCFBGRji5pQjoTuBkYBPwTmA+cmHDfL3nvlznnOgO/iMs5snAD59wkYFL9fHV1dcKi\nRaQ9THtocWpln/XVfVMrO824Zfslbfa9EjjCzLoDFkL4Z9IDeO+XxZ8bnXO/Bj72P8J7XwPU1M/X\n1NSErbcREZGOLdEzJDNbABBC2FCfjOqXNcc5t4NzbueCRScAi1oTqIiIdGxJb9k12i5+jvTJBPvt\nBtzpnKskagTxOnByiyIUEZFcKDYe0jnAucCOZvZOwapuwC3FCvfevw7ogZCIiBRVrIZ0HTALuBaY\nULB8XQjh3dSiEhGR3Gk2IYUQ1gJrga+XJhwREcmrpF0H9QYuBA4GutYvDyFoxFgREWkTSXtqmA4s\nBXoCFwB/A+5PKSYREcmhpAnpMyGEy4APQgj3AscBo9ILS0RE8iZpQvow/nzfzHYFNhHVlkRERNpE\n0veQFseJ6HfA08A64NnUohIRkdxJ2nVQfb91V5jZs8DOwAOpRSUiIrmTtIbUIITwpzQCERGRfCvW\nU8O7RKPDfmwVEEIIu6QSlYiI5E6xGlJVSaIQEZHcK9ZTwxulCkRERPItaU8NS2ji1l0I4bNtHpGI\niORS0kYNRxVMdwVOAt5u+3BERCSvkjb7fnGrRc+a2ZPAxW0fkoiI5FHSnhoaiV+S/XQbxyIiIjmW\n9BnSIj56hlQJ7AX8/7SCEhGR/En6DGliwfQm4PUQwlspxCMiIjmV9BnSo2kHIiIi+Zb0lt3+ROMg\n9S/cJ4RwUEpxiYhIziS9ZXc7cAvwG2Bzaw7knDsFuBE41nt/d2vKEBGRjitpQtocQvhVaw/inOsH\n/BD4c2vLEBGRji1ps+/5Zval1hzAOVcB3ACcAXzQmjJERKTjS5qQ7gDuN7O/mdnrZrbEzF5PuO8k\n4AnvvQb0ExGRbUp6y+4m4MeApwXPkJxzBwLHA83Wrpxzk4gSFwDV1dVJD9Eqq6+6OrWye51xempl\nS8cy7aHFqZbfpde8FEsflVrJaf+7SHYlTUjrQwg3tqL8YUA/4BXnHES9O/zWOdfHe39t/Ube+xqg\npn6+pqamqTGYRESkA0uakO43s2+EEO5tSeFx0mlIPM65R4Bfq5WdiIhsLWlCOgPYyczqiBomaMRY\nERFpU0kTUpuMHOu9/0pblCMiIh1P0q6DNHKsiIikqtmEZGb/FUI4YavevhuEEA5JLTIREcmVYjWk\n+t4ZJja7lYiIyHZqNiGFEJ6NPxt6+zaznUMI76UdmIiI5EuzPTWY2UQz2y+erjCze4F3zGy1mX2h\nJBGKiEguFOs66AfAa/H0t4B9gD7AWOCy9MISEZG8KZaQNoUQPoynRwK3hhBWhhDuBz6ZbmgiIpIn\nxRJSJzOzePow4MmCdZ3TCUlERPKoWCu7PwKzzGwVUY3oTwBm9mk0lISIiLShYjWkycDTwEbgiBDC\npnh5fwo6QxUREdlexZp9bwIub2L546lFJCIiuZR0gD4REZFUKSGJiEgmFHsx9qvx56dKE46IiORV\nsRrSL+PPR1KOQ0REcq5Ys+/OZnYO0NvMztx6ZQjhynTCEhGRvCmWkH4IfA/oBlRvte5jw1GIiIi0\nVrFm308DT5vZGyEE9V0nIiKpSTpi7GVm9jlgVLzowRCCTy8sERHJm0TNvs3sVOAOoDfQC7jTzH6Q\nZmAiIpIviWpIwOnA4BDCagAz+w+ifu5uKLajc+5B4NPAFuAfwJne+0WtC1dERDqqpAmJ+mRUP/1R\nJ+BFfdt7/x6Ac+5YYAZwcAtiFBGRHEjaU8MrZnaJme0Z/1wMvJJkx/pkFNsJtc4TEZEmJK0hTQCu\nAhYSJZR5wL8lPYhz7hZgeDx7ZBPrJwGT6uerq7duYS4iIh1d0lZ2q4HvtPYg3vuTAZxz3yMa+vzI\nrdbXUDCcRU1NjWpRIiI5U9LOVb33NwPDnXO7lvK4IiKSfakmJOfczs653QvmRwNvA++keVwRESk/\niVvZtdJOwH8757oRNfteDRzlvdctORERaaRoQjKzSmBuCGFUsW235r1/A/hcawITEZF8KXrLLoSw\nGehuZhrMT0REUpP0lt0zwH1m9jtgff3CEMI9qUQlIiK5kzQhHRR//rBgWQCUkEREpE0kfQ9pePGt\nREREWi9pb9+dzGyymV0Tz+9tZiPSDU1ERPIk6S27q4FKYGg8/zYwC3BpBCUiIvmTNCF9PoRQZWaL\nAEII75lZ5xTjEhGRnEnalPv9wpn43SQ1AxcRkTaTNKk8b2YnAhVmtg9wHfBIalGJiEjuJE1Ik4Bh\nRCO/PknUDdA5aQUlIiL5k7TZ93pgfPwjIiLS5hIlJDPrApwFjCJ6IfYh4IoQwgcpxiYiIjmStJXd\ndcCuRKPGApwCDAS+n0ZQIiKSP0kT0heA/UIIAcDM7gNeTC0qERHJnaSNGt4GuhXMdwHWtH04IiKS\nV83WkMzszHjyJeBpM/t9PP9Noh7ARURE2kSxW3bVBdMe+Gw8vZCoKyEREZE20WxCCiGcUqpAREQk\n35I2asDMvg70L9wnhFCTRlAiIpI/Sd9DmgnsBywCNseLQ1pBiYhI/iStIR0CHBBC2Fx0ywLOua7A\n7cD+QB2wCvg37/2rLYpSREQ6vKTNvpcSNfVujd8CA7z3BwP/A9zQynJERKQDS1pDmgzMM7NHKBiK\nIoRwUXM7ee/fB+YULPozcHYLYxQRkRxImpAuBT4EugLbMzDfj4lqSY045yYR9SgOQHV19dabtK2l\nj6dY+Okpli2ldtKdF7d3CK32hV67tncIIi2SNCENCCEM2J4DOed+CuwDjNx6nfe+BmhosVdTU6MG\nEyIiOZP0GdLLZvap1h7EOXc2cBzwde/9htaWIyIiHVfSGlIdsNDMHqTxM6RJ294lEt+OOwEY5b1/\nr1VRiohIh5c0If01/mkR51xf4HLgdWC+cw7gA+/9kJaWJSIiHVvSEWMvbE3h3vvlgLVmXxERyZek\nPTWc39TyYs2+RUREkkp6y+6TBdNdgSOBp9o+HBERyaukt+ymFM6b2c+BGSnEIyIiOZW02XcjIYS3\n+WhsJBERke2W9BnSmQWzlcDngL+nEpGIiORS0mdIhX35bAJqiTpNFRERaRNJnyFp5FgREUlVswnJ\nzL7U3PoQwmNtG46IiORVsRrS5U0sC8DuQB+i50kiIiLbrdmEFEI4tHDezHYBfgacCFyQYlwiIpIz\niZp9m1lXMzuPj/qz2y+E8Iv0whIRkbxpNiGZWYWZnQq8AgwEhoQQJsXvIYmIiLSZYs+Q/gJ0AX4K\nPAfsZGYH1a8MITyfYmwiIpIjxRJSd6JGDE11ohpQbw0iItJGijVq6FeiOEREJOda1ZediIhIW1NC\nEhGRTFBCEhGRTFBCEhGRTEja23erOeeuBI4G9gKqvfe1aR9TRETKTylqSHcAQ4E3SnAsEREpU6nX\nkLz3jwE459I+lIiIlDE9QxIRkUxIvYaUhHNuEjCpfr66urqZrbffXz4cnFrZw1MrWaRlnnotvS4n\nD/lUakVLjmUiIXnva4Ca+vmamprQjuGIiEg70C07ERHJhNQTknPueufccqAvMNc592raxxQRkfJT\nilZ249M+hoiIlD/dshMRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIR\nkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQQhIRkUxQ\nQhIRkUxQQhIRkUxQQhIRkUzolPYBnHP9gZuBnsBaYKz3/sW0jysiIuWlFDWk64Hfeu/3BS4DZpTg\nmCIiUmZSTUjOud6AA34XL7oT+Ixzbp80jysiIuUn7RrSZ4C3vPebALz3AVgG7JnycUVEpMyk/gwp\nCefcJGBSwaIXZs6cOa+94knoEGDhx5a635c+ku3X9LmUJ51LCfwv/9PSXTJ7Lq3Q4c7ltvNSPcZe\nSTe0EEJqUcS37F4FdvHeb3LOGfAWMNR7/2pqBy4B59xy733f9o6jLehcsknnkk06l/SkesvOe7+K\n6C+JE+NFxwPLyz0ZiYhI2yvFLbvxwAzn3E+BdcApJTimiIiUmdQTkvf+ZeALaR+nHdS0dwBtSOeS\nTTqXbNK5pCTVZ0giIiJJqesgERHJBCUkERHJhEy8h5QVSfvdc84dBfwKqAReiLdbF68bAvwW6AYs\nB07y3q8ozRk0irHouTjnBgG/AXoDm4AFwGne+7p4fQD+AmyOdznDe/94ac6gsYTn0w94jeg7qXe8\n9/61eH05fTeHE3W1Va838Hfv/SHx+nb/bpxzVwJHE71nUu29r93GduVwvRQ9l3K5XhKeSz8yeK2o\nhtRY0X73nHM7AtOB0d77/sDfgH+P11UAtwET4zLmAL8uTegfk6QPwfeB0733A4GDgR2Ac7baZpj3\nvir+aZdkFEvaJ+I/CuKtKrjAyuq78d7PLTwPotcnbttqs/b+bu4AhgJvbGuDMrpeip4L5XO9JDkX\nyOC1ooQUa0G/e18HFnnvX4rnrwFOiKcHA5u89/Pj+euBbzjnuqYX+cclPRfv/Sve++fj6c3AM0C/\nEoaaSBv1iVhW381W++wOjARuTT/C5Lz3j3nvlxfZLPPXCyQ7l3K5XhJ+L81pt+9FCekjSfvd25PG\nf3ksBfo45zptvc57/w+id692Ty/sJrW4D0Hn3A7AD+BjfcLMd84955yribdpDy05nx2cc8865xY6\n5853zlXGy8v2uwHGAnPiF80LZeG7KaYcrpcWy/j1klTmrhUlJME59wlgFvCg9352waq9vPfVwBeB\nXsDU9oivBd4C9vDeDwZGAcOAye0b0vaJu9v6PtFtr0Ll9t10GB3kesnktaKE9JE3+egvt/pfBHsS\n/fVaaBmNOwvsx0d/8TZa55z7JLAT0X3zUkp6LjjnOhNdXG8BPy5c571fFn/+k+hWy7B0w96mROfj\nvf+gvhbhvX8HuJGPYi677yb2ZaArMLdwYYa+m2LK4XpJrEyul6Kyeq0oIcVa0O/eA8AhzrmB8fyP\ngNvj6WeBzs654fH8eOBe7/376UX+cUnPJf6leDvwDnBqfPuofl0P51z3eLoCGAMsKkH4H9OC8+kd\n/8LAOdcFOI6PYi6r76bAOGBG/MwCyNZ3k0Dmr5ekyuV6SSKr14oSUmPjgfHOucXAucT97jnnLnLO\nTYCG+6k/AO52zr0K9AUujtdtIfpFc0VcxlHAWSU/i0jRcyG6aI4jesi+yDlX65z7TbxuIPBn59xz\nRE1DdwWw548yAAACvElEQVQmlvIEtpLkfIYSncdzRL/0/w5cAmX53eCc24no+7lxq/0z8d045653\nzi0nugbmxtdDWV4vSc6FMrleEp5LJq8VdR0kIiKZoBqSiIhkghKSiIhkghKSiIhkghKSiIhkghKS\niIhkghKSSBFmttTMXjaz2vjz3FaUcZSZPVJkm5+bWZOdWJrZ0WY2rWD+QjN7ycyeNrN+Zjahqf1E\nyomGnxBJZkwIodbM9gD+amYPhxAWlOrgIYR7gHsKFv0E+GwI4S0z+wowAbiuVPGIpEE1JJEWCCGs\nAF4i7lrFzE6KaykLzewxMzs4Xt7ZzK4xs1fMbAFQ/9Y7ZtbfzJ4ws+fM7AUz+0XBIfqY2b1m9lcz\ne9jMdon3GWtmd8fTTxJ1J/SgmV1JlIgGxDW4wqQlUlZUQxJpATMbSPQW/iNmdhjRUApfCiF8YGbD\ngJnAAcCpwIB4Ghr3RXc6cF8I4dK4zF0K1g0BBocQ3jaz24l6dbi0MIYQwhfNLADDQgjvxTWkX4cQ\nqtr4dEVKSglJJJlZZraFKMmcFUJYbWZTiAZqe9rM6rfbxcy6EY1fdEsI4UMAM7uRqF86gMeAqWa2\nI/AoMK/gOA+EEN6Op58CBqV5UiJZolt2IsmMCSHsB3wN+KWZDQIMuDmEUFXw0yeEUNfE/g19dIUQ\n7gQOA14mri0VbFfYgeVm9Eej5IgSkkgLhBDmAdcCvyBqZHCime0JYGYVZubiTefF6zqb2SeIO1CN\nt+sPrAwh3ELUOOHz2xnWOqLhAUTKmhKSSMtdTNRb8gaihDLbzJ4DXgS+E2/zn8ArwF+BPwG1Bft/\nE3jBzBYRja2zvU22nwdeNLO/qFGDlDP19i0iIpmgGpKIiGSCEpKIiGSCEpKIiGSCEpKIiGSCEpKI\niGSCEpKIiGSCEpKIiGSCEpKIiGSCEpKIiGTC/wHoYrJHE2foTAAAAABJRU5ErkJggg==\n",
       "text/plain": [
-       "<matplotlib.figure.Figure at 0x111604f28>"
+       "<matplotlib.figure.Figure at 0x10e278630>"
       ]
      },
      "metadata": {},
@@ -534,103 +536,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Setting up a production directory ##\n",
-    "\n",
-    "Before proceeding with simulating noisy output spectra, we will call `desi_pipe`\n",
-    "to setup a production directory hierarchy.  We'll tell it to skip several\n",
-    "of the initial steps since we will use `quickgen` to directly simulate\n",
-    "extracted and calibrated spectra instead of generating pixel-level raw data.\n",
-    "\n",
-    "The following code is equivalent to calling the command line\n",
-    "```\n",
-    "desi_pipe --fakeboot --fakepsf --fakepix\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Working with production /data/desi/spectro/redux/example :\n",
-      "  Updating plans ...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/sbailey/anaconda/envs/desi/lib/python3.5/site-packages/matplotlib/__init__.py:1401: UserWarning:  This call to matplotlib.use() has no effect\n",
-      "because the backend has already been chosen;\n",
-      "matplotlib.use() must be called *before* pylab, matplotlib.pyplot,\n",
-      "or matplotlib.backends is imported for the first time.\n",
-      "\n",
-      "  warnings.warn(_use_error_msg)\n"
-     ]
-    },
-    {
-     "ename": "KeyError",
-     "evalue": "'r0'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-17-6319d2d14e00>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mdesispec\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mscripts\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mpipe_prod\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0margs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpipe_prod\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mparse\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'--fakeboot'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'--fakepsf'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'--fakepix'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mpipe_prod\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmain\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m/Users/sbailey/desi/git/desispec/py/desispec/scripts/pipe_prod.py\u001b[0m in \u001b[0;36mmain\u001b[0;34m(args)\u001b[0m\n\u001b[1;32m    326\u001b[0m     \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"  Updating plans ...\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    327\u001b[0m     expnightcount, allpix = pipe.create_prod(nightstr=args.nights, \n\u001b[0;32m--> 328\u001b[0;31m         extra=extra, specs=specs, fakepix=args.fakepix, hpxnside=args.nside)\n\u001b[0m\u001b[1;32m    329\u001b[0m     \u001b[0mtotcount\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m{\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    330\u001b[0m     \u001b[0mtotcount\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"flat\"\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/sbailey/desi/git/desispec/py/desispec/pipeline/plan.py\u001b[0m in \u001b[0;36mcreate_prod\u001b[0;34m(nightstr, extra, specs, fakepix, hpxnside)\u001b[0m\n\u001b[1;32m    182\u001b[0m             \u001b[0mos\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmakedirs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnlog\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    183\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 184\u001b[0;31m         \u001b[0mgrph\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mexpcount\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mnpix\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mgraph_night\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnt\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mspecs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfakepix\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mhpxnside\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    185\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    186\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0mpix\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mnpix\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/Users/sbailey/desi/git/desispec/py/desispec/pipeline/plan.py\u001b[0m in \u001b[0;36mgraph_night\u001b[0;34m(rawnight, specs, fakepix, hpxnside)\u001b[0m\n\u001b[1;32m    505\u001b[0m         \u001b[0mcam\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m\"{}{}\"\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mband\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mspec\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    506\u001b[0m         \u001b[0mflatid\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 507\u001b[0;31m         \u001b[0;32mfor\u001b[0m \u001b[0mfid\u001b[0m \u001b[0;32min\u001b[0m \u001b[0msorted\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mflatexpid\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mcam\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    508\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mflatid\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    509\u001b[0m                 \u001b[0mflatid\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfid\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mKeyError\u001b[0m: 'r0'"
-     ]
-    }
-   ],
-   "source": [
-    "from desispec.scripts import pipe_prod\n",
-    "args = pipe_prod.parse(['--fakeboot', '--fakepsf', '--fakepix'])\n",
-    "pipe_prod.main(args)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "DESI_SPECTRO_DATA=/data/desi/spectro/sim/example/\n",
-      "DESI_SPECTRO_REDUX=/data/desi/spectro/redux\n",
-      "SPECPROD=example\n",
-      "/data/desi/spectro/sim/example/\r\n",
-      "/data/desi/spectro/sim/example//20170615\r\n",
-      "/data/desi/spectro/sim/example//20170615/fibermap-00000000.fits\r\n",
-      "/data/desi/spectro/sim/example//20170615/simspec-00000000.fits\r\n",
-      "/data/desi/spectro/sim/example//etc\r\n",
-      "/data/desi/spectro/sim/example//etc/obslog.sqlite\r\n"
-     ]
-    }
-   ],
-   "source": [
-    "#- What went wrong?  Check environments and files\n",
-    "for var in ['DESI_SPECTRO_DATA', 'DESI_SPECTRO_REDUX', 'SPECPROD']:\n",
-    "    print('{}={}'.format(var, os.getenv(var)))\n",
-    "\n",
-    "rawdir = os.path.join(os.getenv('DESI_SPECTRO_DATA'))\n",
-    "!find $rawdir | sort"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Simulating spectra using quickgen.\n",
     "\n",
     "We're now ready to simulate DESI spectra using *quickgen*!  Since we're calling *quickgen* from within this notebook (rather than from the command line in a terminal) we have to parse the *simspec* and *fibermap* filename inputs first.\n",
@@ -646,7 +551,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "metadata": {
     "collapsed": false
    },
@@ -702,11 +607,128 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, let's combine and reorganize the individual *cframe* files into *spectra* files grouped on the sky.\n",
+    "## Regrouping the spectra ##\n",
+    "\n",
+    "Next, let's combine and reorganize the individual *cframe* files into *spectra* files grouped on the sky.  For this simple example of a single exposure, regrouping doesn't matter so much, but it becomes more important for real observations with overlapping tiles where the same object could be reobserved on different exposures separated by short or large amounts of time.\n",
     "\n",
     "**TODO**: Add the spectra files to the desidatamodel\n",
     "\n",
-    "**TODO**: Proceed with calling desi_group_spectra, but first we need to production generation above."
+    "To regroup the spectra, we want to run:\n",
+    "```\n",
+    "desi_group_spectra --hpxnside 64\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:group_spectra.py:74:main: Starting at Sat Jun 17 11:47:43 2017\n",
+      "INFO:group_spectra.py:75:main:   using raw dir /data/desi/spectro/sim/example\n",
+      "INFO:group_spectra.py:76:main:   using spectro production dir /data/desi/spectro/redux/example\n",
+      "INFO:group_spectra.py:197:main: Distributing 1 spectral groups among 1 processes\n",
+      "INFO:group_spectra.py:220:main:   (0000) Begin spectral group spectra-64-12637 at Sat Jun 17 11:47:43 2017\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/sbailey/anaconda/envs/desi/lib/python3.5/site-packages/matplotlib/__init__.py:1401: UserWarning:  This call to matplotlib.use() has no effect\n",
+      "because the backend has already been chosen;\n",
+      "matplotlib.use() must be called *before* pylab, matplotlib.pyplot,\n",
+      "or matplotlib.backends is imported for the first time.\n",
+      "\n",
+      "  warnings.warn(_use_error_msg)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:group_spectra.py:294:main:   (0000) End spectral group spectra-64-12637 at Sat Jun 17 11:48:35 2017\n",
+      "INFO:group_spectra.py:301:main: Finishing at Sat Jun 17 11:48:35 2017\n"
+     ]
+    }
+   ],
+   "source": [
+    "from desispec.scripts import group_spectra\n",
+    "args = group_spectra.parse(['--hpxnside', '64'])\n",
+    "group_spectra.main(args)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Inspect output spectra. ##\n",
+    "\n",
+    "So what did we end up with in the redux output directory?\n",
+    "* `exposures/{night}/{expid}/`: individual spectrograph camera spectra (\"frames\")\n",
+    "  grouped by night/expid\n",
+    "* `spectra-64/`: spectra grouped by healpix location on the sky"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/data/desi/spectro/redux/example\r\n",
+      "/data/desi/spectro/redux/example/exposures\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/calib-b0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/calib-r0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/calib-z0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-b0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-r0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/cframe-z0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/frame-b0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/frame-r0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/frame-z0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/sky-b0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/sky-r0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/exposures/20170615/00000000/sky-z0-00000000.fits\r\n",
+      "/data/desi/spectro/redux/example/spectra-64\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/126\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/126/12609\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/126/12609/spectra-64-12609.fits\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/126/12637\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/126/12637/spectra-64-12637.fits\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/194\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/194/19435\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/194/19435/spectra-64-19435.fits\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/194/19438\r\n",
+      "/data/desi/spectro/redux/example/spectra-64/194/19438/spectra-64-19438.fits\r\n"
+     ]
+    }
+   ],
+   "source": [
+    "reduxdir = desispec.io.specprod_root()\n",
+    "!find $reduxdir | sort"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### TODO: Example reading cframe files ###\n",
+    "\n",
+    "### TODO: Example reading spectra files ###\n"
    ]
   },
   {

--- a/py/desisim/scripts/quickgen.py
+++ b/py/desisim/scripts/quickgen.py
@@ -171,11 +171,11 @@ def parse(options=None):
             msg = 'If simspec set, must also set fibermap'
             log.error(msg)
             raise ValueError(msg)
-        hdr = fits.getheader(args.simspec)
-        night = str(hdr['NIGHT'])
-        expid = int(hdr['EXPID'])
-        args.simspec = desisim.io.findfile('simspec', night, expid)
-        args.fibermap = desispec.io.findfile('fibermap', night, expid)
+        #hdr = fits.getheader(args.simspec)
+        #night = str(hdr['NIGHT'])
+        #expid = int(hdr['EXPID'])
+        #args.simspec = desisim.io.findfile('simspec', night, expid)
+        #args.fibermap = desispec.io.findfile('fibermap', night, expid)
 
     if args.simspec is None and args.brickname is None:
         msg = 'Must have simspec and fibermap files or provide brick name'

--- a/py/desisim/scripts/quickgen.py
+++ b/py/desisim/scripts/quickgen.py
@@ -98,7 +98,7 @@ from desispec.frame import Frame
 from desispec.fiberflat import FiberFlat
 from desispec.sky import SkyModel
 from desispec.fluxcalibration import FluxCalib
-from desispec.log import get_logger, DEBUG, INFO
+from desiutil.log import get_logger, DEBUG, INFO
 from desisim.obs import get_night
 from desisim.targets import sample_objtype
 from desisim.specsim import get_simulator


### PR DESCRIPTION
This PR adds a notebook tutorial for generating simulated spectra using `quickgen`.  However, the tutorial falls apart at the end when calling `desispec.scripts.makebricks` because `$DESI_SPECTRO_SIM`, `$DESI_SPECTRO_DATA`, and `$DESI_SPECTRO_REDUX` are not playing nice and I'm utterly confused about what to update without breaking things.  

Here's the direct link to the notebook -- @sbailey and @geordie666 please take a look if you get a chance.
  https://github.com/desihub/desisim/blob/using-quickgen/doc/nb/simulating-desi-spectra.ipynb