### PR TITLE
changes to speed up MPI by reducing amount of broadcast data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
         # - SCIPY_VERSION=0.16
         - ASTROPY_VERSION=1.3.3
         - SPHINX_VERSION=1.5
-        - DESIUTIL_VERSION=1.9.8
+        - DESIUTIL_VERSION=1.9.9
         # - DESIMODEL_VERSION=0.7.0
         # - DESIMODEL_DATA=branches/test-0.7.0
         - DESIMODEL_VERSION=master

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,10 +10,12 @@ desisim change log
   #303`_).
 * Fixes quickspectra (broken by desispec change) (`PR #306`_).
 * Fixes quickspectra random seed (never worked?) (`PR #306`_).
+* Improves pixsim_mpi performance (`PR #312`_).
 
 .. _`PR #302`: https://github.com/desihub/desisim/pull/302
 .. _`PR #303`: https://github.com/desihub/desisim/pull/303
 .. _`PR #306`: https://github.com/desihub/desisim/pull/306
+.. _`PR #312`: https://github.com/desihub/desisim/pull/312
 
 0.23.0 (2017-12-20)
 -------------------

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -536,10 +536,6 @@ def read_simspec_mpi(filename, comm, channel, spectrographs=None):
     if comm.rank == 0:
         hdus.close()
 
-
-    #weird things are happening, try deleting
-    del shape_dict
-
     return SimSpec(flavor, wave, phot, flux=flux, skyflux=skyflux,
         skyphot=skyphot, metadata=metadata, fibermap=fibermap, obs=obs,
         header=hdr)

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -329,8 +329,6 @@ def read_simspec_mpi(filename, comm, spectrographs=None):
     # rank 0 opens file and gets the metadata and wavelength
     # grids, which will be kept on all processes.
 
-    # set a counter so we only open files and store data one time
-    counter=0
 
     hdr = None
     flavor = None

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -81,7 +81,7 @@ def simulate_frame(night, expid, camera, ccdshape=None, **kwargs):
     desispec.io.write_image(pixfile, image)
 
 
-def simulate(camera, channel, simspec, psf, fibers=None, nspec=None, ncpu=None,
+def simulate(camera, simspec, psf, fibers=None, nspec=None, ncpu=None,
     cosmics=None, wavemin=None, wavemax=None, preproc=True, comm=None):
     """Run pixel-level simulation of input spectra
 
@@ -107,8 +107,7 @@ def simulate(camera, channel, simspec, psf, fibers=None, nspec=None, ncpu=None,
         log.info('Starting pixsim.simulate camera {} at {}'.format(camera,
             asctime()))
     #- parse camera name into channel and spectrograph number
-    #channel = camera[0].lower()
-    #instead feed current channel as input   
+    channel = camera[0].lower()
 
     ispec = int(camera[1])
     assert channel in 'brz', 'unrecognized channel {} camera {}'.format(channel, camera)

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -81,7 +81,7 @@ def simulate_frame(night, expid, camera, ccdshape=None, **kwargs):
     desispec.io.write_image(pixfile, image)
 
 
-def simulate(camera, simspec, psf, fibers=None, nspec=None, ncpu=None,
+def simulate(camera, channel, simspec, psf, fibers=None, nspec=None, ncpu=None,
     cosmics=None, wavemin=None, wavemax=None, preproc=True, comm=None):
     """Run pixel-level simulation of input spectra
 
@@ -102,11 +102,14 @@ def simulate(camera, simspec, psf, fibers=None, nspec=None, ncpu=None,
             ndarray of unprocessed raw pixel data, and truepix is a 2D ndarray
             of truth for image.pix
     """
+
     if (comm is None) or (comm.rank == 0):
         log.info('Starting pixsim.simulate camera {} at {}'.format(camera,
             asctime()))
     #- parse camera name into channel and spectrograph number
-    channel = camera[0].lower()
+    #channel = camera[0].lower()
+    #instead feed current channel as input   
+
     ispec = int(camera[1])
     assert channel in 'brz', 'unrecognized channel {} camera {}'.format(channel, camera)
     assert 0 <= ispec < 10, 'unrecognized spectrograph {} camera {}'.format(ispec, camera)

--- a/py/desisim/scripts/pixsim.py
+++ b/py/desisim/scripts/pixsim.py
@@ -272,7 +272,7 @@ def main(args, comm=None):
         psf = load_psf(args.psf)
 
     # Read and distribute the simspec data
-    # use collections library to create list of tuples
+    # create list of tuples
     camera_channel_list=[]
     if comm is not None:
         if rank == 0:

--- a/py/desisim/scripts/pixsim.py
+++ b/py/desisim/scripts/pixsim.py
@@ -382,7 +382,7 @@ def main(args, comm=None):
     
             #try passing in current camera so we don't hit a key error
             image[camera], rawpix[camera], truepix[camera] = \
-                simulate(camera, channel, simspec, psf, fibers=group_fibers, 
+                simulate(camera, simspec, psf, fibers=group_fibers, 
                     ncpu=args.ncpu, nspec=args.nspec, cosmics=cosmics, 
                     wavemin=args.wavemin, wavemax=args.wavemax, preproc=False,
                     comm=comm_group)
@@ -452,7 +452,7 @@ def main(args, comm=None):
                     "{}".format(group, group_size, camera))
 
             image[camera], rawpix[camera], truepix[camera] = \
-                simulate(camera, channel, simspec, psf, fibers=group_fibers, 
+                simulate(camera, simspec, psf, fibers=group_fibers, 
                     ncpu=args.ncpu, nspec=args.nspec, cosmics=cosmics, 
                     wavemin=args.wavemin, wavemax=args.wavemax, preproc=False,
                     comm=comm_group)


### PR DESCRIPTION
Changed MPI bcast to Bcast to take advantage of faster numpy arrays vs slower python objects. Instead of preallocating as 'None', this required a little more work to correctly pre-allocate the empty numpy broadcast arrays. 

Speed testing is still in progress, but on a single node for a single processor (Haswell), the runtime for the MPI version is approximately 7 percent slower than the multiprocessing version. As the number of processes grow, MPI becomes increasingly slower than multiprocessing due to overhead. This may need to be improved in the future with functions like MPI scatter and gather, rather than broadcast. 