### PR TITLE
Use new arc lamp template from WINLIGHT data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ env:
         # - DESIMODEL_DATA=branches/test-0.7.0
         - DESIMODEL_VERSION=master
         - DESIMODEL_DATA=trunk
-        - DESISIM_TESTDATA_VERSION=0.3.3
+        - DESISIM_TESTDATA_VERSION=master
         - SPECLITE_VERSION=0.5
         - SPECSIM_VERSION=master
         - SPECTER_VERSION=0.7.0

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -116,7 +116,7 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
     
     if program == 'arc':
         if arc_lines_filename is None :
-            infile = os.getenv('DESI_ROOT')+'/spectro/templates/calib/v0.3/arc-lines-average-in-vacuum.fits'
+            infile = os.getenv('DESI_ROOT')+'/spectro/templates/calib/v0.4/arc-lines-average-in-vacuum-from-winlight-20170118.fits'
         else :
             infile = arc_lines_filename
         arcdata = fits.getdata(infile, 1)
@@ -135,7 +135,7 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
     
     elif program == 'flat':
         if flat_spectrum_filename is None :
-            infile = os.getenv('DESI_ROOT')+'/spectro/templates/calib/v0.3/flat-3100K-quartz-iodine.fits'
+            infile = os.getenv('DESI_ROOT')+'/spectro/templates/calib/v0.4/flat-3100K-quartz-iodine.fits'
         else :
             infile = flat_spectrum_filename
 

--- a/py/desisim/scripts/newarc.py
+++ b/py/desisim/scripts/newarc.py
@@ -22,7 +22,7 @@ def parse(options=None):
 
     if 'DESI_ROOT' in os.environ:
         _default_arcfile = os.path.join(os.getenv('DESI_ROOT'),
-            'spectro', 'templates', 'calib', 'v0.3', 'arc-lines-average-in-vacuum.fits')
+            'spectro', 'templates', 'calib', 'v0.4', 'arc-lines-average-in-vacuum-from-winlight-20170118.fits')
     else:
         _default_arcfile = None
 

--- a/py/desisim/scripts/newflat.py
+++ b/py/desisim/scripts/newflat.py
@@ -22,7 +22,7 @@ def parse(options=None):
 
     if 'DESI_ROOT' in os.environ:
         _default_flatfile = os.path.join(os.getenv('DESI_ROOT'),
-            'spectro', 'templates', 'calib', 'v0.3', 'flat-3100K-quartz-iodine.fits')
+            'spectro', 'templates', 'calib', 'v0.4', 'flat-3100K-quartz-iodine.fits')
     else:
         _default_flatfile = None
 


### PR DESCRIPTION
 - Use new arc lamp template from WINLIGHT data  (data from 2017/01/18, with a flux boost in B and Z to account for expected change of throughput)
 - File saved in $DESI_ROOT/spectro/templates/calib/v0.4 (at NERSC)
 - Changes to obs.py newarc.py  newflat.py which have a hardcoded calib version 

