### PR TITLE
Fast fiber acceptance

### DIFF
--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -493,7 +493,7 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, dwave_out=No
             
             # the source position angle is in degrees
             source_position_angle = np.zeros((nspec,2))
-            random_angles = np.random.uniform(size=nspec)
+            random_angles = 360.*np.random.uniform(size=nspec)
             source_position_angle[elgs,0]=random_angles[elgs]
             source_position_angle[lrgs,1]=random_angles[lrgs]
             source_position_angle[bgss,1]=random_angles[bgss]

--- a/py/desisim/specsim.py
+++ b/py/desisim/specsim.py
@@ -41,12 +41,6 @@ def get_simulator(config='desi', num_fibers=1):
         import specsim.simulator
         qsim = specsim.simulator.Simulator(config, num_fibers)
 
-        #- TODO FIXME HACK: desimodel/specsim doesn't have BGS fiberloss yet
-        #- so scale from LRG
-        if 'bgs' not in qsim.instrument.fiber_acceptance_dict.keys():
-            log.warning('Treating BGS fiberloss = 0.5 * LRG fiberloss')
-            qsim.instrument.fiber_acceptance_dict['bgs'] = 0.5 * qsim.instrument.fiber_acceptance_dict['lrg']
-
         #- Cache defaults to reset back to original state later
         defaults = dict()
         defaults['focal_xy'] = qsim.source.focal_xy


### PR DESCRIPTION
Use the fast fiber acceptance of specsim in desisim (why two packages ...)

 - In desisim/simexp.py , for source_type = ELG or LRG , use DISK or BULGE source profiles with 0.45" and 1" half light radii. For BGS, I implemented the same parameters as for LRG. We can change this if this is not the best choice. We may also include there a range of half light radii correlated with magnitudes if needed. 

 - Added in bin/quickspectra a --source-type option to use the correct fiber aperture loss.

Code tested with quickspectra (S/N dropping by a factor 2.4 when ran with --source-type lrg or star )


