### PR TITLE
optionally do not wavelength resample the QSO templates 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
         # - SCIPY_VERSION=0.16
         - ASTROPY_VERSION=1.3.3
         - SPHINX_VERSION=1.5
-        - DESIUTIL_VERSION=1.9.8
+        - DESIUTIL_VERSION=1.9.9
         # - DESIMODEL_VERSION=0.7.0
         # - DESIMODEL_DATA=branches/test-0.7.0
         - DESIMODEL_VERSION=master

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -9,11 +9,12 @@ desisim change log
 * Bug fixes and additional features added to SIMQSO template maker. (`PR
   #303`_).
 * Fixes quickspectra (broken by desispec change) (`PR #306`_).
-* Fixes quickspectra random seed (never worked?) (`PR #306`_).
+* Optionally do not wavelength resample simqso templates (`PR #310`_).
 
 .. _`PR #302`: https://github.com/desihub/desisim/pull/302
 .. _`PR #303`: https://github.com/desihub/desisim/pull/303
 .. _`PR #306`: https://github.com/desihub/desisim/pull/306
+.. _`PR #310`: https://github.com/desihub/desisim/pull/310
 
 0.23.0 (2017-12-20)
 -------------------

--- a/py/desisim/lya_spectra.py
+++ b/py/desisim/lya_spectra.py
@@ -57,7 +57,7 @@ def apply_lya_transmission(qso_wave,qso_flux,trans_wave,trans) :
     
     output_flux = qso_flux.copy()
     for q in range(qso_flux.shape[0]) :
-        output_flux[q] *= np.interp(qso_wave,trans_wave,trans[q],left=0,right=1)
+        output_flux[q, :] *= np.interp(qso_wave,trans_wave,trans[q, :],left=0,right=1)
     return output_flux
 
 
@@ -117,7 +117,7 @@ def get_spectra(lyafile, nqso=None, wave=None, templateid=None, normfilter='sdss
         templateid = np.arange(nqso)
     else:
         templateid = np.asarray(templateid)
-        nqso = len(templateid)
+        nqso = len(np.atleast_1d(templateid))
 
     if rand is None:
         rand = np.random.RandomState(seed)

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -2203,8 +2203,8 @@ class SIMQSO():
             return outflux, meta, qsometa
 
     def make_templates(self, nmodel=100, zrange=(0.5, 4.0), rmagrange=(19.0, 23.0),
-                       seed=None, redshift=None, input_meta=None, input_qsometa=None,
-                       maxiter=20, lyaforest=True, nocolorcuts=False, noresample=False,
+                       seed=None, redshift=None, input_qsometa=None, maxiter=20,
+                       lyaforest=True, nocolorcuts=False, noresample=False,
                        return_qsometa=False, verbose=False):
         """Build Monte Carlo QSO spectra/templates.
 
@@ -2240,20 +2240,24 @@ class SIMQSO():
           mag (float, optional): Input/output template magnitudes in the band
             specified by self.normfilter.  Array size must equal nmodel.
             Ignores rmagrange input.
-          input_meta (astropy.Table): *Input* metadata table with the following
-            required columns: SEED, REDSHIFT, and MAG (where mag is specified by
-            self.normfilter).  See desisim.io.empty_metatable for the required
-            data type for each column.  If this table is passed then all other
-            optional inputs (nmodel, redshift, mag, zrange, rmagrange, etc.) are
-            ignored.
+          input_qsometa (simqso.sqgrids.QsoSimPoints or FITS filename): *Input*
+            QsoSimPoints object or FITS filename (with a 'QSOMETA' HDU) from
+            which to (re)generate the QSO spectra.  All other inputs are ignored
+            when this optional input is present.
           maxiter (int): maximum number of iterations for findng a template that
             satisfies the color-cuts (default 20).
           lyaforest (bool, optional): Include Lyman-alpha forest absorption
             (default True).
-          noresample (bool, optional): Do not resample the QSO spectra in
-            wavelength (default False).
           nocolorcuts (bool, optional): Do not apply the fiducial rzW1W2 color-cuts
             cuts (default False).
+          noresample (bool, optional): Do not resample the QSO spectra in
+            wavelength (default False).
+          return_qsometa (bool, optional): Optionally return the full
+            simqso.sqgrids.QsoSimPoints object, which contains all the data
+            necessary to regenerate the QSO spectra.  In particular, the data
+            attribute is an astropy.Table object which contains lots of useful
+            info.  This object can be written to disk with the
+            simqso.sqgrids.QsoSimObjects.write method.
           verbose (bool, optional): Be verbose!
 
         Returns (outflux, wave, meta) tuple where:


### PR DESCRIPTION
This PR is tangentially related to #297.  It adds the option of not resampling the QSO templates in wavelength, which may be necessary when applying the Lya forest transmission *outside* (i.e., after) making the templates (also softly related to https://github.com/desihub/desitarget/issues/252).

This PR also adds the documentation requested by @sbailey in #303.  See also cells [32-38] of the [simqso-templates notebook](https://github.com/desihub/desisim/blob/master/doc/nb/simqso-templates.ipynb) for a demonstration of how the `qsometa` object can be used to regenerate simqso templates.