### PR TITLE
newexp wrapper updates

### DIFF
--- a/bin/wrap-fastframe
+++ b/bin/wrap-fastframe
@@ -28,7 +28,7 @@ else:
     rank = 0
 
 #- The proceed with other imports
-import sys, os, glob, time
+import sys, os, glob, time, subprocess
 tstart = time.time()
 import numpy as np
 
@@ -89,8 +89,24 @@ if rank < len(simspecfiles):
 
         try:
             t0 = time.time()
-            desisim.scripts.fastframe.main(cmd.split()[1:])
+            logfile = filename.replace('simspec', 'fastframe').replace('.fits', '.log')
+            assert logfile != filename
+
+            #- Use subprocess.call instead of fastframe.main() to avoid
+            #- potential memory leaks and separate logging; this does incur
+            #- extra python interpreter startup time.
+            ### desisim.scripts.fastframe.main(cmd.split()[1:])
+
+            print('logging to {}'.format(logfile))
+            with open(logfile, 'w') as logx:
+                err = subprocess.call(cmd.split(), stdout=logx, stderr=logx)
+
             runtime = time.time() - t0
+            if err != 0:
+                print("ERROR: rank {} simspec {} error code {} after {:.1f} sec".format(
+                    rank, os.path.basename(filename), err, runtime))
+                raise RuntimeError
+
             print("rank {} took {:.1f} seconds for {} frame".format(rank, runtime, flavor))
             sys.stdout.flush()
         except:

--- a/bin/wrap-newexp
+++ b/bin/wrap-newexp
@@ -49,7 +49,7 @@ from astropy.table import Table
 
 from desisim.util import dateobs2night
 import desisim.io
-import desisim.scripts.newexp
+import desisim.scripts.newexp_mock
 import desisim.scripts.newflat
 import desisim.scripts.newarc
 
@@ -166,7 +166,7 @@ if rank < len(todo):
         (flavor, night, expid, obsnum, obscond) = thisobs
         assert flavor in ('science', 'arc', 'flat')
         if flavor == 'science':
