### PR TITLE
Redshift QA metrics from summary tables

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desisim change log
 0.27.1 (unreleased)
 -------------------
 
-* No changes yet
+* Enable redshift QA using input summary catalogs of truth and redshifts
 
 0.27.0 (2018-03-29)
 -------------------

--- a/py/desisim/scripts/qa_zfind.py
+++ b/py/desisim/scripts/qa_zfind.py
@@ -125,7 +125,7 @@ def main(args):
         # yamlify
         # Write yaml
         desispec.io.util.makepath(args.yaml_file)
-        with open(args.yaml_qafile, 'w') as outfile:
+        with open(args.yaml_file, 'w') as outfile:
             outfile.write(yaml.dump(yamlify(meta), default_flow_style=False))
             outfile.write(yaml.dump(yamlify(summ_dict), default_flow_style=False))
 

--- a/py/desisim/scripts/qa_zfind.py
+++ b/py/desisim/scripts/qa_zfind.py
@@ -49,7 +49,6 @@ def main(args):
     from desisim.spec_qa import redshifts as dsqa_z
     from desiutil.io import yamlify
     import desiutil.depend
-    from desimodel.footprint import radec2pix
 
     log = get_logger()
 
@@ -79,25 +78,6 @@ def main(args):
                 if not os.path.exists(fibermap_path):
                     log.debug('Skipping exposure %08d with no fibermap.' % exposure)
                     continue
-                '''
-                # Search for zbest files
-                fibermap_data = desispec.io.read_fibermap(fibermap_path)
-                flavor = fibermap_data.meta['FLAVOR']
-                if flavor.lower() in ('arc', 'flat', 'bias'):
-                    log.debug('Skipping calibration {} exposure {:08d}'.format(flavor, exposure))
-                    continue
-
-                brick_names = set(fibermap_data['BRICKNAME'])
-                import pdb; pdb.set_trace()
-                for brick in brick_names:
-                    zbest_path=desispec.io.findfile('zbest', groupname=brick, specprod_dir=args.reduxdir)
-                    if os.path.exists(zbest_path):
-                        log.debug('Found {}'.format(os.path.basename(zbest_path)))
-                        zbest_files.append(zbest_path)
-                    else:
-                        log.warn('Missing {}'.format(os.path.basename(zbest_path)))
-                        #pdb.set_trace()
-                '''
                 # Load data
                 fibermap_data = desispec.io.read_fibermap(fibermap_path)
                 # Skip calib
@@ -109,15 +89,8 @@ def main(args):
                     pdb.set_trace()
                 # Append fibermap file
                 fibermap_files.append(fibermap_path)
-                # Search for zbest files with healpy
-                ra_targ = fibermap_data['RA_TARGET'].data
-                dec_targ = fibermap_data['DEC_TARGET'].data
-                # Getting some NAN in RA/DEC
-                good = np.isfinite(ra_targ) & np.isfinite(dec_targ)
-                pixels = radec2pix(64, ra_targ[good], dec_targ[good])
-                uni_pixels = np.unique(pixels)
-                for uni_pix in uni_pixels:
-                    zbest_files.append(desispec.io.findfile('zbest', groupname=uni_pix, nside=64))
+                # Slurp the zbest_files
+                zbest_files += dsqa_z.find_zbest_files(fibermap_data)
 
         # Cut down zbest_files to unique ones
         zbest_files = list(set(zbest_files))
@@ -127,7 +100,7 @@ def main(args):
             sys.exit(1)
 
         # Write? Table
-        simz_tab = dsqa_z.load_z(fibermap_files, zbest_files)
+        simz_tab = dsqa_z.load_z(fibermap_files, zbest_files=zbest_files)
         if args.write_simz_table is not None:
             simz_tab.write(args.write_simz_table, overwrite=True)
 
@@ -148,7 +121,7 @@ def main(args):
     log.info("Running stats..")
     summ_dict = dsqa_z.summ_stats(simz_tab)
     if args.yaml_file is not None:
-        log.info("Generating yaml file: {:s}".format(args.qafile))
+        log.info("Generating yaml file of stats: {:s}".format(args.yaml_file))
         # yamlify
         # Write yaml
         desispec.io.util.makepath(args.yaml_file)

--- a/py/desisim/scripts/qa_zfind.py
+++ b/py/desisim/scripts/qa_zfind.py
@@ -100,7 +100,8 @@ def main(args):
             sys.exit(1)
 
         # Write? Table
-        simz_tab = dsqa_z.load_z(fibermap_files, zbest_files=zbest_files)
+        simz_tab, zbtab = dsqa_z.load_z(fibermap_files, zbest_files=zbest_files)
+        dsqa_z.match_truth_z(simz_tab, zbtab)
         if args.write_simz_table is not None:
             simz_tab.write(args.write_simz_table, overwrite=True)
 

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -253,14 +253,11 @@ def load_z(fibermap_files, zbest_files=None, outfil=None):
 
 def match_truth_z(simz_tab, zb_tab, mini_read=False, outfil=None):
     """ Match truth and zbest tables
-    :param simz_tab: astropy.Table
-      Either generated from load_z() or read from disk via 'truth.fits'
-    :param zb_tab: astropy.Table
-      Either generated from load_z() or read from disk via 'zcatalog-mini.fits'
-    :param mini_read: bool, optional
-      Tables were read from the summary tables written to disk
+    :param simz_tab: astropy.Table; Either generated from load_z() or read from disk via 'truth.fits'
+    :param zb_tab: astropy.Table; Either generated from load_z() or read from disk via 'zcatalog-mini.fits'
+    :param mini_read: bool, optional; Tables were read from the summary tables written to disk
     :param outfil: str, optional
-    :return: simz_tab is modified in place
+    :return: simz_tab:  modified in place
     """
 
     nsim = len(simz_tab)

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -407,7 +407,7 @@ def slice_simz(simz_tab, objtype=None, redm=False, survey=False,
             # Update
             survey_mask[elg[~elg_mask]] = False
         else:
-            import pdb; pdb.set_trace()
+            pass
     else:
         survey_mask = np.array([True]*nrow)
     # Catastrophic/Good (This gets messy...)

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -63,9 +63,9 @@ def calc_stats(simz_tab, objtype, flux_lim=True):
     obj_tab = slice_simz(simz_tab, objtype=objtype)
     stat_dict['NTARG'] = len(obj_tab)
 
-    # Number of objects with RedMonster
+    # Number of objects with Redshift Analysis
     zobj_tab = slice_simz(simz_tab,objtype=objtype,redm=True)
-    stat_dict['N_RM'] = len(zobj_tab)
+    stat_dict['N_zA'] = len(zobj_tab)
 
 
     # Redshift measured (includes catastrophics)
@@ -133,26 +133,6 @@ def find_zbest_files(fibermap_data):
         zbest_files.append(desispec.io.findfile('zbest', groupname=uni_pix, nside=64))
     # Return
     return zbest_files
-
-'''
-    # Search for zbest files
-    fibermap_data = desispec.io.read_fibermap(fibermap_path)
-    flavor = fibermap_data.meta['FLAVOR']
-    if flavor.lower() in ('arc', 'flat', 'bias'):
-        log.debug('Skipping calibration {} exposure {:08d}'.format(flavor, exposure))
-        continue
-
-    brick_names = set(fibermap_data['BRICKNAME'])
-    import pdb; pdb.set_trace()
-    for brick in brick_names:
-        zbest_path=desispec.io.findfile('zbest', groupname=brick, specprod_dir=args.reduxdir)
-        if os.path.exists(zbest_path):
-            log.debug('Found {}'.format(os.path.basename(zbest_path)))
-            zbest_files.append(zbest_path)
-        else:
-            log.warn('Missing {}'.format(os.path.basename(zbest_path)))
-            #pdb.set_trace()
-'''
 
 
 def load_z(fibermap_files, zbest_files=None, outfil=None):
@@ -696,7 +676,7 @@ def summ_fig(simz_tab, summ_tab, meta, outfile=None):
 
 
 
-def summ_stats(simz_tab, outfil=None):
+def summ_stats(simz_tab):
     '''Generate summary stats
 
     Parameters
@@ -712,7 +692,22 @@ def summ_stats(simz_tab, outfil=None):
     otypes = ['ELG','LRG', 'QSO_L', 'QSO_T', 'BGS', 'MWS']  # WILL HAVE TO DEAL WITH QSO_TRACER vs QSO_LYA
     summ_dict = {}
 
-    rows = []
+    summ_dict['A_Legend'] = {}
+    summ_dict['A_Legend']['CAT_RATE'] = 'Catastrohic Redshift failure rate'
+    summ_dict['A_Legend']['EFF'] = 'Redshift Effeciency'
+    summ_dict['A_Legend']['MEAN_DZ'] = 'Average redshift offset between measured and truth'
+    summ_dict['A_Legend']['MEDIAN_DZ'] = 'Median redshift offset between measured and truth'
+    summ_dict['A_Legend']['RMS_DZ'] = 'RMS of the redshift offsets'
+    summ_dict['A_Legend']['NCAT'] = 'Number of Catastropic failures'
+    summ_dict['A_Legend']['NTARG'] = 'Number of targets of the object type'
+    summ_dict['A_Legend']['N_GDZ'] = 'Number of targets with a correct redshift (within tolerance)'
+    summ_dict['A_Legend']['N_zA'] = 'Number of targets analyzed by the redshift code'
+    summ_dict['A_Legend']['N_SURVEY'] = 'Number of targets included in the survey (ELGs with sufficient [OII] flux)'
+    summ_dict['A_Legend']['N_ZWARN0'] = 'Number of redshifts with ZWARN == 0'
+    summ_dict['A_Legend']['PURITY'] = 'Fraction of redshifts with ZWARN == 0 that are correct'
+    summ_dict['A_Legend']['REQ_FINAL'] = 'Did the reduction pass all Requirements?'
+    summ_dict['A_Legend']['REQ_INDIV'] = 'Did the reduction pass these individual requirements?'
+
     for otype in otypes:
         # Calculate stats
         stat_dict = calc_stats(simz_tab, otype)
@@ -721,12 +716,8 @@ def summ_stats(simz_tab, outfil=None):
         summ_dict[otype]['REQ_INDIV'], passf = obj_requirements(stat_dict,otype)
         summ_dict[otype]['REQ_FINAL'] = passf
 
-    # Generate Table
-    #stat_tab = Table(rows=rows)
-
     # Return
     return summ_dict
-    #return stat_tab
 
 
 def plot_slices(x, y, ok, bad, x_lo, x_hi, y_cut, num_slices=5, min_count=100,

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -154,6 +154,7 @@ def find_zbest_files(fibermap_data):
             #pdb.set_trace()
 '''
 
+
 def load_z(fibermap_files, zbest_files=None, outfil=None):
     '''Load input and output redshift values for a set of exposures
 
@@ -169,8 +170,10 @@ def load_z(fibermap_files, zbest_files=None, outfil=None):
 
     Returns
     -------
-    Table
-      Table of target info including Redmonster redshifts
+    simz_tab: astropy.Table
+      Merged table of simpsec data
+    zb_tab: astropy.Table
+      Merged table of zbest output
     '''
     # imports
     log = get_logger()

--- a/py/desisim/spec_qa/utils.py
+++ b/py/desisim/spec_qa/utils.py
@@ -75,6 +75,7 @@ def get_sty_otype():
         QSO_T={'color':'cyan', 'lbl':'QSO z<2.1', 'pcolor':'GnBu'})
     return sty_otype
 
