### PR TITLE
fix EXTNAME=FIBERMAP and newexp-mock nspec option

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,16 +2,26 @@
 desisim change log
 ==================
 
-0.26.1 (unreleased)
+0.27.0 (unreleased)
 -------------------
 
 * Fix pixsim_mpi; make it faster with scatter/gather
   (`PR #329`_ and `PR #332`_).
-* Fix PSF convolution for newexp_mock (`PR #331`_).
+* Fix PSF convolution for newexp-mock (`PR #331`_).
+* BGS redshift bug fix (`PR #333`_).
+* Astropy 2 compatibility (`PR #334`_).
+* preprocessed images changed name and location (`PR #337`_ and `PR #339`_).
+* Fix newexp-mock --nspec option (`PR #340`_).
+* Fix fibermap EXTNAME (`PR #340`_).
 
 .. _`PR #329`: https://github.com/desihub/desisim/pull/329
 .. _`PR #331`: https://github.com/desihub/desisim/pull/331
 .. _`PR #332`: https://github.com/desihub/desisim/pull/332
+.. _`PR #333`: https://github.com/desihub/desisim/pull/332
+.. _`PR #334`: https://github.com/desihub/desisim/pull/334
+.. _`PR #337`: https://github.com/desihub/desisim/pull/334
+.. _`PR #339`: https://github.com/desihub/desisim/pull/339
+.. _`PR #340`: https://github.com/desihub/desisim/pull/340
 
 0.26.0 (2018-02-27)
 -------------------

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -129,7 +129,7 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
 
         fibermap.meta['NIGHT'] = night
         fibermap.meta['EXPID'] = expid
-        fibermap.write(outfibermap)
+        desispec.io.write_fibermap(outfibermap, fibermap)
         truth = dict(WAVE=wave, PHOT=phot, UNITS='photon')
         return truth, fibermap, None, None
 
@@ -151,7 +151,7 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
 
         fibermap.meta['NIGHT'] = night
         fibermap.meta['EXPID'] = expid
-        fibermap.write(outfibermap)
+        desispec.io.write_fibermap(outfibermap, fibermap)
         # fluxunits = 1e-17 * u.erg / (u.s * u.cm**2 * u.Angstrom)
         fluxunits = '1e-17 erg/(s * cm2 * Angstrom)'
         flux = sim.simulated['source_flux'].to(fluxunits)
@@ -208,7 +208,8 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
     simfile = io.write_simspec(sim, meta, fibermap, obsconditions,
         expid, night, header=hdr, filename=outsimspec)
 
-    desispec.io.write_fibermap(outfibermap, fibermap, header=hdr)
+    fibermap.meta.update(hdr)
+    desispec.io.write_fibermap(outfibermap, fibermap)
     log.info('Wrote '+outfibermap)
 
     update_obslog(obstype='science', program=program, expid=expid, dateobs=dateobs, tileid=tileid)

--- a/py/desisim/scripts/newarc.py
+++ b/py/desisim/scripts/newarc.py
@@ -83,6 +83,7 @@ def main(args=None):
     log.info('Writing {}'.format(args.fibermap))
     fibermap.meta['NIGHT'] = args.night
     fibermap.meta['EXPID'] = args.expid
+    fibermap.meta['EXTNAME'] = 'FIBERMAP'
     fibermap.write(args.fibermap, overwrite=args.clobber)
 
     #- TODO: explain bypassing desisim.io.write_simspec

--- a/py/desisim/scripts/newexp_mock.py
+++ b/py/desisim/scripts/newexp_mock.py
@@ -100,6 +100,12 @@ def main(args=None):
 
     if args.nspec is None:
         args.nspec = len(fiberassign)
+    elif args.nspec <= len(fiberassign):
+        fiberassign = fiberassign[0:args.nspec]
+    else:
+        log.error('args.nspec {} > len(fiberassign) {}'.format(
+            args.nspec, len(fiberassign)))
+        sys.exit(1)
 
     log.info('Simulating night {} expid {} tile {}'.format(night, args.expid, tileid))
     try:
@@ -109,8 +115,8 @@ def main(args=None):
             args.obsnum, args.fiberassign, tileid))
         raise err
 
-    sim, fibermap = simscience((flux, wave, meta), fiberassign, obsconditions=obs,
-        nspec=args.nspec, psfconvolve=False)
+    sim, fibermap = simscience((flux, wave, meta), fiberassign,
+        obsconditions=obs, psfconvolve=False)
 
     #- TODO: header keyword code is replicated from obs.new_exposure()
     telera, teledec = desisim.io.get_tile_radec(tileid)
@@ -133,6 +139,7 @@ def main(args=None):
 
     #- Write fibermap to $DESI_SPECTRO_SIM/$PIXPROD not $DESI_SPECTRO_DATA
     fibermap.meta.update(header)
+    fibermap.meta['EXTNAME'] = 'FIBERMAP'
     fibermap.write(desisim.io.findfile('simfibermap', night, args.expid,
         outdir=args.outdir), overwrite=args.clobber)
 

--- a/py/desisim/scripts/newflat.py
+++ b/py/desisim/scripts/newflat.py
@@ -77,6 +77,7 @@ def main(args=None):
     log.info('Writing {}'.format(args.fibermap))
     fibermap.meta['NIGHT'] = args.night
     fibermap.meta['EXPID'] = args.expid
+    fibermap.meta['EXTNAME'] = 'FIBERMAP'
     fibermap.write(args.fibermap, overwrite=args.clobber)
 
     header = fits.Header()

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -246,8 +246,11 @@ def simscience(targets, fiberassign, obsconditions='DARK', expid=None,
 
     if nspec is not None:
         fiberassign = fiberassign[0:nspec]
+        flux = flux[0:nspec]
+        meta = meta[0:nspec]
 
     assert np.all(fiberassign['TARGETID'] == meta['TARGETID'])
+
     fibermap = fibermeta2fibermap(fiberassign, meta)
 
     #- Parse multiple options for obsconditions


### PR DESCRIPTION
This PR fixes desihub/desispec#521 by ensuring that fibemap files have EXTNAME=FIBERMAP set.  It also fixes a bug in the `newexp-mock --nspec` option that I found while testing this.  I tested fibermap outputs from `newflat`, `newarc`, `newexp-mock`, and `newexp-random`.

I plan to self-merge after (if?) Travis tests pass to move on with software release 18.3 integration testing.