### PR TITLE
converts to using desiutil.log instead of desispec.log

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,12 +2,13 @@
 desisim change log
 ==================
 
-0.19.1 (unreleased)
+0.20.0 (unreleased)
 -------------------
 
 * Adds tutorial on simulating spectra (`PR #244`_).
 * Fixes QSO template wavelength extrapolation (`PR #247`_);
   requires desispec > 0.15.1.
+* Uses desiutil.log instead of desispec.log
 
 .. _`PR #244`: https://github.com/desihub/desisim/pull/244
 .. _`PR #247`: https://github.com/desihub/desisim/pull/247

--- a/py/desisim/batch/__init__.py
+++ b/py/desisim/batch/__init__.py
@@ -8,7 +8,7 @@ Batch scripts.  Why exactly is this sub-package different from
 from __future__ import absolute_import, division, print_function
 import math
 
-from desispec.log import get_logger
+from desiutil.log import get_logger
 _log = get_logger()
 
 def calc_nodes(ntasks, tasktime, maxtime):

--- a/py/desisim/batch/pixsim.py
+++ b/py/desisim/batch/pixsim.py
@@ -32,7 +32,7 @@ import desispec.io
 from desisim import obs
 from desisim.batch import calc_nodes
 
-from desispec.log import get_logger
+from desiutil.log import get_logger
 log = get_logger()
 
 def batch_newexp(batchfile, flavors, nspec=5000, night=None, expids=None,

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -19,7 +19,7 @@ import desimodel.io
 import desispec.io
 from desispec.interpolation import resample_flux
 
-from desispec.log import get_logger
+from desiutil.log import get_logger
 log = get_logger()
 
 from .targets import get_targets_parallel

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -22,7 +22,7 @@ from desispec.image import Image
 import desispec.cosmics
 
 from . import obs, io
-from desispec.log import get_logger
+from desiutil.log import get_logger
 log = get_logger()
 
 def simulate_frame(night, expid, camera, ccdshape=None, **kwargs):

--- a/py/desisim/qso_template/desi_qso_templ.py
+++ b/py/desisim/qso_template/desi_qso_templ.py
@@ -23,7 +23,7 @@ import desisim.io
 
 from desispec.interpolation import resample_flux
 
-from desispec.log import get_logger
+from desiutil.log import get_logger
 log = get_logger()
 
 #from xastropy.stats.basic import perc

--- a/py/desisim/quickcat.py
+++ b/py/desisim/quickcat.py
@@ -36,7 +36,7 @@ from desitarget.targets import desi_mask
 from desitarget.targets import bgs_mask
 from desitarget.targets import mws_mask
 
-from desispec.log import get_logger
+from desiutil.log import get_logger
 log = get_logger()
 
 #- redshift errors and zwarn fractions from DESI-1657

--- a/py/desisim/scripts/brightsims.py
+++ b/py/desisim/scripts/brightsims.py
@@ -17,7 +17,7 @@ from astropy.io import fits
 from astropy.table import Table
 
 import desisim.scripts.quickgen as quickbrick
-from desispec.log import get_logger, DEBUG
+from desiutil.log import get_logger, DEBUG
 from desispec.io.util import write_bintable, makepath
 
 def parse(options=None):

--- a/py/desisim/scripts/pixsim.py
+++ b/py/desisim/scripts/pixsim.py
@@ -20,7 +20,7 @@ import desispec.io
 import desisim
 import desisim.pixsim
 from desisim import obs, io
-from desispec.log import get_logger
+from desiutil.log import get_logger
 log = get_logger()
 
 def expand_args(args):

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -20,7 +20,7 @@ import matplotlib.gridspec as gridspec
 from astropy.io import fits
 from astropy.table import Table, vstack, hstack, MaskedColumn, join
 
-from desispec.log import get_logger, DEBUG
+from desiutil.log import get_logger, DEBUG
 
 
 def calc_dz(simz_tab):

--- a/py/desisim/specsim.py
+++ b/py/desisim/specsim.py
@@ -14,8 +14,8 @@ _simulators = dict()
 #- simulator back to a reference state before returning it as a cached copy
 _simdefaults = dict()
 
-import desispec.log
-log = desispec.log.get_logger()
+import desiutil.log
+log = desiutil.log.get_logger()
 
 def get_simulator(config='desi', num_fibers=1):
     '''

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -19,7 +19,7 @@ from astropy.table import Table, Column, hstack
 from desimodel.focalplane import FocalPlane
 from desisim.io import empty_metatable, empty_star_properties
 import desimodel.io
-from desispec.log import get_logger
+from desiutil.log import get_logger
 log = get_logger()
 
 from desiutil import brick

--- a/py/desisim/test/integration_test_quickgen.py
+++ b/py/desisim/test/integration_test_quickgen.py
@@ -8,7 +8,7 @@ import sys
 import desisim.io
 import desispec.io
 import desispec.pipeline as pipe
-import desispec.log as logging
+import desiutil.log as logging
 
 desi_templates_available = 'DESI_ROOT' in os.environ
 desi_root_available = 'DESI_ROOT' in os.environ

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -13,7 +13,7 @@ from desisim import obs
 from desisim import pixsim
 import desisim.scripts.pixsim
 
-from desispec.log import get_logger
+from desiutil.log import get_logger
 log = get_logger()
 
 desi_templates_available = 'DESI_ROOT' in os.environ

--- a/py/desisim/test/test_quickgen.py
+++ b/py/desisim/test/test_quickgen.py
@@ -11,7 +11,7 @@ import desispec.io
 from desisim import io
 from desisim import obs
 from desisim.scripts import quickgen
-from desispec.log import get_logger
+from desiutil.log import get_logger
 log = get_logger()
 
 desi_templates_available = 'DESI_ROOT' in os.environ


### PR DESCRIPTION
Small change to a bunch of files: use `desiutil.log` instead of the deprecated `desispec.log`, thus avoiding warning messages.