### PR TITLE
update desitarget.targetmask.desi_mask imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,16 +46,15 @@ env:
         - DESIUTIL_VERSION=1.9.9
         # - DESIMODEL_VERSION=0.7.0
         # - DESIMODEL_DATA=branches/test-0.7.0
-        - DESIMODEL_VERSION=master
-        - DESIMODEL_DATA=trunk
-        - DESISIM_TESTDATA_VERSION=master
+        - DESIMODEL_VERSION=0.9.1
+        - DESIMODEL_DATA=branches/test-0.9
+        - DESISIM_TESTDATA_VERSION=0.4.0
         - SPECLITE_VERSION=0.7
-        - SPECSIM_VERSION=master
-        - SPECTER_VERSION=0.7.0
-        - DESISPEC_VERSION=master
-        - DESITARGET_VERSION=master
+        - SPECSIM_VERSION=v0.11
+        - SPECTER_VERSION=0.8.3
+        - DESISPEC_VERSION=0.18.0
+        - DESITARGET_VERSION=0.19.0
         - SIMQSO_VERSION=v1.2.1
-        # - DESIMODEL_VERSION=trunk
         - DESI_LOGLEVEL=DEBUG
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ env:
         - DESIUTIL_VERSION=1.9.9
         # - DESIMODEL_VERSION=0.7.0
         # - DESIMODEL_DATA=branches/test-0.7.0
-        - DESIMODEL_VERSION=0.9.1
-        - DESIMODEL_DATA=branches/test-0.9
+        - DESIMODEL_VERSION=0.9.2
+        - DESIMODEL_DATA=tags/0.9.2
         - DESISIM_TESTDATA_VERSION=0.4.0
         - SPECLITE_VERSION=0.7
         - SPECSIM_VERSION=v0.11
@@ -62,7 +62,7 @@ env:
         # These packages will only be installed for documentation builds.
         - CONDA_SPHINX_DEPENDENCIES="scipy pyyaml sphinx==1.5"
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES="scipy matplotlib coverage==3.7.1 pyyaml"
+        - CONDA_ALL_DEPENDENCIES="scipy matplotlib coverage==3.7.1 pyyaml numba"
         # These packages will always be installed.
         - PIP_DEPENDENCIES=""
         # These packages will only be installed if we really need them.

--- a/py/desisim/quickcat.py
+++ b/py/desisim/quickcat.py
@@ -32,9 +32,7 @@ from desisim.targets import get_simtype
 import astropy.constants
 c = astropy.constants.c.to('km/s').value
 
-from desitarget.targets import desi_mask
-from desitarget.targets import bgs_mask
-from desitarget.targets import mws_mask
+from desitarget.targetmask import desi_mask, bgs_mask, mws_mask
 
 from desiutil.log import get_logger
 log = get_logger()
@@ -553,7 +551,7 @@ def get_median_obsconditions(tileids):
     obsconditions['SEEING'] = np.ones(n) * 1.1
 
     #- Add lunar conditions, defaulting to dark time
-    from desitarget import obsconditions as obsbits
+    from desitarget.targetmask import obsconditions as obsbits
     obsconditions['MOONFRAC'] = np.zeros(n)
     obsconditions['MOONALT'] = -20.0 * np.ones(n)
     obsconditions['MOONSEP'] = 180.0 * np.ones(n)

--- a/py/desisim/quicksurvey.py
+++ b/py/desisim/quicksurvey.py
@@ -27,7 +27,7 @@ import fitsio
 import desitarget.mtl
 from desisim.quickcat import quickcat
 from astropy.table import join
-from desitarget.targets import desi_mask
+from desitarget.targetmask import desi_mask
 
 class SimSetup(object):
     """Setup to simulate the DESI survey

--- a/py/desisim/scripts/quickspectra.py
+++ b/py/desisim/scripts/quickspectra.py
@@ -71,7 +71,7 @@ def sim_spectra(wave, flux, program, spectra_filename, obsconditions=None,
     frame_fibermap.meta["EXPID"]=expid
     
     # add DESI_TARGET 
-    tm = desitarget.desi_mask    
+    tm = desitarget.targetmask.desi_mask
     frame_fibermap['DESI_TARGET'][sourcetype=="star"]=tm.STD_FSTAR
     frame_fibermap['DESI_TARGET'][sourcetype=="lrg"]=tm.LRG
     frame_fibermap['DESI_TARGET'][sourcetype=="elg"]=tm.ELG

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -13,6 +13,7 @@ from astropy.io import fits
 import fitsio
 
 import desitarget
+import desitarget.targetmask
 import desispec.io
 import desispec.io.util
 import desimodel.io
@@ -293,7 +294,7 @@ def fibermeta2fibermap(fiberassign, meta):
     A future refactor will standardize the column names of fiber assignment,
     target catalogs, and fibermaps, but in the meantime this is needed.
     '''
-    from desitarget import desi_mask
+    from desitarget.targetmask import desi_mask
 
     #- Copy column names in common
     fibermap = desispec.io.empty_fibermap(len(fiberassign))
@@ -629,7 +630,7 @@ def get_source_types(fibermap):
     source_type = np.zeros(len(fibermap), dtype='U4')
     assert np.all(source_type == '')
 
-    tm = desitarget.desi_mask
+    tm = desitarget.targetmask.desi_mask
     if 'TARGETID' in fibermap.dtype.names:
         unassigned = fibermap['TARGETID'] == -1
         source_type[unassigned] = 'sky'
@@ -722,7 +723,7 @@ def get_mock_spectra(fiberassign, mockdir=None):
     meta = None
     wave = None
 
-    issky = (fiberassign['DESI_TARGET'] & desitarget.desi_mask.SKY) != 0
+    issky = (fiberassign['DESI_TARGET'] & desitarget.targetmask.desi_mask.SKY) != 0
     skyids = fiberassign['TARGETID'][issky]
 
     for truthfile, targetids in zip(*targets2truthfiles(fiberassign, basedir=mockdir)):

--- a/py/desisim/spec_qa/utils.py
+++ b/py/desisim/spec_qa/utils.py
@@ -80,7 +80,7 @@ def match_otype(tbl, objtype):
     :param objtype: str
     :return: targets: bool mask
     """
-    from desitarget import desi_mask
+    from desitarget.targetmask import desi_mask
     if objtype in ['BGS']:
         targets = (tbl['DESI_TARGET'] & desi_mask['BGS_ANY']) != 0
     elif objtype in ['MWS']:

--- a/py/desisim/test/test_quickcat.py
+++ b/py/desisim/test/test_quickcat.py
@@ -4,7 +4,7 @@ import unittest
 from astropy.table import Table, Column
 from astropy.io import fits
 from desisim.quickcat import quickcat
-from desitarget import desi_mask, bgs_mask, mws_mask
+from desitarget.targetmask import desi_mask, bgs_mask, mws_mask
 import desimodel.io
 
 class TestQuickCat(unittest.TestCase):


### PR DESCRIPTION
This PR updates the imports of `desitarget.targetmask.desi_mask`, `bgs_mask`, etc. after the restructuring from desihub/desitarget#282.  It also fixes #314 by updating the travis tests to depend upon tags instead of master.