### PR TITLE
qa_zfind even if specter wasn't used

### DIFF
--- a/py/desisim/scripts/qa_zfind.py
+++ b/py/desisim/scripts/qa_zfind.py
@@ -125,10 +125,15 @@ def main(args):
     # Meta data
     meta = dict(
         DESISIM = desiutil.depend.getdep(simz_tab.meta, 'desisim'),
-        SPECTER = desiutil.depend.getdep(simz_tab.meta, 'specter'),
         SPECPROD = os.getenv('SPECPROD', 'unknown'),
         PIXPROD = os.getenv('PIXPROD', 'unknown'),
         )
+    # Include specter version if it was used to generate input files
+    # (it isn't used for specsim inputs so that dependency may not exist)
+    try:
+        meta['SPECTER'] = desiutil.depend.getdep(simz_tab.meta, 'specter')
+    except KeyError:
+        pass
     
     # Run stats
     log.info("Running stats..")

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -200,7 +200,7 @@ def load_z(fibermap_files, zbest_files, outfil=None):
         try:
             zb_hdu = fits.open(zbest_file)
         except FileNotFoundError:
-            log.info("ZBEST FILE NOT FOUND.  I HOPE YOU ARE ONLY TESTING")
+            log.error("zbest file {} not found".format(zbest_file))
         else:
             zb_tabs.append(Table(zb_hdu[1].data))
 


### PR DESCRIPTION
This is a minor fix to enable `desi_qa_zfind` to work even on specsim-based simulation productions that never needed specter.  The previous code would crash if specter wasn't in the known dependencies list of header keywords.  Now that is optional.