### PR TITLE
fixes quickspectra

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,11 +8,13 @@ desisim change log
 * Support new LRG templates (v2.0). (`PR #302`_).
 * Bug fixes and additional features added to SIMQSO template maker. (`PR
   #303`_).
+* Fixes quickspectra (broken by desispec change)
+* Fixes quickspectra random seed (never worked?)
 
 .. _`PR #302`: https://github.com/desihub/desisim/pull/302
 .. _`PR #303`: https://github.com/desihub/desisim/pull/303
 
-0.23.0 (unreleased)
+0.23.0 (2017-12-20)
 -------------------
 
 * Fixed crash in newexp-mock success print message.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -8,11 +8,12 @@ desisim change log
 * Support new LRG templates (v2.0). (`PR #302`_).
 * Bug fixes and additional features added to SIMQSO template maker. (`PR
   #303`_).
-* Fixes quickspectra (broken by desispec change)
-* Fixes quickspectra random seed (never worked?)
+* Fixes quickspectra (broken by desispec change) (`PR #306`_).
+* Fixes quickspectra random seed (never worked?) (`PR #306`_).
 
 .. _`PR #302`: https://github.com/desihub/desisim/pull/302
 .. _`PR #303`: https://github.com/desihub/desisim/pull/303
+.. _`PR #306`: https://github.com/desihub/desisim/pull/306
 
 0.23.0 (2017-12-20)
 -------------------

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -126,8 +126,6 @@ def simflat(flatfile, nspec=5000, nonuniform=False, exptime=10, testslit=False):
     from desiutil.log import get_logger
     log = get_logger()
 
-    random_state = np.random.RandomState(seed)
-
     log.info('Reading flat lamp spectrum from {}'.format(flatfile))
     sbflux, hdr = fits.getdata(flatfile, header=True)
     wave = desispec.io.util.header2wave(hdr)
@@ -369,6 +367,8 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None,
 
     from desiutil.log import get_logger
     log = get_logger('DEBUG')
+
+    random_state = np.random.RandomState(seed)
 
     nspec, nwave = flux.shape
 

--- a/py/desisim/test/test_quickspectra.py
+++ b/py/desisim/test/test_quickspectra.py
@@ -1,0 +1,111 @@
+import unittest, os, shutil, tempfile, subprocess
+import numpy as np
+from desisim.scripts import quickspectra
+import desispec.io
+from astropy.io import fits
+
+class TestQuickSpectra(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.origdir = os.getcwd()
+        cls.testdir = tempfile.mkdtemp()
+        os.chdir(cls.testdir)
+        cls.inspec_txt = os.path.join(cls.testdir, 'inspec.txt')
+        cls.inspec_fits = os.path.join(cls.testdir, 'inspec.fits')
+        cls.outspec1 = os.path.join(cls.testdir, 'outspec1.fits')
+        cls.outspec2 = os.path.join(cls.testdir, 'outspec2.fits')
+
+        #- Create matching inputs in both text and FITS format
+        wave = np.arange(3600, 9800, 1)
+        flux = np.random.uniform(1,2, size=(2, len(wave)))
+        with open(cls.inspec_txt, 'w') as fx:
+            for i in range(len(wave)):
+                fx.write('{} {} {}\n'.format(wave[i], flux[0,i], flux[1,i]))
+
+        hx = fits.HDUList()
+        hx.append(fits.PrimaryHDU(None))
+        hx.append(fits.ImageHDU(wave, name='WAVELENGTH'))
+        hx.append(fits.ImageHDU(flux, name='FLUX'))
+        hx.writeto(cls.inspec_fits, overwrite=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        #- Remove all test input and output files
+        os.chdir(cls.origdir)
+        if os.path.exists(cls.testdir):
+            shutil.rmtree(cls.testdir)
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        #- Remove output files but not input files
+        for filename in [self.outspec1, self.outspec2]:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+    def _check_spectra_match(self, sp1, sp2, invert=False):
+        '''
+        Check if two spectra objects match.
+
+        If invert=True, check that wavelengths match but not flux.
+        '''
+        for x in ['b', 'r', 'z']:
+            self.assertTrue(np.allclose(sp1.wave[x], sp2.wave[x]))
+            if invert:
+                self.assertFalse(np.allclose(sp1.flux[x], sp2.flux[x]))
+                self.assertFalse(np.allclose(sp1.ivar[x], sp2.ivar[x]))
+            else:
+                self.assertTrue(np.allclose(sp1.flux[x], sp2.flux[x]))
+                self.assertTrue(np.allclose(sp1.ivar[x], sp2.ivar[x]))
+
+    def test_quickspectra(self):
+        cmd = 'quickspectra -i {} -o {} --seed 1'.format(self.inspec_txt, self.outspec1)
+        opts = quickspectra.parse(cmd.split()[1:])
+        quickspectra.main(opts)
+        self.assertTrue(os.path.exists(self.outspec1))
+
+        cmd = 'quickspectra -i {} -o {} --seed 1'.format(self.inspec_fits, self.outspec2)
+        opts = quickspectra.parse(cmd.split()[1:])
+        quickspectra.main(opts)
+        self.assertTrue(os.path.exists(self.outspec2))
+
+        sp1 = desispec.io.read_spectra(self.outspec1)
+        sp2 = desispec.io.read_spectra(self.outspec2)
+        self._check_spectra_match(sp1, sp2)
+
+        #- Different seed should result in different spectra
+        cmd = 'quickspectra -i {} -o {} --seed 2'.format(self.inspec_fits, self.outspec2)
+        opts = quickspectra.parse(cmd.split()[1:])
+        quickspectra.main(opts)
+        self.assertTrue(os.path.exists(self.outspec2))
+        sp2 = desispec.io.read_spectra(self.outspec2)
+        self._check_spectra_match(sp1, sp2, invert=True)
+
+        #- FITS output
+        cmd = 'quickspectra -i {} -o {} --seed 1'.format(self.inspec_fits, self.outspec2)
+        opts = quickspectra.parse(cmd.split()[1:])
+        quickspectra.main(opts)
+        self.assertTrue(os.path.exists(self.outspec2))
+        sp2 = desispec.io.read_spectra(self.outspec2)
+        self._check_spectra_match(sp1, sp2)
+
+        #- Changing moon paramters should change spectra
+        cmd = 'quickspectra -i {} -o {} --seed 1'.format(self.inspec_fits, self.outspec2)
+        cmd += ' --moonfrac 0.9 --moonalt 80 --moonsep 10'
+        opts = quickspectra.parse(cmd.split()[1:])
+        quickspectra.main(opts)
+        self.assertTrue(os.path.exists(self.outspec2))
+        sp2 = desispec.io.read_spectra(self.outspec2)
+        self._check_spectra_match(sp1, sp2, invert=True)
+
+if __name__ == '__main__':
+    unittest.main()
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m desisim.test.test_quickspectra
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)


### PR DESCRIPTION
This PR
* fixes quickspectra, which was broken by [desispec PR #473](https://github.com/desihub/desispec/pull/473) removing `desispec.spectra.spectra_dtype`.  Thanks to @paulmartini for reporting.
* Adds quickspectra tests that would have caught that bug.
* Fixes quickspectra --seed option, which appears to have never worked due to randomness in specsim quick fiberloss calculations (see [specsim #83](https://github.com/desihub/specsim/issues/83)).  This is also included in the unit tests now.

Unfortunately quickspectra is broken in the desisim 0.23.0 tag used by the desimodules 17.12 release, but this PR restores it to working in master for the next tag and includes basic tests to keep it working.