+
 def match_otype(tbl, objtype):
     """ Generate a mask for the input objtype
     :param tbl:
@@ -94,27 +95,4 @@ def match_otype(tbl, objtype):
     # Return
     return targets
 
-def add_desitarget(tbl):
-    """  Add a DESI_TARGET column to the input table based on the TEMPLATETYPE strings
-    This is a somewhat painful FOR loop..
-    :param tbl: astropy.Table
-    :return:
-    """
-    desi_targ = []
-    for row in tbl:
-        if 'LRG' in row['TEMPLATETYPE']:
-            desi_targ.append(desi_mask['LRG'])
-        elif 'BGS' in row['TEMPLATETYPE']:
-            desi_targ.append(desi_mask['BGS_ANY'])
-        elif 'QSO' in row['TEMPLATETYPE']:
-            desi_targ.append(desi_mask['QSO'])
-        elif 'ELG' in row['TEMPLATETYPE']:
-            desi_targ.append(desi_mask['ELG'])
-        elif 'STAR' in row['TEMPLATETYPE']:
-            desi_targ.append(desi_mask['MWS_ANY'])
-        elif 'WD' in row['TEMPLATETYPE']:
-            desi_targ.append(desi_mask['STD_WD'])
-        else:
-            desi_targ.append(-1)
-    tbl['DESI_TARGET'] = desi_targ
-    return
+

--- a/py/desisim/spec_qa/utils.py
+++ b/py/desisim/spec_qa/utils.py
@@ -15,6 +15,7 @@ from astropy.io import fits
 from astropy.table import Table, vstack, hstack, MaskedColumn, join
 
 from desiutil.log import get_logger, DEBUG
+from desitarget.targetmask import desi_mask
 
 
 def elg_flux_lim(z, oii_flux):
@@ -80,7 +81,6 @@ def match_otype(tbl, objtype):
     :param objtype: str
     :return: targets: bool mask
     """