-            cmd = "newexp --obslist {} --fiberassign {} --mockdir {}".format(
+            cmd = "newexp-mock --obslist {} --fiberassign {} --mockdir {}".format(
                 args.obslist, args.fiberassign, args.mockdir)
             if args.outdir is not None:
                 cmd = cmd + " --outdir {}".format(args.outdir)
@@ -189,7 +189,7 @@ if rank < len(todo):
         try:
             t0 = time.time()
             if cmd.startswith('newexp'):
-                desisim.scripts.newexp.main(cmd.split()[1:])
+                desisim.scripts.newexp_mock.main(cmd.split()[1:])
             elif cmd.startswith('newflat'):
                 desisim.scripts.newflat.main(cmd.split()[1:])
             elif cmd.startswith('newarc'):

--- a/bin/wrap-newexp
+++ b/bin/wrap-newexp
@@ -8,6 +8,10 @@ MPI wrapper for newexp
 #- from login node where MPI doesn't work
 from __future__ import absolute_import, division, print_function
 import argparse
+import subprocess
+import sys
+
+import desisim.io
 
 parser=argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
@@ -183,19 +187,33 @@ if rank < len(todo):
         #- TODO: what about logging?  Use desisim.pipe log redirection logic?
 
         print('RUNNING: {}'.format(cmd))
+        sys.stdout.flush()
         if args.dryrun:
             continue
 
         try:
             t0 = time.time()
-            if cmd.startswith('newexp'):
-                desisim.scripts.newexp_mock.main(cmd.split()[1:])
-            elif cmd.startswith('newflat'):
-                desisim.scripts.newflat.main(cmd.split()[1:])
-            elif cmd.startswith('newarc'):
-                desisim.scripts.newarc.main(cmd.split()[1:])
-            else:
-                print('ERROR: unknown command {}'.format(cmd))
+            logfile = desisim.io.findfile(
+                'simspec', night, expid).replace('.fits', '.log')
+            print('logging {}-{} {} to {}'.format(night, expid, flavor, logfile))
+
+            #- Spawn call to avoid memory leak problems from repeated
+            #- desisim.scripts.newexp_mock.main() calls within same interpreter
+            with open(logfile, 'w') as logx:
+                err = subprocess.call(cmd.split(), stdout=logx, stderr=logx)
+            # if cmd.startswith('newexp'):
+            #     desisim.scripts.newexp_mock.main(cmd.split()[1:])
+            # elif cmd.startswith('newflat'):
+            #     desisim.scripts.newflat.main(cmd.split()[1:])
+            # elif cmd.startswith('newarc'):
+            #     desisim.scripts.newarc.main(cmd.split()[1:])
+            # else:
+            #     print('ERROR: unknown command {}'.format(cmd))
+            if err != 0:
+                print('ERROR: night {} expid {} failed with error {}'.format(
+                    night, expid, err))
+                raise RuntimeError
+
             runtime = time.time() - t0
             print("{} took {:.1f} seconds".format(cmd.split()[0], runtime))
             sys.stdout.flush()

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -18,6 +18,7 @@ desisim change log
 * Miscellaneous polishing in QA (velocity, clip before RMS, extend [OII] flux, S/N per Ang)
 * Bug fix: correctly select both "bright" and "faint" BGS templates by default
   (`PR #257`_).  
+* Updates for newexp/fastframe wrappers for end-to-end sims.
 
 .. _`PR #250`: https://github.com/desihub/desisim/pull/250
 .. _`PR #252`: https://github.com/desihub/desisim/pull/252

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -18,12 +18,13 @@ desisim change log
 * Miscellaneous polishing in QA (velocity, clip before RMS, extend [OII] flux, S/N per Ang)
 * Bug fix: correctly select both "bright" and "faint" BGS templates by default
   (`PR #257`_).  
-* Updates for newexp/fastframe wrappers for end-to-end sims.
+* Updates for newexp/fastframe wrappers for end-to-end sims (`PR #258`_).
 
 .. _`PR #250`: https://github.com/desihub/desisim/pull/250
 .. _`PR #252`: https://github.com/desihub/desisim/pull/252
 .. _`PR #254`: https://github.com/desihub/desisim/pull/254
 .. _`PR #257`: https://github.com/desihub/desisim/pull/257
+.. _`PR #258`: https://github.com/desihub/desisim/pull/258
 
 0.20.0 (2017-07-12)
 -------------------

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -886,7 +886,7 @@ def simdir(night='', mkdir=False):
     Return $DESI_SPECTRO_SIM/$PIXPROD/{night}
     If mkdir is True, create directory if needed
     """
-    dirname = os.path.join(os.getenv('DESI_SPECTRO_SIM'), os.getenv('PIXPROD'), night)
+    dirname = os.path.join(os.getenv('DESI_SPECTRO_SIM'), os.getenv('PIXPROD'), str(night))
     if mkdir and not os.path.exists(dirname):
         os.makedirs(dirname)
 

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -129,9 +129,15 @@ def write_simspec(sim, truth, fibermap, obs, expid, night, outdir=None, filename
     header['NIGHT'] = night
     header['EXPTIME'] = sim.observation.exposure_time.to('s').value
     if obs is not None:
-        for key in obs.keys():
-            if key not in header:
-                header[key] = obs[key]
+        try:
+            keys = obs.keys()
+        except AttributeError:
+            keys = obs.dtype.names
+
+        for key in keys:
+            shortkey = key[0:8]  #- FITS keywords can only be 8 char
+            if shortkey not in header:
+                header[shortkey] = obs[key]
     if 'DOSVER' not in header:
         header['DOSVER'] = 'SIM'
     if 'FEEVER' not in header:

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -60,6 +60,8 @@ def findfile(filetype, night, expid, camera=None, outdir=None, mkdir=True):
         simpix = '{outdir:s}/simpix-{expid:08d}.fits',
         simfibermap = '{outdir:s}/fibermap-{expid:08d}.fits',
         pix = '{outdir:s}/pix-{camera:s}-{expid:08d}.fits',
+        fastframelog = '{outdir:s}/fastframe-{expid:08d}.log',
+        newexplog = '{outdir:s}/newexp-{expid:08d}.log',
     )
 
     #- Do we know about this kind of file?

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -175,7 +175,7 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
     if exptime is not None:
         obsconditions['EXPTIME'] = exptime
 
-    sim = simulate_spectra(wave, 1e-17*flux, fibermap=fibermap, obsconditions=obsconditions)
+    sim = simulate_spectra(wave, flux, fibermap=fibermap, obsconditions=obsconditions)
 
     #- Override $DESI_SPECTRO_DATA in order to write to simulation area
     datadir_orig = os.getenv('DESI_SPECTRO_DATA')

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -444,7 +444,9 @@ def update_obslog(obstype='science', program='DARK', expid=None, dateobs=None,
     INSERT OR REPLACE INTO obslog(expid,dateobs,night,obstype,program,tileid,ra,dec)
     VALUES (?,?,?,?,?,?,?,?)
     """
-    db.execute(insert, (expid, time.mktime(dateobs), night, obstype.upper(), program.upper(), tileid, ra, dec))
+    db.execute(insert, (int(expid), time.mktime(dateobs), str(night),
+        str(obstype.upper()), str(program.upper()), int(tileid),
+        float(ra), float(dec)))
     db.commit()
 
     return expid, dateobs

--- a/py/desisim/scripts/fastframe.py
+++ b/py/desisim/scripts/fastframe.py
@@ -22,8 +22,10 @@ def parse(options=None):
     parser = argparse.ArgumentParser(usage = "{prog} [options]")
     parser.add_argument("--simspec", type=str,  help="input simspec file")
     parser.add_argument("--outdir", type=str,  help="output directory")
-    parser.add_argument("--firstspec", type=int, default=0, help="first spectrum to simulate")
-    parser.add_argument("--nspec", type=int, default=5000, help="number of spectra to simulate")
+    parser.add_argument("--firstspec", type=int, default=0,
+                        help="first spectrum to simulate")
+    parser.add_argument("--nspec", type=int, default=5000,
+                        help="number of spectra to simulate")
 
     if options is None:
         args = parser.parse_args()
@@ -61,12 +63,13 @@ def main(args=None):
     flux = simspec.flux
     ii = slice(firstspec, firstspec+nspec)
     if simspec.flavor == 'science':
-        sim = desisim.simexp.simulate_spectra(wave, 1e-17*flux[ii], fibermap=fibermap[ii],
-            obsconditions=obs, dwave_out=1.0)
+        sim = desisim.simexp.simulate_spectra(wave, 1e-17*flux[ii],
+                fibermap=fibermap[ii], obsconditions=obs, dwave_out=1.0)
     elif simspec.flavor in ['arc', 'flat', 'calib']:
         x = fibermap['X_TARGET']
         y = fibermap['Y_TARGET']
-        fiber_area = desisim.simexp.fiber_area_arcsec2(fibermap['X_TARGET'], fibermap['Y_TARGET'])
+        fiber_area = desisim.simexp.fiber_area_arcsec2(
+                fibermap['X_TARGET'], fibermap['Y_TARGET'])
         surface_brightness = (flux.T / fiber_area).T
         config = desisim.simexp._specsim_config_for_wave(wave, dwave_out=1.0)
         # sim = specsim.simulator.Simulator(config, num_fibers=nspec)
@@ -74,7 +77,8 @@ def main(args=None):
         sim.observation.exposure_time = simspec.header['EXPTIME'] * u.s
         sbunit = 1e-17 * u.erg / (u.Angstrom * u.s * u.cm ** 2 * u.arcsec ** 2)
         xy = np.vstack([x, y]).T * u.mm
-        sim.simulate(calibration_surface_brightness=surface_brightness[ii]*sbunit, focal_positions=xy[ii])
+        sim.simulate(calibration_surface_brightness=surface_brightness[ii]*sbunit,
+                     focal_positions=xy[ii])
     else:
         raise ValueError('Unknown simspec flavor {}'.format(simspec.flavor))
 
@@ -89,7 +93,8 @@ def main(args=None):
                 results['random_noise_electrons']).T
         ivar = 1.0 / results['variance_electrons'].T
         R = Resolution(sim.instrument.cameras[i].get_output_resolution_matrix())
