### PR TITLE
Quickspectra

### DIFF
--- a/py/desisim/scripts/quickspectra.py
+++ b/py/desisim/scripts/quickspectra.py
@@ -258,13 +258,16 @@ def main(args=None):
     
     if isfits :
         log.info("Reading an input FITS file")
-        if not "WAVELENGTH" in hdulist :
+        if 'WAVELENGTH' in hdulist:
+            input_wave = hdulist["WAVELENGTH"].data
+        elif "WAVE" in hdulist:
+            input_wave = hdulist["WAVE"].data
+        else:
             log.error("need an HDU with EXTNAME='WAVELENGTH' with a 1D array/image of wavelength in A in vacuum")
             sys.exit(12)
         if not "FLUX" in hdulist :
             log.error("need an HDU with EXTNAME='FLUX' with a 1D or 2D array/image of flux in units of 10^-17 ergs/s/cm2/A")
             sys.exit(12)
-        input_wave = hdulist["WAVELENGTH"].data
         input_flux = hdulist["FLUX"].data
         if input_wave.size != input_flux.shape[1] :
             log.error("WAVELENGTH size {} != FLUX shape[1] = {} (NAXIS1 in fits)")

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -133,8 +133,14 @@ def simflat(flatfile, nspec=5000, nonuniform=False, exptime=10, testslit=False):
 
     #- Trim to DESI wavelength ranges
     #- TODO: is there an easier way to get these parameters?
-    wavemin = desimodel.io.load_throughput('b').wavemin
-    wavemax = desimodel.io.load_throughput('z').wavemax
+    try:
+        params = desimodel.io.load_desiparams()
+        wavemin = params['ccd']['b']['wavemin']
+        wavemax = params['ccd']['z']['wavemax']
+    except KeyError:
+        wavemin = desimodel.io.load_throughput('b').wavemin
+        wavemax = desimodel.io.load_throughput('z').wavemax
+
     ii = (wavemin <= wave) & (wave <= wavemax)
     wave = wave[ii]
     sbflux = sbflux[ii]

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -266,8 +266,13 @@ def get_targets(nspec, program, tileid=None, seed=None, specify_targets=dict(), 
     true_objtype, target_objtype = sample_objtype(nspec, program)
 
     #- Get DESI wavelength coverage
-    wavemin = desimodel.io.load_throughput('b').wavemin
-    wavemax = desimodel.io.load_throughput('z').wavemax
+    try:
+        params = desimodel.io.load_desiparams()
+        wavemin = params['ccd']['b']['wavemin']
+        wavemax = params['ccd']['z']['wavemax']
+    except KeyError:
+        wavemin = desimodel.io.load_throughput('b').wavemin
+        wavemax = desimodel.io.load_throughput('z').wavemax
     dw = 0.2
     wave = np.arange(round(wavemin, 1), wavemax, dw)
     nwave = len(wave)
@@ -437,11 +442,18 @@ def sample_nz(objtype, n):
 
 def _default_wave(wavemin=None, wavemax=None, dw=0.2):
     '''Construct and return the default wavelength vector.'''
-
+    params = desimodel.io.load_desiparams()
     if wavemin is None:
-        wavemin = desimodel.io.load_throughput('b').wavemin
+        try:
+            wavemin = params['ccd']['b']['wavemin']
+        except KeyError:
+            wavemin = desimodel.io.load_throughput('b').wavemin
     if wavemax is None:
-        wavemax = desimodel.io.load_throughput('z').wavemax
+        try:
+            wavemax = params['ccd']['z']['wavemax']
+        except KeyError:
+            wavemax = desimodel.io.load_throughput('z').wavemax
+
     wave = np.arange(round(wavemin, 1), wavemax, dw)
 
     return wave


### PR DESCRIPTION
This PR makes several small improvements to quickspectra:
* uses wavemin/wavemax from `desimodel.io.load_params()` if those parameters are available, thus enabling quickspectra to work without specter.  This requires desihub/desimodel#68 to be merged and installed, or otherwise it will continue to use specter via desimodel.io.load_throughput() to get the wavemin/max values.
* zero pads input spectra if the input wavelength coverage doesn't span the full DESI wavelength range.  It prints a warning if it does this, but it no longer crashes due to insufficient coverage.  I think this is handy, but one could reasonably argue that it is dangerous and that that user should be forced to realize that their coverage is insufficient and do something about it themselves.
* Allows an input fits spectra file to have either WAVE or WAVELENGTH, thus enabling quickspectra to directly work from a simspec file output by newexp-random or newexp-mock.