### PR TITLE
Quickgen now takes simspec moon params and fixed precedences

### DIFF
--- a/py/desisim/scripts/quickgen.py
+++ b/py/desisim/scripts/quickgen.py
@@ -465,7 +465,7 @@ def main(args):
         qsim.atmosphere.moon.moon_zenith = 100 * u.deg
 
     # Set Moon - Object Angle
-    if args.separation_angle is not None:
+    if args.moon_angle is not None:
         qsim.atmosphere.moon.separation_angle = args.moon_angle * u.deg
     elif args.simspec and 'MOONSEP' in simspec.header:
         qsim.atmosphere.moon.separation_angle = simspec.header['MOONSEP'] * u.deg


### PR DESCRIPTION
Update quickgen to define moon params, exptime, and airmass in correct order of precedence. Change default value of airmass to None! Default is maintained at 1.25 in code if passed airmass = None.