### PR TITLE
Quick lya

### DIFF
--- a/bin/quickquasars
+++ b/bin/quickquasars
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+
+"""
+Generate a spectra file
+"""
+
+import sys
+from desisim.scripts.quickquasars import main
+sys.exit(main())

--- a/etc/quickquasar_slurm_script.sh
+++ b/etc/quickquasar_slurm_script.sh
@@ -1,0 +1,72 @@
+#!/bin/bash -l
+
+#SBATCH --partition=debug
+#SBATCH --account=desi
+#SBATCH --nodes=20
+#SBATCH --time=00:30:00
+#SBATCH --job-name=lyasim
+#SBATCH --output=lyasim.log
+
+# HOWTO:
+# 1) copy this script  
+# 2) choose your options to quickquasars (z range, downsampling, target selection, DESI footprint) in the command below
+# 3) change idir outdir downsampling output nodes nthreads time  
+# 4) verify nodes=XX below is same as --nodes=XX above
+# 5) sbatch yourjob.sh
+#
+# example: v1.1.0
+# the QSO density (z>2.1) = 52.4 /deg2 , so I set downsampling=1, 
+# it's only one chunk , almost fully contained in DESI footprint
+downsampling=1.
+idir=/project/projectdirs/desi/mocks/lya_forest/v1.1/v1.1.0
+outdir=/project/projectdirs/desi/users/jguy/qso-v1.1.0-3
+
+nodes=20 # CHECK MATCHING #SBATCH --nodes ABOVE !!!!
+nthreads=4 # TO BE TUNED ; CAN HIT NODE MEMORY LIMIT ; 4 is max on edison for nside=16 and ~50 QSOs/deg2
+
+    
+if [ ! -d $outdir/jobs ] ; then
+    mkdir -p $outdir/jobs
+fi
+if [ ! -d $outdir/logs ] ; then
+    mkdir -p $outdir/logs
+fi
+if [ ! -d $outdir/spectra-16 ] ; then
+    mkdir -p $outdir/spectra-16
+fi
+
+echo "get list of skewers to run ..."
+
+files=`\ls -1 $idir/*/*/transmission*.fits`
+nfiles=`echo $files | wc -w`
+nfilespernode=$((nfiles/nodes+1))
+
+echo "n files =" $nfiles
+echo "n files per node =" $nfilespernode
+
+first=1
+last=$nfilespernode
+for node in `seq $nodes` ; do
+    echo "starting node $node"
+
+    # list of files to run
+    if (( $node == $nodes )) ; then
+	last=""
+    fi
+    echo ${first}-${last}
+    tfiles=`echo $files | cut -d " " -f ${first}-${last}`
+    first=$(( first + nfilespernode ))
+    last=$(( last + nfilespernode ))
+    command="srun -N 1 -n 1 -c $nthreads  quickquasars --exptime 4000. -i $tfiles --zmin 1.6 --nproc $nthreads --outdir $outdir/spectra-16 --downsampling $downsampling --zbest"
+    echo $command
+    echo "log in $outdir/logs/node-$node.log"
+    
+    $command >& $outdir/logs/node-$node.log &
+    
+done
+
+wait
+echo "END"
+
+
+

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -6,6 +6,7 @@ import time
 import numpy as np
 from astropy.table import Table
 import astropy.io.fits as pyfits
+import multiprocessing
 
 from desiutil.log import get_logger
 from desispec.io.util import write_bintable
@@ -58,6 +59,167 @@ def parse(options=None):
 
     return args
 