-    from desitarget.targetmask import desi_mask
     if objtype in ['BGS']:
         targets = (tbl['DESI_TARGET'] & desi_mask['BGS_ANY']) != 0
     elif objtype in ['MWS']:
@@ -93,3 +93,28 @@ def match_otype(tbl, objtype):
         targets = (tbl['DESI_TARGET'] & desi_mask[objtype]) != 0
     # Return
     return targets
+
+def add_desitarget(tbl):
+    """  Add a DESI_TARGET column to the input table based on the TEMPLATETYPE strings
+    This is a somewhat painful FOR loop..
+    :param tbl: astropy.Table
+    :return:
+    """
+    desi_targ = []
+    for row in tbl:
+        if 'LRG' in row['TEMPLATETYPE']:
+            desi_targ.append(desi_mask['LRG'])
+        elif 'BGS' in row['TEMPLATETYPE']:
+            desi_targ.append(desi_mask['BGS_ANY'])
+        elif 'QSO' in row['TEMPLATETYPE']:
+            desi_targ.append(desi_mask['QSO'])
+        elif 'ELG' in row['TEMPLATETYPE']:
+            desi_targ.append(desi_mask['ELG'])
+        elif 'STAR' in row['TEMPLATETYPE']:
+            desi_targ.append(desi_mask['MWS_ANY'])
+        elif 'WD' in row['TEMPLATETYPE']:
+            desi_targ.append(desi_mask['STD_WD'])
+        else:
+            desi_targ.append(-1)
+    tbl['DESI_TARGET'] = desi_targ
+    return


### PR DESCRIPTION
Calculate the summary QA statistics for redshift performance
provided an input truth and measured redshift tables.  Tested
to work with truth.fits and zcatalog-mini.fits from reference run 18.3

Here is the code snippet

```
from desisim.spec_qa import redshifts as dsqa_z
from astropy.table import Table   # The underlying code uses MaskedColumn and other astropy functionality

zcat = Table.read('spectro/redux/mini/zcatalog-mini.fits')
truth = Table.read('targets/truth.fits')

# Sync the two tables
dsqa_z.match_truth_z(truth, zcat, mini_read=True)

# Calculate
metric_dict = dsqa_z.summ_stats(truth)
```

Addresses Issue #346 

Have also tested that --yaml_file= option in desi_qa_zfind works
with reference run 18.3.  Will add it to the minitest Notebook soon.