### PR TITLE
fix double PSF convolution in pixsim

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desisim change log
 0.24.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Fix double PSF convolution in pixsims.
 
 0.24.0 (2018-01-30)
 -------------------

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -184,9 +184,9 @@ def write_simspec(sim, truth, fibermap, obs, expid, night, outdir=None, filename
     hx.append(hdu_skyflux)
 
     #- DEPRECATE?  per-camera photons (derivable from flux and throughput)
-    for i, camera in enumerate(sorted(sim.camera_names)):
-        wavemin = sim.camera_output[i]['wavelength'][0]
-        wavemax = sim.camera_output[i]['wavelength'][-1]
+    for i, camera in enumerate(sim.camera_names):
+        wavemin = sim.instrument.cameras[i].wavelength_min.to('Angstrom').value
+        wavemax = sim.instrument.cameras[i].wavelength_max.to('Angstrom').value
         ii = (wavemin <= wave) & (wave <= wavemax)
         hx.append(fits.ImageHDU(wave[ii], name='WAVE_'+camera.upper()))
 

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -141,7 +141,8 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
 
         if exptime is None:
             exptime = 10
-        sim, fibermap = desisim.simexp.simflat(infile, nspec=nspec, exptime=exptime, testslit=testslit)
+        sim, fibermap = desisim.simexp.simflat(infile, nspec=nspec,
+            exptime=exptime, testslit=testslit, camera_output=False)
 
         header['EXPTIME'] = exptime
         header['FLAVOR'] = 'flat'
@@ -182,7 +183,8 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
     if exptime is not None:
         obsconditions['EXPTIME'] = exptime
 
-    sim = simulate_spectra(wave, flux, fibermap=fibermap, obsconditions=obsconditions)
+    sim = simulate_spectra(wave, flux, fibermap=fibermap,
+        obsconditions=obsconditions, camera_output=False)
 
     #- Write fibermap
     telera, teledec = io.get_tile_radec(tileid)

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -105,7 +105,8 @@ def simarc(arcdata, nspec=5000, nonuniform=False, testslit=False):
 
     return wave, phot, fibermap
 
-def simflat(flatfile, nspec=5000, nonuniform=False, exptime=10, testslit=False):
+def simflat(flatfile, nspec=5000, nonuniform=False, exptime=10, testslit=False,
+    camera_output=True):
     '''
     Simulates a flat lamp calibration exposure
 
@@ -116,6 +117,8 @@ def simflat(flatfile, nspec=5000, nonuniform=False, exptime=10, testslit=False):
         nspec: (int) number of spectra to simulate
         nonuniform: (bool) include calibration screen non-uniformity
         exptime: (float) exposure time in seconds
+        camera_output: (bool) passed to simspec.simulator.Simulator.
+            if True, convolve with PSF and include per-camera outputs
 
     Returns: (sim, fibermap)
         sim: specsim Simulator object
@@ -177,7 +180,8 @@ def simflat(flatfile, nspec=5000, nonuniform=False, exptime=10, testslit=False):
     config = _specsim_config_for_wave(wave)
     log.debug('Creating specsim simulator for {} spectra'.format(nspec))
     # sim = specsim.simulator.Simulator(config, num_fibers=nspec)
-    sim = desisim.specsim.get_simulator(config, num_fibers=nspec)
+    sim = desisim.specsim.get_simulator(config, num_fibers=nspec,
+        camera_output=camera_output)
     sim.observation.exposure_time = exptime * u.s
     log.debug('Simulating')
     sim.simulate(calibration_surface_brightness=sbflux, focal_positions=xy)
@@ -340,7 +344,7 @@ def fibermeta2fibermap(fiberassign, meta):
 #- specsim related routines
 
 def simulate_spectra(wave, flux, fibermap=None, obsconditions=None,
-    dwave_out=None, seed=None):
+    dwave_out=None, seed=None, camera_output=True):
     '''
     Simulates an exposure without reading/writing data files
 
@@ -355,6 +359,8 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None,
             SEEING (arcsec), EXPTIME (sec), AIRMASS,
             MOONFRAC (0-1), MOONALT (deg), MOONSEP (deg)
         seed: (int) random seed
+        camera_output: (bool) passed to simspec.simulator.Simulator.
+            if True, convolve with PSF and include per-camera outputs
 
     TODO: galsim support
 
@@ -386,7 +392,8 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None,
     #- Create simulator
     log.debug('creating specsim desi simulator')
     # desi = specsim.simulator.Simulator(config, num_fibers=nspec)
-    desi = desisim.specsim.get_simulator(config, num_fibers=nspec)
+    desi = desisim.specsim.get_simulator(config, num_fibers=nspec,
+        camera_output=camera_output)
 
     if obsconditions is None:
         log.warning('Assuming DARK conditions')

--- a/py/desisim/specsim.py
+++ b/py/desisim/specsim.py
@@ -20,7 +20,7 @@ from specsim.config import Configuration
 import desiutil.log
 log = desiutil.log.get_logger()
 
-def get_simulator(config='desi', num_fibers=1):
+def get_simulator(config='desi', num_fibers=1, camera_output=True):
     '''
     returns new or cached specsim.simulator.Simulator object
 
@@ -29,9 +29,9 @@ def get_simulator(config='desi', num_fibers=1):
     if isinstance(config, Configuration):
         w = config.wavelength
         wavehash = (np.min(w), np.max(w), len(w))
-        key = (config.name, wavehash, num_fibers)
+        key = (config.name, wavehash, num_fibers, camera_output)
     else:
-        key = (config, num_fibers)
+        key = (config, num_fibers, camera_output)
 
     if key in _simulators:
         log.debug('Returning cached {} Simulator'.format(key))
@@ -49,7 +49,8 @@ def get_simulator(config='desi', num_fibers=1):
 
         #- New config; create Simulator object
         import specsim.simulator
-        qsim = specsim.simulator.Simulator(config, num_fibers)
+        qsim = specsim.simulator.Simulator(config, num_fibers,
+            camera_output=camera_output)
 
         #- Cache defaults to reset back to original state later
         defaults = dict()


### PR DESCRIPTION
This PR does the minimal change to fix #318, where @julienguy noticed that the pixsims were getting double convolved by the PSF.  The fix is to use `specsim.simulator.Simulator(camera_output=False)` and write the unconvolved electrons to the simspec output files.

fastframe uses the FLUX (not PHOT) HDUs so isn't impacted.  This fix is fragile since it risks us making the opposite mistake later and thinking that the simspec PHOT HDUs are convolved when now they aren't.  A better long term solution would be to store just the FLUX in the simspec files, and re-run specsim on-the-fly for pixsim as is done for fastframe.  However, @lastephey is in the middle of refactoring the MPI pixsims to improve it's performance and I want to let that settle before making another change on top of it.

Comparison plot showing that the new simspec CCD photons are not convolved, how much better the sky lines appear in the 2D images, and how the fastframe outputs are not impacted:
![convolve_comparison](https://user-images.githubusercontent.com/218471/35718144-f8dfec02-0797-11e8-8a02-fdba1312c2cc.png)

For the record:
```
#- Using master:
newexp-random --program elg --nspec 5 --seed 1
#- Then using pixsim-no-convolve branch:
newexp-random --program elg --nspec 5 --seed 1

fastframe --simspec simspec-00000000.fits --outdir .
fastframe --simspec simspec-00000001.fits --outdir .

pixsim --psf /Users/sbailey/desi/git/desimodel/svn/trunk/data/specpsf/psf-r.fits --simspec simspec-00000000.fits --rawfile desi-0.fits.fz --cameras r0 --nspec 5 --wavemin 6280 --wavemax 6320
pixsim --psf /Users/sbailey/desi/git/desimodel/svn/trunk/data/specpsf/psf-r.fits --simspec simspec-00000001.fits --rawfile desi-1.fits.fz --cameras r0 --nspec 5 --wavemin 6280 --wavemax 6320

#- from ipython --pylab
from astropy.io import fits
import desisim.io
import desispec.io

s0 = desisim.io.read_simspec('simspec-00000000.fits')
s1 = desisim.io.read_simspec('simspec-00000001.fits')
r0 = fits.getdata('desi-0.fits.fz')
r1 = fits.getdata('desi-1.fits.fz')
f0 = desispec.io.read_frame('frame-r0-00000000.fits')
f1 = desispec.io.read_frame('frame-r0-00000001.fits')

clf()
subplot(311)
plot(s0.wave['r'], s0.skyphot['r'][0], label='master')
plot(s1.wave['r'], s1.skyphot['r'][0], label='new')
xlim(6280, 6320)
text(6282, 20000, 'simspec PHOT')
legend()

subplot(323)
imshow(r0[1290:1340, 170:220])
text(5, 40, 'master', color='y')
xlabel('master')

subplot(324)
imshow(r1[1290:1340, 170:220])
text(5, 40, 'new', color='y')
xlabel('new')

subplot(313)
plot(f0.wave, f0.flux[0], label='master')
plot(f1.wave, f1.flux[0], '--', label='new')
xlim(6280, 6320)
text(6282, 20000, 'fastframe output')
legend()
```