### PR TITLE
pix file renamed preproc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
 .ipynb_checkpoints                                                                                            
+*.pyc
 # C extensions
 *.so
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,8 @@ env:
         - DESIMODEL_DATA=tags/0.9.2
         - DESISIM_TESTDATA_VERSION=0.4.0
         - SPECSIM_VERSION=v0.11
-        - DESISPEC_VERSION=0.18.0
+        # - DESISPEC_VERSION=0.18.0
+        - DESISPEC_VERSION=master
         - DESITARGET_VERSION=0.19.0
         - SIMQSO_VERSION=v1.2.1
         - DESI_LOGLEVEL=DEBUG

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,16 +2,18 @@
 desisim change log
 ==================
 
-0.26.1 (unreleased)
+0.27.0 (unreleased)
 -------------------
 
 * Fix pixsim_mpi; make it faster with scatter/gather
   (`PR #329`_ and `PR #332`_).
 * Fix PSF convolution for newexp_mock (`PR #331`_).
+* Match desispec renaming and relocating of of pix -> preproc (`PR #339`).
 
 .. _`PR #329`: https://github.com/desihub/desisim/pull/329
 .. _`PR #331`: https://github.com/desihub/desisim/pull/331
 .. _`PR #332`: https://github.com/desihub/desisim/pull/332
+.. _`PR #339`: https://github.com/desihub/desisim/pull/339
 
 0.26.0 (2018-02-27)
 -------------------

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -35,7 +35,7 @@ def findfile(filetype, night, expid, camera=None, outdir=None, mkdir=True):
     """Return canonical location of where a file should be on disk
 
     Args:
-        filetype (str): file type, e.g. 'pix' or 'pixsim'
+        filetype (str): file type, e.g. 'preproc' or 'simpix'
         night (str): YEARMMDD string
         expid (int): exposure id integer
         camera (str): e.g. 'b0', 'r1', 'z9'
@@ -58,7 +58,6 @@ def findfile(filetype, night, expid, camera=None, outdir=None, mkdir=True):
         simspec = '{outdir:s}/simspec-{expid:08d}.fits',
         simpix = '{outdir:s}/simpix-{expid:08d}.fits',
         simfibermap = '{outdir:s}/fibermap-{expid:08d}.fits',
-        pix = '{outdir:s}/pix-{camera:s}-{expid:08d}.fits',
         fastframelog = '{outdir:s}/fastframe-{expid:08d}.log',
         newexplog = '{outdir:s}/newexp-{expid:08d}.log',
     )
@@ -68,8 +67,8 @@ def findfile(filetype, night, expid, camera=None, outdir=None, mkdir=True):
         raise ValueError("Unknown filetype {}; known types are {}".format(filetype, list(location.keys())))
 
     #- Some but not all filetypes require camera
-    if filetype == 'pix' and camera is None:
-        raise ValueError('camera is required for filetype '+filetype)
+    # if filetype == 'preproc' and camera is None:
+    #     raise ValueError('camera is required for filetype '+filetype)
 
     #- get outfile location and cleanup extraneous // from path
     outfile = location[filetype].format(
@@ -1139,7 +1138,7 @@ def _parse_filename(filename):
     camera=None if the filename isn't camera specific
 
     e.g. /blat/foo/simspec-00000003.fits -> ('simspec', None, 3)
-    e.g. /blat/foo/pix-r2-00000003.fits -> ('pix', 'r2', 3)
+    e.g. /blat/foo/preproc-r2-00000003.fits -> ('preproc', 'r2', 3)
     """
     base = os.path.basename(os.path.splitext(filename)[0])
     x = base.split('-')

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -45,10 +45,12 @@ def simulate_frame(night, expid, camera, ccdshape=None, **kwargs):
     Writes:
         $DESI_SPECTRO_SIM/$PIXPROD/{night}/simpix-{camera}-{expid}.fits
         $DESI_SPECTRO_SIM/$PIXPROD/{night}/desi-{expid}.fits
-        $DESI_SPECTRO_SIM/$PIXPROD/{night}/pix-{camera}-{expid}.fits
 
     For a lower-level pixel simulation interface that doesn't perform I/O,
     see pixsim.simulate()
