### PR TITLE
Astropy 2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,12 @@ os:
 
 # Travis tech support recommended trying sudo true for more stable builds.
 # Seems odd, but maybe they isolate us from other users more if we need sudo.
-sudo: true
+# sudo: true
+# Setting sudo to false opts in to Travis-CI container-based builds.
+sudo: false
+
+# Use Ubuntu 14.04 LTS "trusty" instead of default 12.04
+dist: trusty
 
 # The apt packages below are needed for sphinx builds, which can no longer
 # be installed with sudo apt-get.
@@ -41,32 +46,33 @@ env:
         # to repeat them for all configurations.
         # - NUMPY_VERSION=1.10
         # - SCIPY_VERSION=0.16
-        - ASTROPY_VERSION=1.3.3
-        - SPHINX_VERSION=1.5
+        - ASTROPY_VERSION=2.0.4
+        # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=1.9.9
-        # - DESIMODEL_VERSION=0.7.0
-        # - DESIMODEL_DATA=branches/test-0.7.0
+        - SPECLITE_VERSION=0.7
+        - SPECTER_VERSION=0.8.3
         - DESIMODEL_VERSION=0.9.2
+        # - DESIMODEL_DATA=branches/test-0.9
         - DESIMODEL_DATA=tags/0.9.2
         - DESISIM_TESTDATA_VERSION=0.4.0
-        - SPECLITE_VERSION=0.7
         - SPECSIM_VERSION=v0.11
-        - SPECTER_VERSION=0.8.3
         - DESISPEC_VERSION=0.18.0
         - DESITARGET_VERSION=0.19.0
         - SIMQSO_VERSION=v1.2.1
         - DESI_LOGLEVEL=DEBUG
         - MAIN_CMD='python setup.py'
+        # Additional conda channels to use.
+        - CONDA_CHANNELS="openastronomy"
         # These packages will always be installed.
-        - CONDA_DEPENDENCIES="scipy pyyaml"
+        - CONDA_DEPENDENCIES=""
         # These packages will only be installed for documentation builds.
-        - CONDA_SPHINX_DEPENDENCIES="scipy pyyaml sphinx==1.5"
+        # - CONDA_SPHINX_DEPENDENCIES="scipy pyyaml sphinx==1.5"
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES="scipy matplotlib coverage==3.7.1 pyyaml numba"
+        - CONDA_ALL_DEPENDENCIES="scipy matplotlib coverage pyyaml healpy numba fitsio"
         # These packages will always be installed.
         - PIP_DEPENDENCIES=""
         # These packages will only be installed if we really need them.
-        - PIP_ALL_DEPENDENCIES="healpy speclite==${SPECLITE_VERSION} coveralls fitsio"
+        - PIP_ALL_DEPENDENCIES="speclite==${SPECLITE_VERSION} coveralls"
         # These pip packages need to be installed in a certain order, so we
         # do that separately from the astropy/ci-helpers scripts.
         - DESIHUB_PIP_DEPENDENCIES="desiutil=${DESIUTIL_VERSION}"
@@ -75,9 +81,11 @@ env:
         - DEBUG=False
     matrix:
         - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
-        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=2.7 SETUP_CMD='bdist_egg'
+        - PYTHON_VERSION=3.5 SETUP_CMD='egg_info'
         - PYTHON_VERSION=3.5 SETUP_CMD='bdist_egg'
+        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.6 SETUP_CMD='bdist_egg'
 
 matrix:
     # Don't wait for allowed failures.
@@ -86,14 +94,22 @@ matrix:
     # OS X support is still experimental, so don't penalize failuures.
     allow_failures:
         - os: osx
+        - os: linux
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
+               ASTROPY_VERSION=3.0
+               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+               PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
+               DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
 
     include:
 
-        # Check for sphinx doc build warnings - we do this first because it
-        # runs for a long time
+        # Check for sphinx doc build warnings.
+        # Note: this test is not a perfectly realistic test of ReadTheDocs
+        # builds, which operate in a much more bare-bones environment
         - os: linux
           env: PYTHON_VERSION=3.5 SETUP_CMD='build_sphinx --warning-is-error'