+def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filters) :
+    
+    log = get_logger()
+    
+    healpix=0
+    nside=0
+    vals = os.path.basename(ifilename).split(".")[0].split("-")
+    if len(vals)<3 :
+        log.error("Cannot guess nside and healpix from filename {}".format(ifilename))
+        raise ValueError("Cannot guess nside and healpix from filename {}".format(ifilename))
+    try :
+        healpix=int(vals[-1])
+        nside=int(vals[-2])
+    except ValueError:
+        raise ValueError("Cannot guess nside and healpix from filename {}".format(ifilename))
+
+    if args.outfile :
+        ofilename = args.outfile
+    else :
+        ofilename = os.path.join(args.outdir,"{}/{}/spectra-{}-{}.fits".format(healpix//100,healpix,nside,healpix))
+
+    if not args.overwrite :
+        if os.path.isfile(ofilename) :
+            log.info("skip existing {}".format(ofilename))
+            return
+
+    log.info("Read skewers in {}".format(ifilename))
+    trans_wave, transmission, metadata = read_lya_skewers(ifilename)
+    ok = np.where(( metadata['Z'] >= args.zmin ) & (metadata['Z'] <= args.zmax ))[0]
+    transmission = transmission[ok]
+    metadata = metadata[:][ok]
+
+    # set seed now in case we are downsampling
+    np.random.seed(args.seed)
+
+    # create quasars
+    nqso=transmission.shape[0]
+    if args.downsampling is not None :
+        if args.downsampling <= 0 or  args.downsampling > 1 :
+           log.error("Down sampling fraction={} must be between 0 and 1".format(args.downsampling))
+           raise ValueError("Down sampling fraction={} must be between 0 and 1".format(args.downsampling))
+        indices = np.where(np.random.uniform(size=nqso)<args.downsampling)[0]
+        if indices.size == 0 : 
+            log.warning("Down sampling from {} to 0 (by chance I presume)".format(nqso))
+            return
+        transmission = transmission[indices]
+        metadata = metadata[:][indices]
+        nqso = transmission.shape[0]
+
+    if args.nmax is not None :
+        if args.nmax < nqso :
+            log.info("Limit number of QSOs from {} to nmax={} (random subsample)".format(nqso,args.nmax))
+            # take a random subsample
+            indices = (np.random.uniform(size=args.nmax)*nqso).astype(int)
+            transmission = transmission[indices]
+            metadata = metadata[:][indices]
+            nqso = args.nmax
+
+    log.info("Simulate {} QSOs".format(nqso))
+    tmp_qso_flux, tmp_qso_wave, meta = model.make_templates(
+        nmodel=nqso, redshift=metadata['Z'], seed=args.seed,
+        lyaforest=False, nocolorcuts=True, noresample=True)
+
+    log.info("Resample to transmission wavelength grid")
+    # because we don't want to alter the transmission field with resampling here
+    qso_flux=np.zeros((tmp_qso_flux.shape[0],trans_wave.size))
+    for q in range(tmp_qso_flux.shape[0]) :
+        qso_flux[q]=np.interp(trans_wave,tmp_qso_wave,tmp_qso_flux[q])
+        log.info("".format(nqso))
+    tmp_qso_flux = qso_flux
+    tmp_qso_wave = trans_wave
+
+    log.info("Apply lya")
+    tmp_qso_flux = apply_lya_transmission(tmp_qso_wave,tmp_qso_flux,trans_wave,transmission)
+
+    if args.target_selection :
+        log.info("Compute QSO magnitudes for target selection")
+        maggies = decam_and_wise_filters.get_ab_maggies(
+            1e-17 * tmp_qso_flux, tmp_qso_wave.copy(), mask_invalid=True)
+        for band, filt in zip( ('FLUX_G', 'FLUX_R', 'FLUX_Z', 'FLUX_W1', 'FLUX_W2'),
+                               ('decam2014-g', 'decam2014-r', 'decam2014-z',
+                                'wise2010-W1', 'wise2010-W2') ):
+            meta[band] = np.ma.getdata(1e9 * maggies[filt]) # nanomaggies
+        isqso = isQSO_colors(gflux=meta['FLUX_G'], rflux=meta['FLUX_R'], zflux=meta['FLUX_Z'],
+                           w1flux=meta['FLUX_W1'], w2flux=meta['FLUX_W2'])
+        log.info("Target selection: {}/{} QSOs selected".format(np.sum(isqso),nqso))
+        selection=np.where(isqso)[0]
+        if selection.size==0 : return
+        tmp_qso_flux = tmp_qso_flux[selection]
+        metadata     = metadata[:][selection]
+        meta         = meta[:][selection]
+        nqso         = selection.size
+
+    log.info("Resample to a linear wavelength grid (needed by DESI sim.)")
+    # we need a linear grid. for this resampling we take care of integrating in bins
+    # we do not do a simple interpolation
+    qso_wave=np.linspace(args.wmin,args.wmax,int((args.wmax-args.wmin)/args.dwave)+1)
+    qso_flux=np.zeros((tmp_qso_flux.shape[0],qso_wave.size))
+    for q in range(tmp_qso_flux.shape[0]) :
+        qso_flux[q]=resample_flux(qso_wave,tmp_qso_wave,tmp_qso_flux[q])
+
+    log.info("Simulate DESI observation and write output file")
+    pixdir = os.path.dirname(ofilename)
+    if not os.path.isdir(pixdir) :
+        log.info("Creating dir {}".format(pixdir))
+        os.makedirs(pixdir)
+
+    if "MOCKID" in metadata.dtype.names :
+        #log.warning("Using MOCKID as TARGETID")
+        targetid=np.array(metadata["MOCKID"]).astype(int)
+    elif "ID" in metadata.dtype.names :
+        log.warning("Using ID as TARGETID")
+        targetid=np.array(metadata["ID"]).astype(int)
+    else :
+        log.warning("No TARGETID")
+        targetid=None
+
+    sim_spectra(qso_wave,qso_flux, args.program, obsconditions=obsconditions,spectra_filename=ofilename,seed=args.seed,sourcetype="qso", skyerr=args.skyerr,ra=metadata["RA"],dec=metadata["DEC"],targetid=targetid)
+
+    if args.zbest :
+        log.info("Read fibermap")
+        fibermap = read_fibermap(ofilename)
+
+        zbest_filename = os.path.join(pixdir,"zbest-{}-{}.fits".format(nside,healpix))
+
+        log.info("Writing a zbest file {}".format(zbest_filename))
+        columns = [
+            ('CHI2', 'f8'),
+            ('COEFF', 'f8' , (4,)),
+            ('Z', 'f8'),
+            ('ZERR', 'f8'),
+            ('ZWARN', 'i8'),
+            ('SPECTYPE', (str,96)),
+            ('SUBTYPE', (str,16)),
+            ('TARGETID', 'i8'),
+            ('DELTACHI2', 'f8'),
+            ('BRICKNAME', (str,8))]
+        zbest = Table(np.zeros(nqso, dtype=columns))
+        zbest["CHI2"][:]      = 0.
+        zbest["Z"]            = metadata['Z']
+        zbest["ZERR"][:]      = 0.
+        zbest["ZWARN"][:]     = 0
+        zbest["SPECTYPE"][:]  = "QSO"
+        zbest["SUBTYPE"][:]   = ""
+        zbest["TARGETID"]     = fibermap["TARGETID"]
+        zbest["DELTACHI2"][:] = 25.
+
+        hzbest = pyfits.convenience.table_to_hdu(zbest); hzbest.name="ZBEST"
+        hfmap  = pyfits.convenience.table_to_hdu(fibermap);  hfmap.name="FIBERMAP"
+
+        hdulist =pyfits.HDUList([pyfits.PrimaryHDU(),hzbest,hfmap])
+        hdulist.writeto(zbest_filename, clobber=True)
+
+
+
+
+
+def _func(arg) :
+    """ Used for multiprocessing.Pool """
+    return simulate_one_healpix(**arg)
+
 def main(args=None):
 
     log = get_logger()
@@ -95,9 +257,9 @@ def main(args=None):
         obsconditions['MOONSEP'] = args.moonsep
     
     log.info("Load SIMQSO model")
-    model=SIMQSO(normfilter=args.norm_filter,nproc=args.nproc)
-
+    model=SIMQSO(normfilter=args.norm_filter,nproc=1)
     
+    decam_and_wise_filters = None
     if args.target_selection :
         log.info("Load DeCAM and WISE filters for target selection sim.")
         
@@ -107,157 +269,13 @@ def main(args=None):
         decam_and_wise_filters = filters.load_filters('decam2014-g', 'decam2014-r', 'decam2014-z',
                                          'wise2010-W1', 'wise2010-W2')
         
-
-    for ifilename in args.infile : 
-
-        healpix=0
-        nside=0
-        vals = os.path.basename(ifilename).split(".")[0].split("-")
-        if len(vals)<3 :
-            log.error("Cannot guess nside and healpix from filename {}".format(ifilename))
-            raise ValueError("Cannot guess nside and healpix from filename {}".format(ifilename))
-        try :
-            healpix=int(vals[-1])
-            nside=int(vals[-2])
-        except ValueError:
-            raise ValueError("Cannot guess nside and healpix from filename {}".format(ifilename))
+    
+    if args.nproc > 1 :
+        func_args = [ {"ifilename":filename , "args":args, "model":model , "obsconditions":obsconditions , "decam_and_wise_filters": decam_and_wise_filters} for filename in args.infile ]
+        pool = multiprocessing.Pool(args.nproc)
+        pool.map(_func, func_args)
+    else :
+        for ifilename in args.infile : 
+            simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filters)
+    
         
-        if args.outfile :
-            ofilename = args.outfile
-        else :
-            ofilename = os.path.join(args.outdir,"{}/{}/spectra-{}-{}.fits".format(healpix//100,healpix,nside,healpix))
-        
-        if not args.overwrite :
-            if os.path.isfile(ofilename) :
-                log.info("skip existing {}".format(ofilename))
-                continue
-
-        log.info("Read skewers in {}".format(ifilename))
-        trans_wave, transmission, metadata = read_lya_skewers(ifilename)
-        ok = np.where(( metadata['Z'] >= args.zmin ) & (metadata['Z'] <= args.zmax ))[0]
-        transmission = transmission[ok]
-        metadata = metadata[:][ok]
-
-        # set seed now in case we are downsampling
-        np.random.seed(args.seed)
-
-        # create quasars
-        nqso=transmission.shape[0]
-        if args.downsampling is not None :
-            if args.downsampling <= 0 or  args.downsampling > 1 :
-               log.error("Down sampling fraction={} must be between 0 and 1".format(args.downsampling))
-               raise ValueError("Down sampling fraction={} must be between 0 and 1".format(args.downsampling))
-            indices = np.where(np.random.uniform(size=nqso)<args.downsampling)[0]
-            if indices.size == 0 : 
-                log.warning("Down sampling from {} to 0 (by chance I presume)".format(nqso))
-                continue
-            transmission = transmission[indices]
-            metadata = metadata[:][indices]
-            nqso = transmission.shape[0]
-
-        if args.nmax is not None :
-            if args.nmax < nqso :
-                log.info("Limit number of QSOs from {} to nmax={} (random subsample)".format(nqso,args.nmax))
-                # take a random subsample
-                indices = (np.random.uniform(size=args.nmax)*nqso).astype(int)
-                transmission = transmission[indices]
-                metadata = metadata[:][indices]
-                nqso = args.nmax
-
-        log.info("Simulate {} QSOs".format(nqso))
-        tmp_qso_flux, tmp_qso_wave, meta = model.make_templates(
-            nmodel=nqso, redshift=metadata['Z'], seed=args.seed,
-            lyaforest=False, nocolorcuts=True, noresample=True)
-        
-        log.info("Resample to transmission wavelength grid")
-        # because we don't want to alter the transmission field with resampling here
-        qso_flux=np.zeros((tmp_qso_flux.shape[0],trans_wave.size))
-        for q in range(tmp_qso_flux.shape[0]) :
-            qso_flux[q]=np.interp(trans_wave,tmp_qso_wave,tmp_qso_flux[q])
-            log.info("".format(nqso))
-        tmp_qso_flux = qso_flux
-        tmp_qso_wave = trans_wave
-        
-        log.info("Apply lya")
-        tmp_qso_flux = apply_lya_transmission(tmp_qso_wave,tmp_qso_flux,trans_wave,transmission)
-
-        if args.target_selection :
-            log.info("Compute QSO magnitudes for target selection")
-            maggies = decam_and_wise_filters.get_ab_maggies(
-                1e-17 * tmp_qso_flux, tmp_qso_wave.copy(), mask_invalid=True)
-            for band, filt in zip( ('FLUX_G', 'FLUX_R', 'FLUX_Z', 'FLUX_W1', 'FLUX_W2'),
-                                   ('decam2014-g', 'decam2014-r', 'decam2014-z',
-                                    'wise2010-W1', 'wise2010-W2') ):
-                meta[band] = np.ma.getdata(1e9 * maggies[filt]) # nanomaggies
-            isqso = isQSO_colors(gflux=meta['FLUX_G'], rflux=meta['FLUX_R'], zflux=meta['FLUX_Z'],
-                               w1flux=meta['FLUX_W1'], w2flux=meta['FLUX_W2'])
-            log.info("Target selection: {}/{} QSOs selected".format(np.sum(isqso),nqso))
-            selection=np.where(isqso)[0]
-            if selection.size==0 : continue
-            tmp_qso_flux = tmp_qso_flux[selection]
-            metadata     = metadata[:][selection]
-            meta         = meta[:][selection]
-            nqso         = selection.size
-        
-        log.info("Resample to a linear wavelength grid (needed by DESI sim.)")
-        # we need a linear grid. for this resampling we take care of integrating in bins
-        # we do not do a simple interpolation
-        qso_wave=np.linspace(args.wmin,args.wmax,int((args.wmax-args.wmin)/args.dwave)+1)
-        qso_flux=np.zeros((tmp_qso_flux.shape[0],qso_wave.size))
-        for q in range(tmp_qso_flux.shape[0]) :
-            qso_flux[q]=resample_flux(qso_wave,tmp_qso_wave,tmp_qso_flux[q])
-        
-        log.info("Simulate DESI observation and write output file")
-        pixdir = os.path.dirname(ofilename)
-        if not os.path.isdir(pixdir) :
-            log.info("Creating dir {}".format(pixdir))
-            os.makedirs(pixdir)
-        
-        if "MOCKID" in metadata.dtype.names :
-            #log.warning("Using MOCKID as TARGETID")
-            targetid=np.array(metadata["MOCKID"]).astype(int)
-        elif "ID" in metadata.dtype.names :
-            log.warning("Using ID as TARGETID")
-            targetid=np.array(metadata["ID"]).astype(int)
-        else :
-            log.warning("No TARGETID")
-            targetid=None
-        
-        sim_spectra(qso_wave,qso_flux, args.program, obsconditions=obsconditions,spectra_filename=ofilename,seed=args.seed,sourcetype="qso", skyerr=args.skyerr,ra=metadata["RA"],dec=metadata["DEC"],targetid=targetid)
-        
-        if args.zbest :
-            log.info("Read fibermap")
-            fibermap = read_fibermap(ofilename)
-            
-            zbest_filename = os.path.join(pixdir,"zbest-{}-{}.fits".format(nside,healpix))
-            
-            log.info("Writing a zbest file {}".format(zbest_filename))
-            columns = [
-                ('CHI2', 'f8'),
-                ('COEFF', 'f8' , (4,)),
-                ('Z', 'f8'),
-                ('ZERR', 'f8'),
-                ('ZWARN', 'i8'),
-                ('SPECTYPE', (str,96)),
-                ('SUBTYPE', (str,16)),
-                ('TARGETID', 'i8'),
-                ('DELTACHI2', 'f8'),
-                ('BRICKNAME', (str,8))]
-            zbest = Table(np.zeros(nqso, dtype=columns))
-            zbest["CHI2"][:]      = 0.
-            zbest["Z"]            = metadata['Z']
-            zbest["ZERR"][:]      = 0.
-            zbest["ZWARN"][:]     = 0
-            zbest["SPECTYPE"][:]  = "QSO"
-            zbest["SUBTYPE"][:]   = ""
-            zbest["TARGETID"]     = fibermap["TARGETID"]
-            zbest["DELTACHI2"][:] = 25.
-
-            hzbest = pyfits.convenience.table_to_hdu(zbest); hzbest.name="ZBEST"
-            hfmap  = pyfits.convenience.table_to_hdu(fibermap);  hfmap.name="FIBERMAP"
-            
-            hdulist =pyfits.HDUList([pyfits.PrimaryHDU(),hzbest,hfmap])
-            hdulist.writeto(zbest_filename, clobber=True)
-            
-
-

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -1,0 +1,167 @@
+from __future__ import absolute_import, division, print_function
+import sys, os
+import argparse
+import time
+
+import numpy as np
+from desiutil.log import get_logger
+
+from desisim.simexp import reference_conditions
+from desisim.templates import SIMQSO
+from desisim.scripts.quickspectra import sim_spectra
+from desisim.lya_spectra import read_lya_skewers , apply_lya_transmission
+
+import matplotlib.pyplot as plt
+
+def parse(options=None):
+    parser=argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+                                   description="""Fast simulation of spectra into the final DESI format (Spectra class) that can be directly used as
+                                   an input to the redshift fitter (redrock). The input file is an ASCII file with first column the wavelength in A (in vacuum, redshifted), the other columns are treated as spectral flux densities in units of 10^-17 ergs/s/cm2/A.""")
+
+    #- Required
+    parser.add_argument('-i','--infile', type=str, nargs= "*", required=True, help="Input skewer healpix fits file(s)")
+    parser.add_argument('-o','--outfile', type=str, required=False, help="Output spectra (only used if single input file)")
+    parser.add_argument('--outdir', type=str, default=".", required=False, help="Output directory")
+    
+    #- Optional observing conditions to override program defaults
+    parser.add_argument('--program', type=str, default="DARK", help="Program (DARK, GRAY or BRIGHT)")
+    parser.add_argument('--seeing', type=float, default=None, help="Seeing FWHM [arcsec]")
+    parser.add_argument('--airmass', type=float, default=None, help="Airmass")
+    parser.add_argument('--exptime', type=float, default=None, help="Exposure time [sec]")
+    parser.add_argument('--moonfrac', type=float, default=None, help="Moon illumination fraction; 1=full")
+    parser.add_argument('--moonalt', type=float, default=None, help="Moon altitude [degrees]")
+    parser.add_argument('--moonsep', type=float, default=None, help="Moon separation to tile [degrees]")
+    parser.add_argument('--seed', type=int, default=0, help="Random seed")
+    parser.add_argument('--skyerr', type=float, default=0.0, help="Fractional sky subtraction error")
+    parser.add_argument('--norm-filter', type=str, default="decam2014-g", help="Broadband filter for normalization")
+    parser.add_argument('--nmax', type=int, default=None, help="Max number of QSO per input file")
+    parser.add_argument('--downsampling', type=float, default=None,help="fractional random down-sampling (value between 0 and 1)")
+    parser.add_argument('--zmin', type=float, default=0,help="Min redshift")
+    parser.add_argument('--zmax', type=float, default=10,help="Max redshift")
+    parser.add_argument('--wmin', type=float, default=3500,help="Min wavelength (obs. frame)")
+    parser.add_argument('--wmax', type=float, default=10000,help="Max wavelength (obs. frame)")
+    parser.add_argument('--dwave', type=float, default=0.2,help="Internal wavelength step (don't change this)")
+    parser.add_argument('--nproc', type=int, default=1,help="number of processors to run faster")
+    
+    if options is None:
+        args = parser.parse_args()
+    else:
+        args = parser.parse_args(options)
+
+    return args
+
+def main(args=None):
+
+    log = get_logger()
+    if isinstance(args, (list, tuple, type(None))):
+        args = parse(args)
+
+    if isinstance(args, (list, tuple, type(None))):
+        args = parse(args)
+    
+    if args.outfile is not None and len(args.infile)>1 :
+        log.error("Cannot specify single output file with multiple inputs, use --outdir option instead")
+        return 1
+        
+    if not os.path.isdir(args.outdir) :
+        log.info("Creating dir {}".format(args.outdir))
+        os.makedirs(args.outdir)
+    
+    exptime = args.exptime
+    if exptime is None :
+        exptime = 1000. # sec
+    
+    #- Generate obsconditions with args.program, then override as needed
+    obsconditions = reference_conditions[args.program.upper()]
+    if args.airmass is not None:
+        obsconditions['AIRMASS'] = args.airmass
+    if args.seeing is not None:
+        obsconditions['SEEING'] = args.seeing
+    if exptime is not None:
+        obsconditions['EXPTIME'] = exptime
+    if args.moonfrac is not None:
+        obsconditions['MOONFRAC'] = args.moonfrac
+    if args.moonalt is not None:
+        obsconditions['MOONALT'] = args.moonalt
+    if args.moonsep is not None:
+        obsconditions['MOONSEP'] = args.moonsep
+    
+    log.info("Load SIMQSO model")
+    model=SIMQSO(normfilter=args.norm_filter,nproc=args.nproc)
+
+
+    for ifilename in args.infile : 
+        
+        if args.outfile :
+            ofilename = args.outfile
+        else :
+
+            vals = os.path.basename(ifilename).split(".")[0].split("-")
+            if len(vals)<3 :
+                log.error("Cannot guess nside and healpix from filename {}".format(ifilename))
+                raise ValueError("Cannot guess nside and healpix from filename {}".format(ifilename))
+            try :
+                healpix=int(vals[-1])
+                nside=int(vals[-2])
+            except ValueError:
+                raise ValueError("Cannot guess nside and healpix from filename {}".format(ifilename))
+            
+            ofilename = os.path.join(args.outdir,"spectra-{}-{}.fits".format(nside,healpix))
+        
+        log.info("Read skewers in {}".format(ifilename))
+        trans_wave, transmission, metadata = read_lya_skewers(ifilename)
+        ok = np.where(( metadata['Z'] >= args.zmin ) & (metadata['Z'] <= args.zmax ))[0]
+        transmission = transmission[ok]
+        metadata = metadata[:][ok]
+
+
+
+        # create quasars
+        nqso=transmission.shape[0]
+        if args.downsampling is not None :
+            if args.downsampling <= 0 or  args.downsampling > 1 :
+               log.error("Down sampling fraction={} must be between 0 and 1".format(args.downsampling))
+               raise ValueError("Down sampling fraction={} must be between 0 and 1".format(args.downsampling))
+            indices = np.where(np.random.uniform(size=nqso)<args.downsampling)[0]
+            if indices.size == 0 : 
+                log.warning("Down sampling from {} to 0 (by chance I presume)".format(nqso))
+                return
+            transmission = transmission[indices]
+            metadata = metadata[:][indices]
+            nqso = transmission.shape[0]
+
+        if args.nmax is not None :
+            if args.nmax < nqso :
+                log.info("Limit number of QSOs from {} to nmax={} (random subsample)".format(nqso,args.nmax))
+                # take a random subsample
+                indices = (np.random.uniform(size=args.nmax)*nqso).astype(int)
+                transmission = transmission[indices]
+                metadata = metadata[:][indices]
+                nqso = args.nmax
+
+        log.info("Simulate {} QSOs".format(nqso))
+        tmp_qso_flux, tmp_qso_wave, meta = model.make_templates(
+            nmodel=nqso, redshift=metadata['Z'], seed=args.seed,
+            lyaforest=False, nocolorcuts=True, noresample=True)
+
+        log.info("Resample to a linear wavelength grid (needed by DESI sim.)")
+        qso_wave=np.linspace(args.wmin,args.wmax,int((args.wmax-args.wmin)/args.dwave)+1)
+        qso_flux=np.zeros((tmp_qso_flux.shape[0],qso_wave.size))
+        for q in range(tmp_qso_flux.shape[0]) :
+            qso_flux[q]=np.interp(qso_wave,tmp_qso_wave,tmp_qso_flux[q])
+
+
+        log.info("Apply lya")
+        qso_flux = apply_lya_transmission(qso_wave,qso_flux,trans_wave,transmission)
+
+        #print("Redshifts=",metadata['Z'][:nqso])
+        #for q in range(nqso) :
+        #    plt.plot(qso_wave,qso_flux[q])
+        #plt.show()
+
+        log.info("Simulate DESI observation and write output file")
+        sim_spectra(qso_wave,qso_flux, args.program, obsconditions=obsconditions,spectra_filename=ofilename,seed=args.seed,sourcetype="qso", skyerr=args.skyerr)
+
+
+
+

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -19,8 +19,8 @@ import matplotlib.pyplot as plt
 
 def parse(options=None):
     parser=argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-                                   description="""Fast simulation of spectra into the final DESI format (Spectra class) that can be directly used as
-                                   an input to the redshift fitter (redrock). The input file is an ASCII file with first column the wavelength in A (in vacuum, redshifted), the other columns are treated as spectral flux densities in units of 10^-17 ergs/s/cm2/A.""")
+                                   description="""Fast simulation of QSO Lya spectra into the final DESI format (Spectra class) that can be directly used as
+                                   an input to the redshift fitter (redrock) or correlation function code (picca). The input file is a Lya transmission skewer fits file which format is described in https://desi.lbl.gov/trac/wiki/LymanAlphaWG/LyaSpecSim.""")
 
     #- Required
     parser.add_argument('-i','--infile', type=str, nargs= "*", required=True, help="Input skewer healpix fits file(s)")
