### PR TITLE
Make redshift check and correction consistent

### DIFF
--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -538,7 +538,7 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, redshift=Non
         else:
             bgs_redshifts = redshift[bgss]
             # Avoid infinities
-            if np.any(bgs_redshifts == 0.):
+            if np.any(bgs_redshifts <= 0.):
                 bgs_redshifts[bgs_redshifts <= 0.] = 0.0001
             angscales = ( ang_diam_dist(0.1) / ang_diam_dist(bgs_redshifts) ).value
         source_half_light_radius[bgss,0]= bgs_disk_z01 * angscales # disk comp in BGS, arcsec


### PR DESCRIPTION
Correcting a tiny bug that consisted of an equality check (==) instead of a less-than-or-equal (<=)