-        Rdata = np.tile(R.data.T, nspec).T.reshape(nspec, R.data.shape[0], R.data.shape[1])
+        Rdata = np.tile(R.data.T, nspec).T.reshape(
+                        nspec, R.data.shape[0], R.data.shape[1])
         assert np.all(Rdata[0] == R.data)
         assert phot.shape == (nspec, len(wave))
         for spectro in range(10):
@@ -105,6 +110,7 @@ def main(args=None):
             meta['CAMERA'] = camera
             frame = Frame(wave, xphot, xivar, resolution_data=Rdata[0:imax-imin],
                 spectrograph=spectro, fibermap=xfibermap, meta=meta)
-            outfile = desispec.io.findfile('frame', night, expid, camera, outdir=args.outdir)
+            outfile = desispec.io.findfile('frame', night, expid, camera,
+                                           outdir=args.outdir)
             print('writing {}'.format(outfile))
             desispec.io.write_frame(outfile, frame)

--- a/py/desisim/scripts/fastframe.py
+++ b/py/desisim/scripts/fastframe.py
@@ -63,7 +63,7 @@ def main(args=None):
     flux = simspec.flux
     ii = slice(firstspec, firstspec+nspec)
     if simspec.flavor == 'science':
-        sim = desisim.simexp.simulate_spectra(wave, 1e-17*flux[ii],
+        sim = desisim.simexp.simulate_spectra(wave, flux[ii],
                 fibermap=fibermap[ii], obsconditions=obs, dwave_out=1.0)
     elif simspec.flavor in ['arc', 'flat', 'calib']:
         x = fibermap['X_TARGET']

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -271,7 +271,7 @@ def simscience(targets, fiberassign, obsconditions='DARK', expid=None, nspec=Non
     if len(missing_keys) > 0:
         raise ValueError('obsconditions missing keys {}'.format(missing_keys))
 
-    sim = simulate_spectra(wave, 1e-17*flux, fibermap=fibermap, obsconditions=obsconditions)
+    sim = simulate_spectra(wave, flux, fibermap=fibermap, obsconditions=obsconditions)
 
     return sim, fibermap
 
@@ -339,7 +339,8 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, dwave_out=No
 
     Args:
         wave (array): 1D wavelengths in Angstroms
-        flux (array): 2D[nspec,nwave] flux in erg/s/cm2/Angstrom
+        flux (array): 2D[nspec,nwave] flux in 1e-17 erg/s/cm2/Angstrom
+            or astropy Quantity with flux units
 
     Optional:
         fibermap: table from fiberassign or fibermap; uses X/YFOCAL_DESIGN, TARGETID, DESI_TARGET
@@ -363,7 +364,7 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, dwave_out=No
 
     #- Convert to unit-ful quantities for specsim
     if not isinstance(flux, u.Quantity):
-        fluxunits = u.erg / (u.Angstrom * u.s * u.cm**2)
+        fluxunits = 1e-17 * u.erg / (u.Angstrom * u.s * u.cm**2)
         flux = flux * fluxunits
 
     if not isinstance(wave, u.Quantity):

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -271,7 +271,7 @@ def simscience(targets, fiberassign, obsconditions='DARK', expid=None, nspec=Non
     if len(missing_keys) > 0:
         raise ValueError('obsconditions missing keys {}'.format(missing_keys))
 
-    sim = simulate_spectra(wave, flux, fibermap=fibermap, obsconditions=obsconditions)
+    sim = simulate_spectra(wave, 1e-17*flux, fibermap=fibermap, obsconditions=obsconditions)
 
     return sim, fibermap
 


### PR DESCRIPTION
This PR updates the wrap-fastframe and wrap-newexp MPI wrappers as well as fixing several bugs discovered while re-establishing the full end-to-end simulation + processing chain.

An API change is that desisim.simspec.simulate_spectra() now uses 1e-17 erg/s/cm2/A as default units instead of without 1e-17 (though you can still pass it a unit-ful astropy Quantity object and it will use that).

This has been tested with the minitest branch of https://github.com/desihub/two_percent_DESI .

Comments / suggestions are welcome, but I'd like to move forward with a fresh set of tags so comments sooner than later would be much appreciated.