### PR TITLE
add option to directly write cframes

### DIFF
--- a/bin/wrap-fastframe
+++ b/bin/wrap-fastframe
@@ -14,6 +14,7 @@ parser.add_argument('--dryrun', action='store_true', help="print commands but do
 parser.add_argument('--mpi', action='store_true', help="use MPI parallelism")
 parser.add_argument('--start', type=str, help="start date YEARMMDD")
 parser.add_argument('--stop', type=str, help="stop date YEARMMDD")
+parser.add_argument('--cframe',  action='store_true', help="directly write cframe")
 args = parser.parse_args()
 
 #- Load MPI and establish communication
@@ -75,7 +76,10 @@ if rank == 0:
             #- This precheck could get slow; consider caching differently
             done = True
             for camera in cameras:
-                framefile = desispec.io.findfile('frame', night, expid, camera)
+                if args.cframe :
+                    framefile = desispec.io.findfile('cframe', night, expid, camera)
+                else :
+                    framefile = desispec.io.findfile('frame', night, expid, camera)
                 if not os.path.exists(framefile):
                     simspecfiles.append( (flavor, filename) )
                     done = False
@@ -104,6 +108,8 @@ if rank < len(simspecfiles):
             cmd = cmd + " --outdir {}".format(args.outdir)
         if args.clobber:
             cmd = cmd + " --clobber"
+        if args.cframe:
+            cmd = cmd + " --cframe"
         
         print('Rank {} running {}: {}'.format(rank, flavor, cmd))
         sys.stdout.flush()

--- a/py/desisim/scripts/fastframe.py
+++ b/py/desisim/scripts/fastframe.py
@@ -116,8 +116,15 @@ def main(args=None):
             camera = '{}{}'.format(sim.camera_names[i], spectro)
             meta = simspec.header.copy()
             meta['CAMERA'] = camera
+            if args.cframe :
+                units = '1e-17 erg/(s cm2 A)'
+            else :
+                units = 'photon/bin'
+            if 'BUNIT' in meta :
+                meta['BUNIT']=units
+            
             frame = Frame(wave, xphot, xivar, resolution_data=Rdata[0:imax-imin],
-                spectrograph=spectro, fibermap=xfibermap, meta=meta)
+                          spectrograph=spectro, fibermap=xfibermap, meta=meta)
             if args.cframe :
                 outfile = desispec.io.findfile('cframe', night, expid, camera,
                                                outdir=args.outdir)
@@ -125,4 +132,4 @@ def main(args=None):
                 outfile = desispec.io.findfile('frame', night, expid, camera,
                                                outdir=args.outdir)
             print('writing {}'.format(outfile))
-            desispec.io.write_frame(outfile, frame)
+            desispec.io.write_frame(outfile, frame, units=units)


### PR DESCRIPTION
Enable fastframe and wrap_fastframe to directly write cframe files.

This is convenient to study the variation of redshift efficiency with or without the pipeline fiberflat, sky subtraction and flux calibration.

