### PR TITLE
wrap-fastframe and wrap-newexp updates

### DIFF
--- a/bin/wrap-fastframe
+++ b/bin/wrap-fastframe
@@ -36,6 +36,8 @@ from astropy.io import fits
 import astropy.time
 from astropy.table import Table
 
+import desispec.io
+import desispec.io.meta
 import desisim.io
 import desisim.scripts.fastframe
 
@@ -53,14 +55,35 @@ else:
 if rank == 0:
     allfiles = sorted(glob.glob('{}/*/simspec*.fits'.format(desisim.io.simdir())))
 
-    #- TODO: check if outputs already exist
+    #- Generate list of cameras
+    cameras = list()
+    for spectrograph in range(10):
+        for channel in ('b', 'r', 'z'):
+            cameras.append(channel + str(spectrograph))
 
     simspecfiles = list()
     for filename in allfiles:
         night = os.path.basename(os.path.split(filename)[0])
         if (args.start <= night) & (night < args.stop):
             flavor = fits.getval(filename, 'FLAVOR')
-            simspecfiles.append( (flavor, filename) )
+            expid = fits.getval(filename, 'EXPID')
+            if flavor not in ('flat', 'science'):
+                print('night {} expid {} is {}; skipping'.format(
+                    night, expid, flavor))
+                continue
+
+            #- This precheck could get slow; consider caching differently
+            done = True
+            for camera in cameras:
+                framefile = desispec.io.findfile('frame', night, expid, camera)
+                if not os.path.exists(framefile):
+                    simspecfiles.append( (flavor, filename) )
+                    done = False
+                    break
+
+            if done:
+                print('night {} expid {} already done; skipping'.format(
+                    night, expid))
 
     simspecfiles = sorted(simspecfiles)
 else:

--- a/bin/wrap-newexp
+++ b/bin/wrap-newexp
@@ -192,7 +192,6 @@ if rank < len(todo):
             continue
 
         try:
-            t0 = time.time()
             logfile = desisim.io.findfile(
                 'simspec', night, expid).replace('.fits', '.log')
             print('logging {}-{} {} to {}'.format(night, expid, flavor, logfile))
@@ -200,22 +199,16 @@ if rank < len(todo):
             #- Spawn call to avoid memory leak problems from repeated
             #- desisim.scripts.newexp_mock.main() calls within same interpreter
             with open(logfile, 'w') as logx:
+                t0 = time.time()
                 err = subprocess.call(cmd.split(), stdout=logx, stderr=logx)
-            # if cmd.startswith('newexp'):
-            #     desisim.scripts.newexp_mock.main(cmd.split()[1:])
-            # elif cmd.startswith('newflat'):
-            #     desisim.scripts.newflat.main(cmd.split()[1:])
-            # elif cmd.startswith('newarc'):
-            #     desisim.scripts.newarc.main(cmd.split()[1:])
-            # else:
-            #     print('ERROR: unknown command {}'.format(cmd))
-            if err != 0:
-                print('ERROR: night {} expid {} failed with error {}'.format(
-                    night, expid, err))
-                raise RuntimeError
+                runtime = time.time() - t0
+                if err == 0:
+                    print("SUCCESS: {} night {} expid {} took {:.1f} seconds".format(
+                        cmd.split()[0], night, expid,  runtime))
+                else:
+                    print('FAILED: night {} expid {}; see {}'.format(
+                        night, expid, logfile))
 
-            runtime = time.time() - t0
-            print("{} took {:.1f} seconds".format(cmd.split()[0], runtime))
             sys.stdout.flush()
         except:
             print('FAILED: {}'.format(cmd))

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,7 @@ desisim change log
 0.21.1 (unreleased)
 -------------------
 
+* Scaling updates to wrap-fastframe and wrap-newexp
 * Fix a minor units scaling bug in lya_spectra (`PR #264`_).
 
 .. _`PR #264`: https://github.com/desihub/desisim/pull/264


### PR DESCRIPTION
Small updates to `wrap-fastframe` and `wrap-newexp` while testing on the 2% redo data challenge.

`wrap-fastframe` now skips frames that have already been generated and only runs missing ones.  The check is meta-data intensive and kind of slow (~2 minutes for the 2% redo), but still faster than regenerating a bunch of frame files that already exist.  When the pipeline processing database exists, this could be updated to be more efficient.

`wrap-newexp` adding timing information to the success/fail messages.

I plan to self-merge these once Travis test pass.