### PR TITLE
fix psf convolution for newexp_mock

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,10 +2,12 @@
 desisim change log
 ==================
 
-0.26.0 (unreleased)
+0.26.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Fix PSF convolution for newexp_mock (`PR #331`_).
+
+.. _`PR #331`: https://github.com/desihub/desisim/pull/331
 
 0.26.0 (2018-02-27)
 -------------------

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -142,7 +142,7 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
         if exptime is None:
             exptime = 10
         sim, fibermap = desisim.simexp.simflat(infile, nspec=nspec,
-            exptime=exptime, testslit=testslit, camera_output=False)
+            exptime=exptime, testslit=testslit, psfconvolve=False)
 
         header['EXPTIME'] = exptime
         header['FLAVOR'] = 'flat'
@@ -184,7 +184,7 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
         obsconditions['EXPTIME'] = exptime
 
     sim = simulate_spectra(wave, flux, fibermap=fibermap,
-        obsconditions=obsconditions, camera_output=False)
+        obsconditions=obsconditions, psfconvolve=False)
 
     #- Write fibermap
     telera, teledec = io.get_tile_radec(tileid)

--- a/py/desisim/scripts/fastframe.py
+++ b/py/desisim/scripts/fastframe.py
@@ -67,7 +67,8 @@ def main(args=None):
     ii = slice(firstspec, firstspec+nspec)
     if simspec.flavor == 'science':
         sim = desisim.simexp.simulate_spectra(wave, flux[ii],
-                fibermap=fibermap[ii], obsconditions=obs, dwave_out=args.dwave)
+                fibermap=fibermap[ii], obsconditions=obs, dwave_out=args.dwave,
+                psfconvolve=True)
     elif simspec.flavor in ['arc', 'flat', 'calib']:
         x = fibermap['X_TARGET']
         y = fibermap['Y_TARGET']
@@ -76,7 +77,8 @@ def main(args=None):
         surface_brightness = (flux.T / fiber_area).T
         config = desisim.simexp._specsim_config_for_wave(wave, dwave_out=args.dwave)
         # sim = specsim.simulator.Simulator(config, num_fibers=nspec)
-        sim = desisim.specsim.get_simulator(config, num_fibers=nspec)
+        sim = desisim.specsim.get_simulator(config, num_fibers=nspec,
+                                            camera_output=True)
         sim.observation.exposure_time = simspec.header['EXPTIME'] * u.s
         sbunit = 1e-17 * u.erg / (u.Angstrom * u.s * u.cm ** 2 * u.arcsec ** 2)
         xy = np.vstack([x, y]).T * u.mm

--- a/py/desisim/scripts/newexp_mock.py
+++ b/py/desisim/scripts/newexp_mock.py
@@ -105,10 +105,12 @@ def main(args=None):
     try:
         flux, wave, meta = get_mock_spectra(fiberassign, mockdir=args.mockdir)
     except Exception as err:
-        log.fatal('Failed obsnum {} fiberassign {} tile {}'.format(args.obsnum, args.fiberassign, tileid))
+        log.fatal('Failed obsnum {} fiberassign {} tile {}'.format(
+            args.obsnum, args.fiberassign, tileid))
         raise err
 
-    sim, fibermap = simscience((flux, wave, meta), fiberassign, obsconditions=obs, nspec=args.nspec)
+    sim, fibermap = simscience((flux, wave, meta), fiberassign, obsconditions=obs,
+        nspec=args.nspec, psfconvolve=False)
 
     #- TODO: header keyword code is replicated from obs.new_exposure()
     telera, teledec = desisim.io.get_tile_radec(tileid)

--- a/py/desisim/scripts/quickspectra.py
+++ b/py/desisim/scripts/quickspectra.py
@@ -157,7 +157,8 @@ def sim_spectra(wave, flux, program, spectra_filename, obsconditions=None,
     flux = flux[:,ii]*flux_unit
 
     sim = desisim.simexp.simulate_spectra(wave, flux, fibermap=frame_fibermap,
-        obsconditions=obsconditions, redshift=redshift, seed=seed)
+        obsconditions=obsconditions, redshift=redshift, seed=seed,
+        psfconvolve=True)
 
     random_state = np.random.RandomState(seed)
     sim.generate_random_noise(random_state)


### PR DESCRIPTION
Previous PR #320 fixed the PSF double convolution for newexp_random but not newexp_mock (Mea culpa!).  This PR fixes it for newexp_mock too.  I plan to do a few more tests before being ready to merge but I'm opening this PR now to get the travis tests running.