### PR TITLE
fixing MPI wrappers for pixsim

### DIFF
--- a/bin/pixsim_mpi
+++ b/bin/pixsim_mpi
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+"""
+MPI Parallel version of pixsim
+"""
+
+from desispec.parallel import use_mpi
+
+comm = None
+if use_mpi:
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+else:
+    print("mpi4py not found, using only one process")
+
+import sys
+from desisim.scripts import pixsim
+
+if __name__ == '__main__':
+    args = pixsim.parse()
+    sys.exit(pixsim.main(args, comm=comm))
+

--- a/bin/pixsim_nights
+++ b/bin/pixsim_nights
@@ -3,19 +3,10 @@
 """
 Simulate DESI spectrograph CCD images for one or more nights.
 """
-from desispec.parallel import use_mpi
-
-comm = None
-if use_mpi:
-    from mpi4py import MPI
-    comm = MPI.COMM_WORLD
-else:
-    print("mpi4py not found, using only one process")
-
 import sys
 from desisim.scripts import pixsim_nights
 
 if __name__ == '__main__':
     args = pixsim_nights.parse()
-    sys.exit(pixsim_nights.main(args, comm=comm))
+    sys.exit(pixsim_nights.main(args))
 

--- a/bin/pixsim_nights_mpi
+++ b/bin/pixsim_nights_mpi
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+"""
+Simulate DESI spectrograph CCD images for one or more nights.
+"""
+from desispec.parallel import use_mpi
+
+comm = None
+if use_mpi:
+    from mpi4py import MPI
+    comm = MPI.COMM_WORLD
+else:
+    print("mpi4py not found, using only one process")
+
+import sys
+from desisim.scripts import pixsim_nights
+
+if __name__ == '__main__':
+    args = pixsim_nights.parse()
+    sys.exit(pixsim_nights.main(args, comm=comm))
+

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -103,7 +103,8 @@ def simulate(camera, simspec, psf, fibers=None, nspec=None, ncpu=None,
             of truth for image.pix
     """
     if (comm is None) or (comm.rank == 0):
-        log.info('Starting pixsim.simulate {}'.format(asctime()))
+        log.info('Starting pixsim.simulate camera {} at {}'.format(camera,
+            asctime()))
     #- parse camera name into channel and spectrograph number
     channel = camera[0].lower()
     ispec = int(camera[1])
@@ -127,9 +128,6 @@ def simulate(camera, simspec, psf, fibers=None, nspec=None, ncpu=None,
 
         phot = np.zeros((nfibers, allphot.shape[1]))
         phot[fibers%500] = allphot[ii]
-
-        log.debug('Simulating fibers {}'.format(fibers))
-
     else:
         if ispec*nfibers >= simspec.nspec:
             msg = "camera {} not covered by simspec with {} spectra".format(
@@ -158,17 +156,19 @@ def simulate(camera, simspec, psf, fibers=None, nspec=None, ncpu=None,
         phot = phot[:, ii]
         wave = wave[ii]
 
-    #- check if simulation has less than 500 input spectra
-    if phot.shape[0] < nspec:
-        nspec = phot.shape[0]
-
     #- Project to image and append that to file
     if (comm is None) or (comm.rank == 0):
-        log.info("Projecting photons onto {} CCD".format(camera))
+        log.info('Starting {} projection at {}'.format(camera,
+            asctime()))
 
-    # The returned true pixel values will only exist on rank 0 in the
-    # MPI case.  Otherwise it will be None.
+    # The returned true pixel values are for each processes spectra.
+    # Every process is calling this independently, so we disable MPI
+    # parallelization.
     truepix = parallel_project(psf, wave, phot, ncpu=ncpu, comm=comm)
+
+    if (comm is None) or (comm.rank == 0):
+        log.info('Finished {} projection at {}'.format(camera,
+            asctime()))
 
     image = None
     rawpix = None
@@ -224,23 +224,27 @@ def simulate(camera, simspec, psf, fibers=None, nspec=None, ncpu=None,
 
         #- Amp 0 Lower Left
         rawpix[0:nyraw, 0:nxraw] = \
-            photpix2raw(pix[0:ny, 0:nx], gain, header['RDNOISE1'], readorder='lr',
-                nprescan=nprescan, noverscan=noverscan, noisydata=noisydata)
+            photpix2raw(pix[0:ny, 0:nx], gain, header['RDNOISE1'], 
+                readorder='lr', nprescan=nprescan, noverscan=noverscan,
+                noisydata=noisydata)
 
         #- Amp 2 Lower Right
         rawpix[0:nyraw, nxraw:nxraw+nxraw] = \
-            photpix2raw(pix[0:ny, nx:nx+nx], gain, header['RDNOISE2'], readorder='rl',
-                nprescan=nprescan, noverscan=noverscan, noisydata=noisydata)
+            photpix2raw(pix[0:ny, nx:nx+nx], gain, header['RDNOISE2'],
+                readorder='rl', nprescan=nprescan, noverscan=noverscan,
+                noisydata=noisydata)
 
         #- Amp 3 Upper Left
         rawpix[nyraw:nyraw+nyraw, 0:nxraw] = \
-            photpix2raw(pix[ny:ny+ny, 0:nx], gain, header['RDNOISE3'], readorder='lr',
-                nprescan=nprescan, noverscan=noverscan, noisydata=noisydata)
+            photpix2raw(pix[ny:ny+ny, 0:nx], gain, header['RDNOISE3'],
+                readorder='lr', nprescan=nprescan, noverscan=noverscan,
+                noisydata=noisydata)
 
         #- Amp 4 Upper Right
         rawpix[nyraw:nyraw+nyraw, nxraw:nxraw+nxraw] = \
-            photpix2raw(pix[ny:ny+ny, nx:nx+nx], gain, header['RDNOISE4'], readorder='rl',
-                nprescan=nprescan, noverscan=noverscan, noisydata=noisydata)
+            photpix2raw(pix[ny:ny+ny, nx:nx+nx], gain, header['RDNOISE4'],
+                readorder='rl', nprescan=nprescan, noverscan=noverscan,
+                noisydata=noisydata)
 
         def xyslice2header(xyslice):
             '''
@@ -284,7 +288,8 @@ def simulate(camera, simspec, psf, fibers=None, nspec=None, ncpu=None,
             image = Image(np.zeros(rawpix.shape), np.zeros(rawpix.shape), meta=header)
 
     if (comm is None) or (comm.rank == 0):
-        log.info('Finished pixsim.simulate {}'.format(asctime()))
+        log.info('Finished pixsim.simulate for camera {} at {}'.format(camera,
+            asctime()))
 
     return image, rawpix, truepix
 
@@ -379,7 +384,7 @@ def _project(args):
 
 
 #- Move this into specter itself?
-def parallel_project(psf, wave, phot, ncpu=None, comm=None):
+def parallel_project(psf, wave, phot, specmin=0, ncpu=None, comm=None):
     """
     Using psf, project phot[nspec, nw] vs. wave[nw] onto image
 
@@ -391,7 +396,7 @@ def parallel_project(psf, wave, phot, ncpu=None, comm=None):
         from mpi4py import MPI
         specs = np.arange(phot.shape[0], dtype=np.int32)
         myspecs = np.array_split(specs, comm.size)[comm.rank]
-        myimg = psf.project(wave, phot[myspecs])
+        myimg = psf.project(wave, phot[myspecs], specmin=(specmin+myspecs[0]))
         if comm.rank == 0:
             img = np.zeros_like(myimg)
         comm.Reduce(myimg, img, op=MPI.SUM, root=0)
@@ -403,13 +408,13 @@ def parallel_project(psf, wave, phot, ncpu=None, comm=None):
         if ncpu <= 1:
             #- Serial version
             log.debug('Not using multiprocessing (ncpu={})'.format(ncpu))
-            img = psf.project(wave, phot)
+            img = psf.project(wave, phot, specmin=specmin)
         else:
             #- multiprocessing version
             #- Split the spectra into ncpu groups
             log.debug('Using multiprocessing (ncpu={})'.format(ncpu))
             nspec = phot.shape[0]
-            iispec = np.linspace(0, nspec, ncpu+1).astype(int)
+            iispec = np.linspace(specmin, nspec, ncpu+1).astype(int)
             args = list()
             for i in range(ncpu):
                 if iispec[i+1] > iispec[i]:  #- can be false if nspec < ncpu

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -161,9 +161,8 @@ def simulate(camera, simspec, psf, fibers=None, nspec=None, ncpu=None,
         log.info('Starting {} projection at {}'.format(camera,
             asctime()))
 
-    # The returned true pixel values are for each processes spectra.
-    # Every process is calling this independently, so we disable MPI
-    # parallelization.
+    # The returned true pixel values will only exist on rank 0 in the
+    # MPI case.  Otherwise it will be None.
     truepix = parallel_project(psf, wave, phot, ncpu=ncpu, comm=comm)
 
     if (comm is None) or (comm.rank == 0):

--- a/py/desisim/scripts/pixsim.py
+++ b/py/desisim/scripts/pixsim.py
@@ -8,21 +8,22 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import os.path
-import multiprocessing as mp
+import shutil
+
 import random
 from time import asctime
 
 import numpy as np
 
 import desimodel.io
+from desiutil.log import get_logger
 import desispec.io
 from desispec.parallel import stdouterr_redirected
 
-import desisim
-import desisim.pixsim
-from desisim.io import SimSpec
-from desisim import obs, io
-from desiutil.log import get_logger
+from ..pixsim import simulate
+from ..io import SimSpec
+from .. import obs, io
+
 log = get_logger()
 
 def expand_args(args):
@@ -49,6 +50,13 @@ def expand_args(args):
             log.error(msg)
             raise ValueError(msg)
         args.simspec = io.findfile('simspec', args.night, args.expid)
+
+    if args.fibermap is None:
+        if args.night is None or args.expid is None:
+            msg = 'Must set --fibermap or both --night and --expid'
+            log.error(msg)
+            raise ValueError(msg)
+        args.fibermap = io.findfile('simfibermap', args.night, args.expid)
 
     if (args.cameras is None) and (args.spectrographs is None):
         from astropy.io import fits
@@ -82,7 +90,6 @@ def expand_args(args):
                 args.cameras.append(arm+str(ispec))
     else:
         args.cameras = args.cameras.split(',')
-
 
     #- write to same directory as simspec
     if args.rawfile is None:
@@ -132,12 +139,11 @@ def parse(options=None):
     parser.add_argument("--ccd_npix_x", type=int, help="for testing; number of x (columns) to include in output", default=None)
     parser.add_argument("--ccd_npix_y", type=int, help="for testing; number of y (rows) to include in output", default=None)
 
-    # parser.add_argument("--trimxy", action="store_true", help="Trim image to fit spectra")
     parser.add_argument("--verbose", action="store_true", help="Include debug log info")
     parser.add_argument("--overwrite", action="store_true", help="Overwrite existing raw and simpix files")
     parser.add_argument("--seed", type=int, help="random number seed")
-    parser.add_argument("--nspec", type=int, help="Number of spectra to simulate per camera %(default)s", default=500)
-    parser.add_argument("--ncpu", type=int, help="Number of cpu cores per thread to use %(default)s", default=mp.cpu_count() // 2)
+
+    parser.add_argument("--ncpu", type=int, help="Number of cpu cores per thread to use", default=0)
     parser.add_argument("--wavemin", type=float, help="Minimum wavelength to simulate")
     parser.add_argument("--wavemax", type=float, help="Maximum wavelength to simulate")
 
@@ -164,6 +170,10 @@ def main(args, comm=None):
     if comm is not None:
         rank = comm.rank
         nproc = comm.size
+    else:
+        if args.ncpu == 0:
+            import multiprocessing as mp
+            args.ncpu = mp.cpu_count() // 2
 
     if rank == 0:
         log.info('Starting pixsim at {}'.format(asctime()))
@@ -202,13 +212,22 @@ def main(args, comm=None):
             comm_group = comm.Split(color=group, key=group_rank)
             comm_rank = comm.Split(color=group_rank, key=group)
         else:
+            from mpi4py import MPI
             group = comm.rank
             ngroup = comm.size
             comm_group = MPI.COMM_SELF
             comm_rank = comm
 
-    mycameras = np.array_split(np.arange(ncamera, dtype=np.int32), 
+    group_cameras = np.array_split(np.arange(ncamera, dtype=np.int32), 
         ngroup)[group]
+
+    # Compute which spectrographs our group needs to store based on which
+    # cameras we are processing.
+
+    group_spectro = np.unique(np.array([ int(args.cameras[c][1]) for c in \
+        group_cameras ], dtype=np.int32))
+
+    # Remove outputs and or temp files
 
     rawtemp = "{}.tmp".format(args.rawfile)
     simpixtemp = "{}.tmp".format(args.simpixfile)
@@ -225,6 +244,8 @@ def main(args, comm=None):
         # cleanup stale temp files
         if os.path.isfile(rawtemp):
             os.remove(rawtemp)
+        if os.path.isfile(simpixtemp):
+            os.remove(simpixtemp)
     
     if comm is not None:
         comm.barrier()
@@ -234,41 +255,26 @@ def main(args, comm=None):
         from specter.psf import load_psf
         psf = load_psf(args.psf)
 
-    simspec = None
-    if rank == 0:
-        simspec = io.read_simspec(args.simspec)
-    if comm is not None:
-        # Broadcast one array at a time, since this is a 
-        # very large object.
-        flv = None
-        wv = None
-        pht = None
-        if simspec is not None:
-            flv = simspec.flavor
-            wv = simspec.wave
-            pht = simspec.phot
-        flv = comm.bcast(flv, root=0)
-        wv = comm.bcast(wv, root=0)
-        pht = comm.bcast(pht, root=0)
-        if simspec is None:
-            simspec = SimSpec(flv, wv, pht)
-        simspec.flux = comm.bcast(simspec.flux, root=0)
-        simspec.skyflux = comm.bcast(simspec.skyflux, root=0)
-        simspec.skyphot = comm.bcast(simspec.skyphot, root=0)
-        simspec.metadata = comm.bcast(simspec.metadata, root=0)
-        simspec.fibermap = comm.bcast(simspec.fibermap, root=0)
-        simspec.obs = comm.bcast(simspec.obs, root=0)
-        simspec.header = comm.bcast(simspec.header, root=0)
+    # Read the fibermap
 
     fibers = None
-    if args.fibermap:
-        if rank == 0:
-            fibermap = desispec.io.read_fibermap(args.fibermap)
-            fibers = fibermap['FIBER']
-            if args.nspec is not None:
-                fibers = fibers[0:args.nspec]
-        if comm is not None:
-            fibers = comm.bcast(fibers, root=0)
+    if rank == 0:
+        fibermap = desispec.io.read_fibermap(args.fibermap)
+        fibers = np.array(fibermap['FIBER'], dtype=np.int32)
+    if comm is not None:
+        fibers = comm.bcast(fibers, root=0)
+
+    fs = np.in1d(fibers//500, group_spectro)
+    group_fibers = fibers[fs]
+
+    # Read and distribute the simspec data
+
+    simspec = None
+    if comm is not None:
+        simspec = io.read_simspec_mpi(args.simspec, comm,
+            spectrographs=group_spectro)
+    else:
+        simspec = io.read_simspec(args.simspec)
 
     # Use original seed to generate different random seeds for each camera
     np.random.seed(args.seed)
@@ -278,7 +284,8 @@ def main(args, comm=None):
     rawpix = {}
     truepix = {}
 
-    for c in mycameras:
+    lastchannel = None
+    for c in group_cameras:
         camera = args.cameras[c]
         if group_rank == 0:
             log.debug('Processing camera {}'.format(camera))
@@ -296,11 +303,13 @@ def main(args, comm=None):
         # objects are not serializable, so we read it on all
         # processes.
         if args.psf is None:
-            psf = desimodel.io.load_psf(channel)
-            if args.ccd_npix_x is not None:
-                psf.npix_x = args.ccd_npix_x
-            if args.ccd_npix_y is not None:
-                psf.npix_y = args.ccd_npix_y
+            if channel != lastchannel:
+                psf = desimodel.io.load_psf(channel)
+                if args.ccd_npix_x is not None:
+                    psf.npix_x = args.ccd_npix_x
+                if args.ccd_npix_y is not None:
+                    psf.npix_y = args.ccd_npix_y
+            lastchannel = channel
 
         cosmics = None
         if args.cosmics:
@@ -320,24 +329,40 @@ def main(args, comm=None):
                 cosmics = comm_group.bcast(cosmics, root=0)
 
         #- Do the actual simulation
+        # Each process in the group is responsible for a subset of the
+        # fibers.
+
+        if group_rank == 0:
+            log.info("Group {} ({} processes) simulating camera "
+                "{}".format(group, comm_group.size, camera))
+
         image[camera], rawpix[camera], truepix[camera] = \
-            desisim.pixsim.simulate(camera, simspec, psf, fibers=fibers,
-            nspec=args.nspec, ncpu=args.ncpu, cosmics=cosmics,
-            wavemin=args.wavemin, wavemax=args.wavemax, preproc=False,
-            comm=comm_group)
+            simulate(camera, simspec, psf, fibers=group_fibers, 
+                ncpu=args.ncpu, cosmics=cosmics, 
+                wavemin=args.wavemin, wavemax=args.wavemax, preproc=False, 
+                comm=comm_group)
 
         if args.psf is None:
             del psf
 
+    # Write the cameras in order.  Only the rank zero process in each
+    # group has the data.  If we are appending new cameras to an existing
+    # raw file, then copy the original to the temporary output first.
+    # Move temp files into place
+    if rank == 0:
+        # Copy the original files into place if we are appending
+        if not args.overwrite and os.path.exists(args.rawfile):
+            shutil.copy2(args.rawfile, rawtemp)
+        if not args.overwrite and os.path.exists(args.simpixfile):
+            shutil.copy2(args.simpixfile, simpixtemp)
+    
     # Wait for all processes to finish their cameras
     if comm is not None:
         comm.barrier()
 
-    # Write the cameras in order.  Only the rank zero process in each
-    # group has the data.
     for c in np.arange(ncamera, dtype=np.int32):
         camera = args.cameras[c]
-        if c in mycameras:
+        if c in group_cameras:
             if group_rank == 0:
                 desispec.io.write_raw(rawtemp, rawpix[camera], 
                     camera=camera, header=image[camera].meta, 
@@ -362,9 +387,9 @@ def main(args, comm=None):
         if rank == 0:
             log.info('Preprocessing raw -> pix files')
         from desispec.scripts import preproc
-        if len(mycameras) > 0:
+        if len(group_cameras) > 0:
             if group_rank == 0:
-                for c in mycameras:
+                for c in group_cameras:
                     camera = args.cameras[c]
                     pixfile = desispec.io.findfile('pix', night=args.night,
                         expid=args.expid, camera=camera)

--- a/py/desisim/scripts/pixsim_nights.py
+++ b/py/desisim/scripts/pixsim_nights.py
@@ -102,8 +102,11 @@ def main(args, comm=None):
         cams = args.cameras.split(",")
     else:
         cams = []
-        for band in ['b', 'r', 'z']:
-            for spec in range(10):
+        # Do this in spectrograph order first, so that
+        # later when we distribute cameras each group will have 
+        # the minimal set of spectrographs to store.
+        for spec in range(10):
+            for band in ['b', 'r', 'z']:
                 cams.append('{}{}'.format(band, spec))
 
     # number of cameras

--- a/py/desisim/scripts/pixsim_nights.py
+++ b/py/desisim/scripts/pixsim_nights.py
@@ -130,8 +130,8 @@ def main(args, comm=None):
 
     comm_group = comm
     comm_rank = None
-    group = comm.rank
-    ngroup = comm.size
+    group = 0
+    ngroup = 1
     group_rank = 0
     if comm is not None:
         from mpi4py import MPI

--- a/py/desisim/scripts/pixsim_nights.py
+++ b/py/desisim/scripts/pixsim_nights.py
@@ -11,6 +11,7 @@ import os
 import re
 import argparse
 import traceback
+import warnings
 
 import numpy as np
 
@@ -40,8 +41,8 @@ def parse(options=None):
     parser.add_argument("--seed", type=int, default=123456, required=False, help="random number seed")
 
     parser.add_argument("--cameras", type=str, default=None, help="cameras, e.g. b0,r5,z9")
-    parser.add_argument("--camera_procs", type=int, default=1, help="Number "
-        "of MPI processes to use per camera")
+    parser.add_argument("--camera_procs", type=int, default=1, required=True,
+        help="Number of MPI processes to use per camera")
 
     args = None
     if options is None:
@@ -123,8 +124,7 @@ def main(args, comm=None):
     # create a set of reproducible seeds for each exposure
     np.random.seed(args.seed)
     maxexp = np.max(expids)
-    allseeds = np.random.randint(2**32, size=(maxexp+1))
-    seeds = allseeds[-nexp:]
+    seeds = np.random.randint(2**32, size=(maxexp+1))
 
     taskproc = ncamera * args.camera_procs
 
@@ -144,8 +144,25 @@ def main(args, comm=None):
         else:
             comm_group = MPI.COMM_SELF
             comm_rank = comm
+    else:
+        taskproc = 1
 
-    myexpids = np.array_split(expids, ngroup)[group]
+    if ngroup * taskproc != nproc:
+        msg = "Using group size {}, which does not divide evenly into total ({}).  Some processes idle.".format(taskproc, nproc)
+        if rank == 0:
+            warnings.warn(msg, RuntimeWarning)
+
+    nactive = ngroup
+    if len(expids) < ngroup:
+        msg = "There are fewer exposures ({}) than process groups ({}).  Some groups idle.".format(len(expids), ngroup)
+        if rank == 0:
+            warnings.warn(msg, RuntimeWarning)
+        nactive = len(expids)
+
+    if group > nactive - 1:
+        myexpids = np.array([], dtype=np.int32)
+    else:
+        myexpids = np.array_split(expids, nactive)[group]
 
     for ex in myexpids:
         nt = exp_to_night[ex]
@@ -201,5 +218,4 @@ def main(args, comm=None):
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
                 print("".join(lines), flush=True)
-
 

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -148,7 +148,7 @@ class TestPixsim(unittest.TestCase):
         obs.new_exposure('arc', night=night, expid=expid, nspec=nspec)
 
         #- run pixsim
-        opts = ['--night', night, '--expid', expid, '--nspec', nspec]
+        opts = ['--night', night, '--expid', expid]
         if ncpu is not None:
             opts.extend( ['--ncpu', ncpu] )
             


### PR DESCRIPTION
Submitting this PR on behalf of @tskisner after iterations with him and @julienguy about this branch and pixsim_fix (latest commit 54c4234) which addresses the same issue in a different way.

This fixes up the pixsim_nights_mpi wrapper around pixsim to work with multiple spectrographs and non-ideal packings of exposures into nodes.  It has been tested under various concurrencies and job sizes up to ~5 short nights of pixel-level simulations.  We'll proceed with this for larger runs for pipeline scaling tests.