### PR TITLE
fix bright/dark test

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -150,7 +150,7 @@ autodoc_mock_imports = ['astropy.constants', 'astropy.cosmology',
                         'matplotlib.backends.backend_pdf', 'matplotlib.gridspec',
                         'numpy', 'scipy', 'scipy.constants',
                         'scipy.interpolate', 'scipy.special',
-                        'specsim.simulator', 'fitsio']
+                        'specsim.simulator', 'specsim.config', 'fitsio']
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -522,7 +522,6 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, dwave_out=No
             source_position_angle[elgs,0]=random_angles[elgs]
             source_position_angle[lrgs,1]=random_angles[lrgs]
             source_position_angle[bgss,1]=random_angles[bgss]
-            
     
     desi.simulate(source_fluxes=flux, focal_positions=xy, source_types=source_types,
                   source_fraction=source_fraction,

--- a/py/desisim/test/test_obs.py
+++ b/py/desisim/test/test_obs.py
@@ -115,11 +115,13 @@ class TestObs(unittest.TestCase):
         "Test different levels of sky brightness"
         night = self.night
         #- programs 'bgs' and 'bright' not yet implemented
-        sim_dark, fibermap, meta, obsconditions = obs.new_exposure('dark', nspec=10, night=night, expid=0, exptime=1000)
-        sim_mws, fibermap, meta, obsconditions  = obs.new_exposure('mws', nspec=10, night=night, expid=1, exptime=1000)
+        sim_dark, fmap_dark, meta_dark, obscond_dark = obs.new_exposure('dark', nspec=10, night=night, expid=0, exptime=1000)
+        dark = sim_dark.simulated.copy()
+        sim_mws, fmap_mws, meta_mws, obscond_mws  = obs.new_exposure('mws', nspec=10, night=night, expid=1, exptime=1000)
+        mws = sim_dark.simulated.copy()
         for channel in ['b', 'r', 'z']:
-            sky_mws = sim_mws.simulated['num_sky_electrons_'+channel]
-            sky_dark = sim_dark.simulated['num_sky_electrons_'+channel]
+            sky_mws = mws['num_sky_electrons_'+channel]
+            sky_dark = dark['num_sky_electrons_'+channel]
             nonzero = (sky_mws != 0.0)
             self.assertTrue(np.all(sky_mws[nonzero] > sky_dark[nonzero]))
 


### PR DESCRIPTION
This PR fixes #298, which turned out to be a test bug that was exposed by a different bug fix in my hotfix to desisim master this morning which was needed due to desispec dropping the Brick class (deprecated in favor of Spectra instead).