@@ -38,7 +38,7 @@ def parse(options=None):
     parser.add_argument('--seed', type=int, default=0, help="Random seed")
     parser.add_argument('--skyerr', type=float, default=0.0, help="Fractional sky subtraction error")
     parser.add_argument('--norm-filter', type=str, default="decam2014-g", help="Broadband filter for normalization")
-    parser.add_argument('--nmax', type=int, default=None, help="Max number of QSO per input file")
+    parser.add_argument('--nmax', type=int, default=None, help="Max number of QSO per input file, for debugging")
     parser.add_argument('--downsampling', type=float, default=None,help="fractional random down-sampling (value between 0 and 1)")
     parser.add_argument('--zmin', type=float, default=0,help="Min redshift")
     parser.add_argument('--zmax', type=float, default=10,help="Max redshift")
@@ -48,7 +48,7 @@ def parse(options=None):
     parser.add_argument('--nproc', type=int, default=1,help="number of processors to run faster")
     parser.add_argument('--zbest', action = "store_true" ,help="add a zbest file per spectrum with the truth")
     parser.add_argument('--overwrite', action = "store_true" ,help="rerun if spectra exists (default is skip)")
-    parser.add_argument('--target-selection', action = "store_true" ,help="apply target selection to the simulated quasars")
+    parser.add_argument('--target-selection', action = "store_true" ,help="apply QSO target selection cuts to the simulated quasars")
     
     if options is None:
         args = parser.parse_args()

