### PR TITLE
correctly select both "bright" and "faint" BGS templates by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ env:
         # These packages will always be installed.
         - CONDA_DEPENDENCIES="scipy pyyaml"
         # These packages will only be installed for documentation builds.
-        - CONDA_SPHINX_DEPENDENCIES="scipy sphinx==1.5"
+        - CONDA_SPHINX_DEPENDENCIES="scipy pyyaml sphinx==1.5"
         # These packages will only be installed if we really need them.
         - CONDA_ALL_DEPENDENCIES="scipy matplotlib coverage==3.7.1 pyyaml qt=4 healpy"
         # These packages will always be installed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,8 +41,8 @@ env:
         # to repeat them for all configurations.
         # - NUMPY_VERSION=1.10
         # - SCIPY_VERSION=0.16
-        # - ASTROPY_VERSION=1.3.3
-        # - SPHINX_VERSION=1.3
+        - ASTROPY_VERSION=1.3.3
+        - SPHINX_VERSION=1.5
         # - DESIUTIL_VERSION=1.8.0
         - DESIUTIL_VERSION=1.9.4
         # - DESIMODEL_VERSION=0.7.0
@@ -60,6 +60,8 @@ env:
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.
         - CONDA_DEPENDENCIES="scipy pyyaml"
+        # These packages will only be installed for documentation builds.
+        - CONDA_SPHINX_DEPENDENCIES="scipy sphinx==1.5"
         # These packages will only be installed if we really need them.
         - CONDA_ALL_DEPENDENCIES="scipy matplotlib coverage==3.7.1 pyyaml qt=4 healpy"
         # These packages will always be installed.
@@ -90,6 +92,7 @@ matrix:
         # runs for a long time
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx --warning-is-error'
+               CONDA_DEPENDENCIES=$CONDA_SPHINX_DEPENDENCIES
 
           # OPTIONAL_DEPS needed because the plot_directive in sphinx needs them
           # -w is an astropy extension

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ env:
         # to repeat them for all configurations.
         # - NUMPY_VERSION=1.10
         # - SCIPY_VERSION=0.16
-        - ASTROPY_VERSION=1.3.3
+        # - ASTROPY_VERSION=1.3.3
         # - SPHINX_VERSION=1.3
         # - DESIUTIL_VERSION=1.8.0
         - DESIUTIL_VERSION=1.9.4

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -16,10 +16,13 @@ desisim change log
 * New plots for S/N of spectra for various objects (ELG, LRG, QSO) (`PR #254`_)
 * Add BGS, MWS to z_find QA
 * Miscellaneous polishing in QA (velocity, clip before RMS, extend [OII] flux, S/N per Ang)
+* Bug fix: correctly select both "bright" and "faint" BGS templates by default
+  (`PR #257`_).  
 
 .. _`PR #250`: https://github.com/desihub/desisim/pull/250
 .. _`PR #252`: https://github.com/desihub/desisim/pull/252
 .. _`PR #254`: https://github.com/desihub/desisim/pull/254
+.. _`PR #257`: https://github.com/desihub/desisim/pull/257
 
 0.20.0 (2017-07-12)
 -------------------

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -712,7 +712,7 @@ class GALAXY(object):
                 if nocolorcuts or self.colorcuts_function is None:
                     colormask = np.repeat(1, nbasechunk)
                 else:
-                    if type(self.colorcuts_function) == tuple:
+                    if isinstance(self.colorcuts_function, (tuple, list)):
                         _colormask = []
                         for cf in self.colorcuts_function:
                             _colormask.append(cf(

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -262,7 +262,10 @@ class GALAXY(object):
           wave (numpy.ndarray): Input/output observed-frame wavelength array,
             overriding the minwave, maxwave, and cdelt arguments (Angstrom).
           colorcuts_function (function name): Function to use to select
-            templates that pass the color-cuts for the specified objtype
+            templates that pass the color-cuts for the specified objtype Note
+            that this argument can also be a tuple of more than one selection
+            function to apply (e.g., desitarget.cuts.isBGS_faint and
+            desitarget.cuts.isBGS_bright) which will be applied in sequence
             (default None).
           normfilter (str): normalize each spectrum to the magnitude in this
             filter bandpass (default 'decam2014-r').
@@ -709,6 +712,8 @@ class GALAXY(object):
                 if nocolorcuts or self.colorcuts_function is None:
                     colormask = np.repeat(1, nbasechunk)
                 else:
+                    import pdb ; pdb.set_trace()
+                    
                     colormask = self.colorcuts_function(
                         gflux=synthnano['decam2014-g'],
                         rflux=synthnano['decam2014-r'],
@@ -869,11 +874,9 @@ class BGS(GALAXY):
 
         """
         if colorcuts_function is None:
-            try:
-                from desitarget.cuts import isBGS_bright as colorcuts_function
-            except:
-                from desitarget.cuts import isBGS as colorcuts_function
-                log.warning('You are using on old version of desitarget')
+            from desitarget.cuts import isBGS_bright
+            from desitarget.cuts import isBGS_faint
+            colorcuts_function = (isBGS_bright, isBGS_faint)
 
         super(BGS, self).__init__(objtype='BGS', minwave=minwave, maxwave=maxwave,
                                   cdelt=cdelt, wave=wave, colorcuts_function=colorcuts_function,

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -712,14 +712,23 @@ class GALAXY(object):
                 if nocolorcuts or self.colorcuts_function is None:
                     colormask = np.repeat(1, nbasechunk)
                 else:
-                    import pdb ; pdb.set_trace()
-                    
-                    colormask = self.colorcuts_function(
-                        gflux=synthnano['decam2014-g'],
-                        rflux=synthnano['decam2014-r'],
-                        zflux=synthnano['decam2014-z'],
-                        w1flux=synthnano['wise2010-W1'],
-                        w2flux=synthnano['wise2010-W2'])
+                    if type(self.colorcuts_function) == tuple:
+                        _colormask = []
+                        for cf in self.colorcuts_function:
+                            _colormask.append(cf(
+                                gflux=synthnano['decam2014-g'],
+                                rflux=synthnano['decam2014-r'],
+                                zflux=synthnano['decam2014-z'],
+                                w1flux=synthnano['wise2010-W1'],
+                                w2flux=synthnano['wise2010-W2']))
+                        colormask = np.any( np.ma.getdata(np.vstack(_colormask)), axis=0)
+                    else:
+                        colormask = self.colorcuts_function(
+                            gflux=synthnano['decam2014-g'],
+                            rflux=synthnano['decam2014-r'],
+                            zflux=synthnano['decam2014-z'],
+                            w1flux=synthnano['wise2010-W1'],
+                            w2flux=synthnano['wise2010-W2'])
 
                 # If the color-cuts pass then populate the output flux vector
                 # (suitably normalized) and metadata table, convolve with the


### PR DESCRIPTION
This PR fixes a bug identified by @akremin.  Previously this snippet of code would fail to return any templates fainter than `r=19.5`:
```
from desisim.templates import BGS
flux, wave, meta = BGS().make_templates(nmodel=100, rmagrange=(19, 20))
```
because the `BGS().colorcuts_function` was being set to *just* `desitarget.cuts.isBGS_bright`, which applies the magnitude cut `r<19.5` (note no equals sign).  

In this PR I allow the option of the `colorcuts_function` attribute to be a tuple and the code checks whether any (using logical or) of the "color cuts" are satisfied.  In the case of BGS these cuts are just magnitude cuts: `r<19.5` for the bright sample and `19.5<=r<20` for the faint sample.

This bug does not affect the 2% sprint simulations because there the target selection cuts were applied outside of `desisim.templates`, but this is affecting @akremin's BGS-only bright-time simulations since the magnitude priors are being passed directly to `desisim.templates` via `desisim.obs.new_exposure`.