-               CONDA_DEPENDENCIES=$CONDA_SPHINX_DEPENDENCIES
+               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+               PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 
         # Try multiple python versions with the latest numpy
         - os: linux
@@ -108,11 +124,18 @@ matrix:
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
                DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
 
-        # - os: linux
-        #   env: PYTHON_VERSION=2.7 SETUP_CMD='test'
-        #        CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-        #        PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
-        #        DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
+        - os: linux
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
+               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+               PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
+               DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
+
+        - os: linux
+          env: PYTHON_VERSION=3.6 SETUP_CMD='test'
+               ASTROPY_VERSION=3.0
+               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+               PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
+               DESIHUB_PIP_DEPENDENCIES=$DESIHUB_PIP_ALL_DEPENDENCIES
 
         # - os: osx
         #   env: PYTHON_VERSION=2.7 SETUP_CMD='test'

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -5,6 +5,9 @@ desisim API
 .. automodule:: desisim
     :members:
 
+.. automodule:: desisim.archetypes
+    :members:
+
 .. automodule:: desisim.batch
     :members:
 
@@ -14,7 +17,13 @@ desisim API
 .. automodule:: desisim.cosmology
     :members:
 
+.. automodule:: desisim.dla
+    :members:
+
 .. automodule:: desisim.io
+    :members:
+
+.. automodule:: desisim.lya_mock_p1d
     :members:
 
 .. automodule:: desisim.lya_spectra
@@ -64,10 +73,40 @@ desisim API
 .. automodule:: desisim.scripts.brightsims
     :members:
 
+.. automodule:: desisim.scripts.fastframe
+    :members:
+
+.. automodule:: desisim.scripts.newarc
+    :members:
+
+.. automodule:: desisim.scripts.newexp_mock
+    :members:
+
+.. automodule:: desisim.scripts.newexp_random
+    :members:
+
+.. automodule:: desisim.scripts.newflat
+    :members:
+
+.. automodule:: desisim.scripts.pixsim_nights
+    :members:
+
 .. automodule:: desisim.scripts.pixsim
     :members:
 
+.. automodule:: desisim.scripts.qa_s2n
+    :members:
+
+.. automodule:: desisim.scripts.qa_zfind
+    :members:
+
 .. automodule:: desisim.scripts.quickgen
+    :members:
+
+.. automodule:: desisim.scripts.quickspectra
+    :members:
+
+.. automodule:: desisim.simexp
     :members:
 
 .. automodule:: desisim.spec_qa
@@ -77,6 +116,12 @@ desisim API
     :members:
 
 .. automodule:: desisim.spec_qa.redshifts
+    :members:
+
+.. automodule:: desisim.spec_qa.s2n
+    :members:
+
+.. automodule:: desisim.spec_qa.utils
     :members:
 
 .. automodule:: desisim.specsim

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import sys
 import os
 import os.path
-
+from importlib import import_module
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -47,7 +47,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
-    napoleon_extension
+    'sphinx.ext.napoleon'
 ]
 
 # Configuration for intersphinx, copied from astropy.
@@ -133,24 +133,13 @@ napoleon_include_private_with_doc = True
 # This value contains a list of modules to be mocked up. This is useful when
 # some external dependencies are not met at build time and break the
 # building process.
