### PR TITLE
do not add random lya forest when also reading lya forest from file

### DIFF
--- a/py/desisim/lya_spectra.py
+++ b/py/desisim/lya_spectra.py
@@ -114,7 +114,7 @@ def get_spectra(lyafile, nqso=None, wave=None, templateid=None, normfilter='sdss
     for ii, indx in enumerate(templateid):
         flux1, _, meta1 = qso.make_templates(nmodel=1, redshift=np.atleast_1d(zqso[ii]), 
                                              mag=np.atleast_1d(mag_g[ii]), seed=templateseed[ii],
-                                             nocolorcuts=nocolorcuts)
+                                             nocolorcuts=nocolorcuts, lyaforest=False)
         flux1 *= 1e-17
         for col in meta1.colnames:
             meta[col][ii] = meta1[col][0]


### PR DESCRIPTION
Tiny pull request to change the default value of lyaforest in desisim.lya_forest. @moustakas, I guess it should be trivial to merge, right? It fixes issue #291 