--- a/py/desisim/scripts/quickspectra.py
+++ b/py/desisim/scripts/quickspectra.py
@@ -23,7 +23,7 @@ from desispec.resolution import Resolution
 import matplotlib.pyplot as plt
 
 def sim_spectra(wave, flux, program, spectra_filename, obsconditions=None,
-    sourcetype=None, targetid=None, redshift=None, expid=0, seed=0, skyerr=0.0):
+                sourcetype=None, targetid=None, redshift=None, expid=0, seed=0, skyerr=0.0, ra=None, dec=None):
     """
     Simulate spectra from an input set of wavelength and flux and writes a FITS file in the Spectra format that can
     be used as input to the redshift fitter.
@@ -44,6 +44,9 @@ def sim_spectra(wave, flux, program, spectra_filename, obsconditions=None,
         expid : this expid number will be saved in the Spectra fibermap
         seed : random seed
         skyerr : fractional sky subtraction error
+        ra : numpy array with targets RA (deg)
+        dec : numpy array with targets Dec (deg)
+
     """
     log = get_logger()
     
@@ -79,6 +82,9 @@ def sim_spectra(wave, flux, program, spectra_filename, obsconditions=None,
     frame_fibermap['DESI_TARGET'][sourcetype=="sky"]=tm.SKY
     frame_fibermap['DESI_TARGET'][sourcetype=="bgs"]=tm.BGS_ANY
     
+    
+
+    
     if targetid is None:
         targetid = np.arange(nspec).astype(int)
         
@@ -93,10 +99,17 @@ def sim_spectra(wave, flux, program, spectra_filename, obsconditions=None,
                        ['NIGHT', 'EXPID', 'TILEID'],
                        [np.int32(night), np.int32(expid), np.int32(tileid)],
                        )
-
+           
     for s in range(nspec):
         for tp in frame_fibermap.dtype.fields:
             spectra_fibermap[s][tp] = frame_fibermap[s][tp]
+ 
+    if ra is not None :
+        spectra_fibermap["RA_TARGET"] = ra
+        spectra_fibermap["RA_OBS"]    = ra
+    if dec is not None :
+        spectra_fibermap["DEC_TARGET"] = dec
+        spectra_fibermap["DEC_OBS"]    = dec
             
     if obsconditions is None:
         if program in ['dark', 'lrg', 'qso']:

--- a/py/desisim/scripts/quickspectra.py
+++ b/py/desisim/scripts/quickspectra.py
@@ -9,6 +9,7 @@ import astropy.time
 import astropy.units as u
 import astropy.io.fits as pyfits
 
+import desisim.specsim
 import desisim.simexp
 import desisim.obs
 import desisim.io
@@ -216,6 +217,11 @@ def sim_spectra(wave, flux, program, spectra_filename, obsconditions=None,
     desispec.io.write_spectra(spectra_filename, specdata)        
     log.info('Wrote '+spectra_filename)
     
+    # need to clear the simulation buffers that keeps growing otherwise
+    # because of a different number of fibers each time ...
+    desisim.specsim._simulators.clear()
+    desisim.specsim._simdefaults.clear()
+
 
 def parse(options=None):
     parser=argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -10,6 +10,7 @@ from __future__ import division, print_function
 import os
 import sys
 import numpy as np
+import multiprocessing
 
 from desisim.io import empty_metatable
 

--- a/py/desisim/test/test_targets.py
+++ b/py/desisim/test/test_targets.py
@@ -48,7 +48,7 @@ class TestObs(unittest.TestCase):
         self.assertEqual(ndec, nspec)
 
     def test_random(self):
-        for nspec in (5):
+        for nspec in (5,):
             fibermap1, (flux1, wave1, meta1) = desisim.targets.get_targets_parallel(nspec, 'DARK', seed=nspec+1)
             fibermap2a, (flux2a, wave2a, meta2a) = desisim.targets.get_targets_parallel(nspec, 'DARK', seed=nspec+2)
             fibermap2b, (flux2b, wave2b, meta2b) = desisim.targets.get_targets_parallel(nspec, 'DARK', seed=nspec+2)

--- a/py/desisim/test/test_targets.py
+++ b/py/desisim/test/test_targets.py
@@ -48,7 +48,7 @@ class TestObs(unittest.TestCase):
         self.assertEqual(ndec, nspec)
 
     def test_random(self):
-        for nspec in (15, 30):
+        for nspec in (5):
             fibermap1, (flux1, wave1, meta1) = desisim.targets.get_targets_parallel(nspec, 'DARK', seed=nspec+1)
             fibermap2a, (flux2a, wave2a, meta2a) = desisim.targets.get_targets_parallel(nspec, 'DARK', seed=nspec+2)
             fibermap2b, (flux2b, wave2b, meta2b) = desisim.targets.get_targets_parallel(nspec, 'DARK', seed=nspec+2)


### PR DESCRIPTION
Script to generate spectra files from lya mock skewers. This is related to issue #338 .
For each skewer file (a healpix), 
 - skewers are read with desisim.lya_spectra.read_lya_skewers
 - quasar are simulated with desisim.templates.SIMQSO
 - lya transmission is applied with desisim.lya_spectra.apply_lya_transmission
 - DESI observations are simulated with desisim.scripts.quickspectra.sim_spectra 
 - optionally can write a fake zbest file, downsample the skewers ...

Example:
```
quickquasars -i /project/projectdirs/desi/mocks/lya_forest/v1.1/v1.1.0/17/1712/transmission-16-1712.fits --zmin 1.6 --nproc 24 --outdir /project/projectdirs/desi/users/jguy/sim2017/qso-v1.1.0/spectra-16 --downsampling 1. --zbest 
```


This PR is not ready for merging. I am now running Jean-Marc's mocks with this code.
Can @londumas and @andreufont have a look at the code and the results in 
```/project/projectdirs/desi/users/jguy/sim2017/qso-v1.1.0/spectra-16``` ?