-autodoc_mock_imports = ['astropy.constants', 'astropy.cosmology',
-                        'astropy.io', 'astropy.stats',
-                        'astropy.table', 'astropy.units',
-                        'astropy.time',
-                        'desimodel.focalplane', 'desimodel.io',
-                        'desispec.cosmics', 'desispec.frame',
-                        'desispec.fiberflat', 'desispec.fluxcalibration',
-                        'desispec.image', 'desispec.parallel',
-                        'desispec.io', 'desispec.io.fibermap', 'desispec.io.util',
-                        'desispec.interpolation', 'desispec.log',
-                        'desispec.resolution', 'desispec.sky',
-                        'desitarget.mtl', 'desitarget.targets',
-                        'desitarget.targetmask',
-                        'matplotlib', 'matplotlib.backends',
-                        'matplotlib.backends.backend_pdf', 'matplotlib.gridspec',
-                        'numpy', 'scipy', 'scipy.constants',
-                        'scipy.interpolate', 'scipy.special',
-                        'specsim.simulator', 'specsim.config', 'fitsio']
+autodoc_mock_imports = []
+for missing in ('astropy', 'desimodel', 'desiutil', 'desispec', 'desitarget',
+                'matplotlib', 'numpy', 'scipy', 'specsim', 'fitsio'):
+    try:
+        foo = import_module(missing)
+    except ImportError:
+        autodoc_mock_imports.append(missing)
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -93,23 +93,21 @@ def write_simspec(sim, truth, fibermap, obs, expid, night, outdir=None, filename
     Write a simspec file
 
     Args:
-        sim: specsim Simulator object
-        truth: truth metadata Table
-        fibermap: fibermap Table
-        obs: dict-like observation conditions with keys
+        sim (Simulator): specsim Simulator object
+        truth (Table): truth metadata Table
+        fibermap (Table): fibermap Table
+        obs (dict-like): dict-like observation conditions with keys
             SEEING (arcsec), EXPTIME (sec), AIRMASS,
             MOONFRAC (0-1), MOONALT (deg), MOONSEP (deg)
-        expid: integer exposure ID
-        night: YEARMMDD string
+        expid (int): integer exposure ID
+        night (str): YEARMMDD string
+        outdir (str, optional): output directory
+        filename (str, optional): if None, auto-derive from envvars, night, expid, and outdir
+        header (dict-like): header to include in HDU0
+        overwrite (bool, optional): overwrite pre-existing files
 
-    Options:
-        outdir: output directory
-        filename: if None, auto-derive from envvars, night, expid, and outdir
-        header: dict-like header to include in HDU0
-        overwrite: overwrite pre-existing files
-    
     Notes:
-        calibration exposures can use truth=None and obs=None
+        Calibration exposures can use ``truth=None`` and ``obs=None``.
     '''
     import astropy.table
     import astropy.units as u
@@ -302,7 +300,7 @@ class SimSpec(object):
         #change to a new testing procedure since channel is now an input
         for channel in phot.keys():
             nspec=phot[channel].shape[0]
- 
+
         for channel in phot.keys():
             assert phot[channel].shape[0]==nspec
 
@@ -367,7 +365,7 @@ def read_simspec_mpi(filename, comm, channel, spectrographs=None):
     wave = comm.bcast(wave, root=0)
     fibermap = comm.bcast(fibermap, root=0)
 
-    # Based on the spectrographs for this process, compute the range of 
+    # Based on the spectrographs for this process, compute the range of
     # spectra we need to store.  The number of spectra per spectrograph (500)
     # is hard-coded several places in desisim.  This should be put in desimodel
     # somewhere...
@@ -398,7 +396,7 @@ def read_simspec_mpi(filename, comm, channel, spectrographs=None):
     #in these next blocks, we fix the endian-ness of the data for each type
     #we also extract the data for later broadcast if comm.rank == 0
     #and we store the shape of the data to allocate numpy arrays if comm_rank !=0
-    #it looks a little silly but it's better than trying to convert from a python 
+    #it looks a little silly but it's better than trying to convert from a python
     #dictionary back to a numpy array later
 
     #preallocate shape_dict
@@ -451,15 +449,15 @@ def read_simspec_mpi(filename, comm, channel, spectrographs=None):
     #one broadcast is more efficienct than many broadcasts
     #this allows the ranks to know what size to preallocate
     shape_dict= comm.bcast(shape_dict, root=0)
-    #add a barrier so we can make sure these data have been broadcast 
+    #add a barrier so we can make sure these data have been broadcast
     #to all ranks before we start the next process
     comm.Barrier()
-  
+
     #we will sort according to flavor in the mpi version
     #flavor = flat has phot and flux
     #flavor = arc has phot
     #flavor = science has phot, flux, skyphot, and skyflux
- 
+
     # Read photons
     # all flavors have photons
     phot = dict()
@@ -1090,7 +1088,7 @@ def write_templates(outfile, flux, wave, meta):
         flux (numpy.ndarray): Flux vector (1e-17 erg/s/cm2/A)
         wave (numpy.ndarray): Wavelength vector (Angstrom).
         meta (astropy.table.Table): metadata table.
-    
+
     """
     from astropy.io import fits
     from desispec.io.util import makepath
@@ -1103,13 +1101,13 @@ def write_templates(outfile, flux, wave, meta):
     hdu_wave.header['EXTNAME'] = 'WAVE'
     hdu_wave.header['BUNIT'] = 'Angstrom'
     hdu_wave.header['AIRORVAC']  = ('vac', 'Vacuum wavelengths')
-    hx.append(hdu_wave)    
-    
+    hx.append(hdu_wave)
+
     hdu_flux = fits.ImageHDU(flux)
     hdu_flux.header['EXTNAME'] = 'FLUX'
     hdu_flux.header['BUNIT'] = str(fluxunits)
     hx.append(hdu_flux)
-    
+
     hdu_meta = fits.table_to_hdu(meta)
     hdu_meta.header['EXTNAME'] = 'METADATA'
     hx.append(hdu_meta)
@@ -1190,13 +1188,13 @@ def empty_metatable(nmodel=1, objtype='ELG', subtype='', add_SNeIa=None):
                            data=np.zeros(nmodel)-1, unit='km/s'))
     meta.add_column(Column(name='OIIDOUBLET', length=nmodel, dtype='f4', data=np.zeros(nmodel)-1))
     meta.add_column(Column(name='OIIIHBETA', length=nmodel, dtype='f4',
-                           data=np.zeros(nmodel)-1, unit='dex'))
+                           data=np.zeros(nmodel)-1, unit='Dex'))
     meta.add_column(Column(name='OIIHBETA', length=nmodel, dtype='f4',
-                           data=np.zeros(nmodel)-1, unit='dex'))
+                           data=np.zeros(nmodel)-1, unit='Dex'))
     meta.add_column(Column(name='NIIHBETA', length=nmodel, dtype='f4',
-                           data=np.zeros(nmodel)-1, unit='dex'))
+                           data=np.zeros(nmodel)-1, unit='Dex'))
     meta.add_column(Column(name='SIIHBETA', length=nmodel, dtype='f4',
-                           data=np.zeros(nmodel)-1, unit='dex'))
+                           data=np.zeros(nmodel)-1, unit='Dex'))
 
     meta.add_column(Column(name='ZMETAL', length=nmodel, dtype='f4',
                            data=np.zeros(nmodel)-1))

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -29,7 +29,7 @@ import desisim.simexp
 from .simexp import simulate_spectra
 
 def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
-                 nproc=None, seed=None, obsconditions=None, 
+                 nproc=None, seed=None, obsconditions=None,
                  specify_targets=dict(), testslit=False, exptime=None,
                  arc_lines_filename=None, flat_spectrum_filename=None,
                  outdir=None):
@@ -38,31 +38,31 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
     Does not generate pixel-level simulations or noisy spectra.
 
     Args:
-        program: 'arc', 'flat', 'bright', 'dark', 'bgs', 'mws', ...
-
-    Options:
-        * nspec : integer number of spectra to simulate
-        * night : YEARMMDD string
-        * expid : positive integer exposure ID
-        * tileid : integer tile ID
-        * seed : random seed
-        * obsconditions: str or dict-like; see options below
-        * specify_targets: (dict of dicts)  Define target properties like magnitude and redshift
-                                 for each target class. Each objtype has its own key,value pair
-                                 see simspec.templates.specify_galparams_dict() 
-                                 or simsepc.templates.specify_starparams_dict()
-        * exptime: float exposure time [seconds], overrides obsconditions['EXPTIME']
-        * testslit : simulate test slit if True, default False; only for arc/flat
-        * arc_lines_filename : use alternate arc lines filename (used if program="arc")
-        * flat_spectrum_filename : use alternate flat spectrum filename (used if program="flat")
-        * outdir: output directory
-
-    Writes to outdir or $DESI_SPECTRO_SIM/$PIXPROD/{night}/
-        * fibermap-{expid}.fits
-        * simspec-{expid}.fits
+        program (str): 'arc', 'flat', 'bright', 'dark', 'bgs', 'mws', ...
+        nspec (int, optional): number of spectra to simulate
+        night (str, optional): YEARMMDD string
+        expid (int, optional): positive integer exposure ID
+        tileid (int, optional): integer tile ID
+        nproc (object, optional): What does this do?
+        seed (int, optional): random seed
+        obsconditions (str or dict-like, optional): see options below
+        specify_targets (dict of dicts, optional): Define target properties like magnitude and redshift
+            for each target class. Each objtype has its own key,value pair
+            see simspec.templates.specify_galparams_dict()
+            or simsepc.templates.specify_starparams_dict()
+        testslit (bool, optional): simulate test slit if True, default False; only for arc/flat
+        exptime (float, optional): exposure time [seconds], overrides obsconditions['EXPTIME']
+        arc_lines_filename (str, optional): use alternate arc lines filename (used if program="arc")
+        flat_spectrum_filename (str, optional): use alternate flat spectrum filename (used if program="flat")
+        outdir (str, optional): output directory
 
     Returns:
-        * science: sim, fibermap, meta, obsconditions
+        science: sim, fibermap, meta, obsconditions
+
+    Writes to outdir or $DESI_SPECTRO_SIM/$PIXPROD/{night}/
+
+        * fibermap-{expid}.fits
+        * simspec-{expid}.fits
 
     input obsconditions can be a string 'dark', 'gray', 'bright', or dict-like
     observation metadata with keys SEEING (arcsec), EXPTIME (sec), AIRMASS,
@@ -104,7 +104,7 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
 
     program = program.lower()
     log.debug('Generating {} targets'.format(nspec))
-    
+
     header = dict(NIGHT=night, EXPID=expid, PROGRAM=program)
     if program in ('arc', 'flat'):
         header['FLAVOR'] = program
@@ -113,7 +113,7 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
 
     #- ISO 8601 DATE-OBS year-mm-ddThh:mm:ss
     header['DATE-OBS'] = time.strftime('%FT%T', dateobs)
-    
+
     if program == 'arc':
         if arc_lines_filename is None :
             infile = os.getenv('DESI_ROOT')+'/spectro/templates/calib/v0.4/arc-lines-average-in-vacuum-from-winlight-20170118.fits'
@@ -132,7 +132,7 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
         fibermap.write(outfibermap)
         truth = dict(WAVE=wave, PHOT=phot, UNITS='photon')
         return truth, fibermap, None, None
-    
+
     elif program == 'flat':
         if flat_spectrum_filename is None :
             infile = os.getenv('DESI_ROOT')+'/spectro/templates/calib/v0.4/flat-3100K-quartz-iodine.fits'

--- a/py/desisim/scripts/pixsim_nights.py
+++ b/py/desisim/scripts/pixsim_nights.py
@@ -1,6 +1,6 @@
 """
 desisim.scripts.pixsim_nights
-======================
+=============================
 
 Entry point for simulating multiple nights.
 """
@@ -104,7 +104,7 @@ def main(args, comm=None):
     else:
         cams = []
         # Do this in spectrograph order first, so that
-        # later when we distribute cameras each group will have 
+        # later when we distribute cameras each group will have
         # the minimal set of spectrographs to store.
         for spec in range(10):
             for band in ['b', 'r', 'z']:
@@ -166,12 +166,12 @@ def main(args, comm=None):
 
     for ex in myexpids:
         nt = exp_to_night[ex]
-        
+
         # path to raw file
         simspecfile = simio.findfile('simspec', nt, ex)
         rawfile = specio.findfile('raw', nt, ex)
         rawfile = os.path.join(os.path.dirname(simspecfile), rawfile)
-        
+
         # Is this exposure already finished?
         done = True
         if group_rank == 0:
@@ -218,4 +218,3 @@ def main(args, comm=None):
                 exc_type, exc_value, exc_traceback = sys.exc_info()
                 lines = traceback.format_exception(exc_type, exc_value, exc_traceback)
                 print("".join(lines), flush=True)
-

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -56,11 +56,10 @@ def simarc(arcdata, nspec=5000, nonuniform=False, testslit=False):
     Simulates an arc lamp exposure
 
     Args:
-        arcdata: Table with columns VACUUM_WAVE and ELECTRONS
-
-    Options:
-        nspec: (int) number of spectra to simulate
-        nonuniform: (bool) include calibration screen non-uniformity
+        arcdata (Table): Table with columns VACUUM_WAVE and ELECTRONS
+        nspec (int, optional) number of spectra to simulate
+        nonuniform (bool, optional): include calibration screen non-uniformity
+        testslit (bool, optional): this argument is undocumented.
 
     Returns: (wave, phot, fibermap)
         wave: 1D[nwave] wavelengths in Angstroms
@@ -113,15 +112,13 @@ def simflat(flatfile, nspec=5000, nonuniform=False, exptime=10, testslit=False,
     Simulates a flat lamp calibration exposure
 
     Args:
-        flatfile: filename with flat lamp spectrum data
-
-    Options:
-        nspec: (int) number of spectra to simulate
-        nonuniform: (bool) include calibration screen non-uniformity
-        exptime: (float) exposure time in seconds
-        psfconvolve: (bool) passed to simspec.simulator.Simulator camera_output.
+        flatfile (str): filename with flat lamp spectrum data
+        nspec (int, optional): number of spectra to simulate
+        nonuniform (bool, optional): include calibration screen non-uniformity
+        exptime (float, optional): exposure time in seconds
+        psfconvolve (bool, optional): passed to simspec.simulator.Simulator camera_output.
             if True, convolve with PSF and include per-camera outputs
-        specsim_config_file: (str) path to DESI instrument config file.
+        specsim_config_file (str, optional): path to DESI instrument config file.
             default is desi config in specsim package.
 
     Returns: (sim, fibermap)
@@ -216,23 +213,25 @@ def simscience(targets, fiberassign, obsconditions='DARK', expid=None,
     Simulates a new DESI exposure from surveysim+fiberassign+mock spectra
 
     Args:
-        targets: tuple of (flux[nspec,nwave], wave[nwave], meta[nspec])
-        fiberassign: fiber assignments table
+        targets (tuple): tuple of (flux[nspec,nwave], wave[nwave], meta[nspec])
+        fiberassign (Table): fiber assignments table
+        obsconditions (object, optional): observation metadata as
 
-    Options:
-        obsconditions: observation metadata as
             str: DARK (default) or GRAY or BRIGHT
-            dict or row of Table with keys
+
+            dict or row of Table with keys::
+
                 SEEING (arcsec), EXPTIME (sec), AIRMASS,
                 MOONFRAC (0-1), MOONALT (deg), MOONSEP (deg)
+
             Table including EXPID for subselection of which row to use
             filename with obsconditions Table; expid must also be set
-        expid: (int) exposure ID
-        nspec: (int) number of spectra to simulate
-        psfconvolve: (bool) passed to simspec.simulator.Simulator camera_output.
+        expid (int, optional): exposure ID
+        nspec (int, optional): number of spectra to simulate
+        psfconvolve (bool, optional): passed to simspec.simulator.Simulator camera_output.
             if True, convolve with PSF and include per-camera outputs
 
-    Returns sim, fibermap, meta
+    Returns: (sim, fibermap, meta)
         sim: specsim.simulate.Simulator object
         fibermap: Table
         meta: target metadata truth table
@@ -361,21 +360,22 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, redshift=Non
         wave (array): 1D wavelengths in Angstroms
         flux (array): 2D[nspec,nwave] flux in 1e-17 erg/s/cm2/Angstrom
             or astropy Quantity with flux units
-
-    Optional:
-        fibermap: table from fiberassign or fibermap; uses X/YFOCAL_DESIGN, TARGETID, DESI_TARGET
-        obsconditions: (dict-like) observation metadata including
+        fibermap (Table, optional): table from fiberassign or fibermap; uses X/YFOCAL_DESIGN, TARGETID, DESI_TARGET
+        obsconditions(dict-like, optional): observation metadata including
             SEEING (arcsec), EXPTIME (sec), AIRMASS,
             MOONFRAC (0-1), MOONALT (deg), MOONSEP (deg)
-        redshift : list/array with each index being the redshifts for that target
-        seed: (int) random seed
-        psfconvolve: (bool) passed to simspec.simulator.Simulator camera_output.
+        redshift (array-like, optional): list/array with each index being the redshifts for that target
+        seed (int, optional): random seed
+        psfconvolve (bool, optional): passed to simspec.simulator.Simulator camera_output.
             if True, convolve with PSF and include per-camera outputs
-        specsim_config_file: (str) path to DESI instrument config file.
+        specsim_config_file (str, optional): path to DESI instrument config file.
             default is desi config in specsim package.
+
+    Returns:
+        A specsim.simulator.Simulator object
+
     TODO: galsim support
 
-    Returns a specsim.simulator.Simulator object
     '''
     import specsim.simulator
     import specsim.config
@@ -389,7 +389,7 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, redshift=Non
     from astropy.cosmology import FlatLambdaCDM
     LCDM = FlatLambdaCDM(H0=70, Om0=0.3)
     ang_diam_dist = LCDM.angular_diameter_distance
-    
+
     random_state = np.random.RandomState(seed)
 
     nspec, nwave = flux.shape
@@ -463,31 +463,31 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, redshift=Non
             #- for the units -> array -> units trick
             xy[unassigned,0] = np.asarray(fiberpos['X'][unassigned], dtype=xy.dtype) * u.mm
             xy[unassigned,1] = np.asarray(fiberpos['Y'][unassigned], dtype=xy.dtype) * u.mm
-        
+
     #- Determine source types
     #- TODO: source shapes + galsim instead of fixed types + fiberloss table
     source_types = get_source_types(fibermap)
-    # source types are sky elg lrg qso bgs star , they 
+    # source types are sky elg lrg qso bgs star , they
     # are only used in specsim.fiberloss for the desi.instrument.fiberloss_method="table" method
-    
+
     desi.instrument.fiberloss_method = 'fastsim'
 
     log.debug('running simulation with {} fiber loss method'.format(desi.instrument.fiberloss_method))
-    
+
     unique_source_types = set(source_types)
     comment_line="source types:"
     for u in set(source_types) :
         comment_line+=" {} {}".format(np.sum(source_types==u),u)
     log.debug(comment_line)
-    
+
     source_fraction=None
     source_half_light_radius=None
     source_minor_major_axis_ratio=None
     source_position_angle=None
-    
+
     if desi.instrument.fiberloss_method == 'fastsim' or desi.instrument.fiberloss_method == 'galsim' :
         # the following parameters are used only with fastsim and galsim methods
-        
+
         elgs=(source_types=="elg")
         lrgs=(source_types=="lrg")
         bgss=(source_types=="bgs")
@@ -496,10 +496,10 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, redshift=Non
             log.warning("the half light radii are fixed here for LRGs and ELGs (and not magnitude or redshift dependent)")
         if np.sum(bgss)>0 and redshift is None:
             log.warning("the half light radii are fixed here for BGS (as redshifts weren't supplied)")
-            
+
         # BGS parameters based on SDSS main sample, in g-band
         # see analysis from J. Moustakas in
-        # https://github.com/desihub/desitarget/blob/master/doc/nb/bgs-morphology-properties.ipynb 
+        # https://github.com/desihub/desitarget/blob/master/doc/nb/bgs-morphology-properties.ipynb
         # B/T (bulge-to-total ratio): 0.48 (0.36 - 0.59).
         # Bulge Sersic n: 2.27 (1.12 - 3.60).
         # log10 (Bulge Half-light radius): 0.11 (-0.077 - 0.307) arcsec
@@ -510,19 +510,19 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, redshift=Non
         # bulge_half_light_radius = 1.3 arcsec
         # disk_half_light_radius  = 4.7 arcsec
         # note we use De Vaucouleurs' law , which correspond to a Sersic index n=4
-        
+
         # source_fraction[:,0] is DISK profile (exponential) fraction
         # source_fraction[:,1] is BULGE profile (devaucouleurs) fraction
         # 1 - np.sum(source_fraction,axis=1) is POINT source profile fraction
         # see specsim.GalsimFiberlossCalculator.create_source routine
-        source_fraction=np.zeros((nspec,2)) 
+        source_fraction=np.zeros((nspec,2))
         source_fraction[elgs,0]=1.   # ELG are disk only
         source_fraction[lrgs,1]=1.   # LRG are bulge only
         source_fraction[bgss,0]=0.52 # disk comp in BGS
-        source_fraction[bgss,1]=0.48 # bulge comp in BGS       
+        source_fraction[bgss,1]=0.48 # bulge comp in BGS
 
         # source_half_light_radius[:,0] is the half light radius in arcsec for the DISK profile
-        # source_half_light_radius[:,1] is the half light radius in arcsec for the BULGE profile        
+        # source_half_light_radius[:,1] is the half light radius in arcsec for the BULGE profile
         # see specsim.GalsimFiberlossCalculator.create_source routine
         source_half_light_radius=np.zeros((nspec,2))
         source_half_light_radius[elgs,0]=0.45 # ELG are disk only, arcsec
@@ -531,7 +531,7 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, redshift=Non
         # 4.7 is angular size of z=0.1 disk, and 1.3 is angular size of z=0.1 bulge
         bgs_disk_z01 = 4.7  # in arcsec
         bgs_bulge_z01 = 1.3 # in arcsec
-        
+
         # Convert to angular size of the objects in this sample with given redshifts
         if redshift is None:
             angscales = np.ones(np.sum(bgss))
@@ -543,18 +543,18 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, redshift=Non
             angscales = ( ang_diam_dist(0.1) / ang_diam_dist(bgs_redshifts) ).value
         source_half_light_radius[bgss,0]= bgs_disk_z01 * angscales # disk comp in BGS, arcsec
         source_half_light_radius[bgss,1]= bgs_bulge_z01 * angscales  # bulge comp in BGS, arcsec
-        
+
         if desi.instrument.fiberloss_method == 'galsim' :
             # the following parameters are used only with galsim method
-        
+
             # source_minor_major_axis_ratio[:,0] is the axis ratio for the DISK profile
             # source_minor_major_axis_ratio[:,1] is the axis ratio for the BULGE profile
             # see specsim.GalsimFiberlossCalculator.create_source routine
-            source_minor_major_axis_ratio=np.zeros((nspec,2)) 
-            source_minor_major_axis_ratio[elgs,0]=0.7 
+            source_minor_major_axis_ratio=np.zeros((nspec,2))
+            source_minor_major_axis_ratio[elgs,0]=0.7
             source_minor_major_axis_ratio[lrgs,1]=0.7
             source_minor_major_axis_ratio[bgss,1]=0.7
-            
+
             # the source position angle is in degrees
             # see specsim.GalsimFiberlossCalculator.create_source routine
             source_position_angle = np.zeros((nspec,2))
@@ -583,10 +583,11 @@ def _specsim_config_for_wave(wave, dwave_out=None, specsim_config_file = "desi")
 
     Args:
         wave: array of linearly spaced wavelengths in Angstroms
-    
+
     Options:
         specsim_config_file: (str) path to DESI instrument config file.
             default is desi config in specsim package.
+
     Returns:
         specsim Configuration object with wavelength parameters set to match
         this input wavelength grid
@@ -865,4 +866,3 @@ def targets2truthfiles(targets, basedir, nside=64):
         targetids.append(np.asarray(targets['TARGETID'][ii]))
 
     return truthfiles, targetids
-


### PR DESCRIPTION
This PR fixes #309.  I am still working out the bug related to `Table()` units.  However, I have determined the exact cause of this bug, and it is **NOT** due to `Table()` somehow requiring that all columns have units.  Please see astropy/astropy#7279 for the exact cause, but in brief, some tables produced by desisim have columns with `dex` as the unit.  There is no problem with a `Table()` having a column with this unit.  The problem is converting that unit *into a FITS-compliant unit*.

I will consider some simple workarounds, like not using 'dex' as a unit.