+
+    Note: call desi_preproc or desispec.preproc.preproc to pre-process the
+    output desi*.fits file for overscan subtraction, noise estimation, etc.
     """
     #- night, expid, camera -> input file names
     simspecfile = io.findfile('simspec', night=night, expid=expid)
@@ -75,11 +77,6 @@ def simulate_frame(night, expid, camera, ccdshape=None, **kwargs):
     rawfile = desispec.io.findfile('desi', night=night, expid=expid)
     rawfile = os.path.join(simdir, os.path.basename(rawfile))
     desispec.io.write_raw(rawfile, rawpix, image.meta, camera=camera)
-
-    pixfile = desispec.io.findfile('pix', night=night, expid=expid, camera=camera)
-    pixfile = os.path.join(simdir, os.path.basename(pixfile))
-    desispec.io.write_image(pixfile, image)
-
 
 def simulate(camera, simspec, psf, fibers=None, nspec=None, ncpu=None,
     cosmics=None, wavemin=None, wavemax=None, preproc=True, comm=None):
@@ -207,11 +204,11 @@ def simulate(camera, simspec, psf, fibers=None, nspec=None, ncpu=None,
             header['RDNOISE3'] = readnoise
             header['RDNOISE4'] = readnoise
 
-        if (comm is None) or (comm.rank == 0):
-            log.info('RDNOISE1 {}'.format(header['RDNOISE1']))
-            log.info('RDNOISE2 {}'.format(header['RDNOISE2']))
-            log.info('RDNOISE3 {}'.format(header['RDNOISE3']))
-            log.info('RDNOISE4 {}'.format(header['RDNOISE4']))
+        # if (comm is None) or (comm.rank == 0):
+        #     log.info('RDNOISE1 {}'.format(header['RDNOISE1']))
+        #     log.info('RDNOISE2 {}'.format(header['RDNOISE2']))
+        #     log.info('RDNOISE3 {}'.format(header['RDNOISE3']))
+        #     log.info('RDNOISE4 {}'.format(header['RDNOISE4']))
 
         #- data already has noise if cosmics were added
         noisydata = (cosmics is not None)

--- a/py/desisim/scripts/pixsim.py
+++ b/py/desisim/scripts/pixsim.py
@@ -93,10 +93,6 @@ def expand_args(args):
         rawfile = os.path.basename(desispec.io.findfile('raw', args.night, args.expid))
         args.rawfile = os.path.join(os.path.dirname(args.simspec), rawfile)
 
-    if args.preproc:
-        if args.preproc_dir is None:
-            args.preproc_dir = os.path.dirname(args.rawfile)
-
     if args.simpixfile is None:
         args.simpixfile = io.findfile(
             'simpix', night=args.night, expid=args.expid,
@@ -523,14 +519,19 @@ def main(args, comm=None):
             if group_rank == 0:
                 for c in group_cameras:
                     camera = args.cameras[c]
-                    pixfile = desispec.io.findfile('pix', night=args.night,
+                    pixfile = desispec.io.findfile('preproc', night=args.night,
                         expid=args.expid, camera=camera)
+                    if args.preproc_dir:
+                        pixfile = os.path.join(args.preproc_dir, os.path.basename(pixfile))
+
                     pixdir = os.path.dirname(pixfile)
                     if not os.path.isdir(pixdir):
                         os.makedirs(pixdir)
-                    preproc_opts = ['--infile', args.rawfile, '--outdir',
-                        args.preproc_dir, '--pixfile', pixfile]
-                    preproc_opts += ['--cameras', camera]
+                    preproc_opts = [
+                        '--infile', args.rawfile,
+                        '--outfile', pixfile,
+                        '--cameras', camera
+                    ]
                     preproc.main(preproc.parse(preproc_opts))
 
     if comm is not None:

--- a/py/desisim/scripts/pixsim_nights.py
+++ b/py/desisim/scripts/pixsim_nights.py
@@ -179,7 +179,7 @@ def main(args, comm=None):
                 done = False
             if args.preproc:
                 for c in cams:
-                    pixfile = specio.findfile('pix', night=nt,
+                    pixfile = specio.findfile('preproc', night=nt,
                         expid=ex, camera=c)
                     if not os.path.isfile(pixfile):
                         done = False

--- a/py/desisim/test/test_io.py
+++ b/py/desisim/test/test_io.py
@@ -60,13 +60,9 @@ class TestIO(unittest.TestCase):
         camera = 'z3'
         filepath = io.findfile('simspec', night, expid)
         filepath = io.findfile('simpix', night, expid, camera)
-        filepath = io.findfile('pix', night, expid, camera)
         outdir = '/blat/foo/bar'
         filepath = io.findfile('simpix', night, expid, camera, outdir=outdir, mkdir=False)
         self.assertTrue(filepath.startswith(outdir))
-
-        with self.assertRaises(ValueError):
-            io.findfile('pix', night, expid)  #- missing camera
 
         with self.assertRaises(ValueError):
             io.findfile('blat', night, expid, camera)  #- bad filetype
@@ -141,8 +137,8 @@ class TestIO(unittest.TestCase):
         self.assertEqual(prefix, 'simspec')
         self.assertEqual(camera, None)
         self.assertEqual(expid, 2)
-        prefix, camera, expid = io._parse_filename('/blat/foo/pix-r2-00000003.fits')
-        self.assertEqual(prefix, 'pix')
+        prefix, camera, expid = io._parse_filename('/blat/foo/preproc-r2-00000003.fits')
+        self.assertEqual(prefix, 'preproc')
         self.assertEqual(camera, 'r2')
         self.assertEqual(expid, 3)
 

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -79,7 +79,7 @@ class TestPixsim(unittest.TestCase):
         self.night = '20150105'
         self.expid = 124
         for expid in (self.expid, self.expid+1):
-            pixfile = desispec.io.findfile('pix', self.night, expid, camera='b0')
+            pixfile = desispec.io.findfile('preproc', self.night, expid, camera='b0')
             pixdir = os.path.dirname(pixfile)
             if not os.path.isdir(pixdir):
                 os.makedirs(pixdir)
@@ -95,7 +95,7 @@ class TestPixsim(unittest.TestCase):
         if os.path.exists(simspecfile):
             os.remove(simspecfile)
         for camera in ('b0', 'r0', 'z0'):
-            pixfile = desispec.io.findfile('pix', self.night, self.expid, camera=camera)
+            pixfile = desispec.io.findfile('preproc', self.night, self.expid, camera=camera)
             if os.path.exists(pixfile):
                 os.remove(pixfile)
             simpixfile = io.findfile('simpix', self.night, self.expid, camera=camera)
@@ -115,7 +115,6 @@ class TestPixsim(unittest.TestCase):
         self.assertTrue(os.path.exists(io.findfile('simspec', night, expid)))
         simspec = io.read_simspec(io.findfile('simspec', night, expid))
         self.assertTrue(os.path.exists(io.findfile('simpix', night, expid, camera)))
-        self.assertTrue(os.path.exists(io.findfile('pix', night, expid, camera)))
 
     @unittest.skipUnless(desi_templates_available, 'The DESI templates directory ($DESI_ROOT/spectro/templates) was not detected.')
     def test_pixsim_cosmics(self):
@@ -128,7 +127,6 @@ class TestPixsim(unittest.TestCase):
         self.assertTrue(os.path.exists(io.findfile('simspec', night, expid)))
         simspec = io.read_simspec(io.findfile('simspec', night, expid))
         self.assertTrue(os.path.exists(io.findfile('simpix', night, expid, camera)))
-        self.assertTrue(os.path.exists(io.findfile('pix', night, expid, camera)))
 
     def test_simulate(self):
         import desispec.image


### PR DESCRIPTION
Fixes pixsim to match desihub/desispec#545 which renamed preprocessed spectrograph data from pix*.fits to preproc*.fits and moved it from the raw data directory to a spectro pipeline step under $DESI_SPECTRO_REDUX/$SPECPROD.