### PR TITLE
Add ztests method to redshift QA

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,11 @@ desisim change log
 0.27.1 (unreleased)
 -------------------
 
-* Enable redshift QA using input summary catalogs of truth and redshifts
+* Add zstats-like QA method from desitest mini Notebook and refactor previous code to enable it
+* Update QA to use qaprod_dir
+* Enable redshift QA using input summary catalogs of truth and redshifts (`PR #349`_)
+
+.. _`PR #349`: https://github.com/desihub/desisim/pull/349
 
 0.27.0 (2018-03-29)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,14 @@ desisim change log
 0.27.1 (unreleased)
 -------------------
 
-* Add zstats-like QA method from desitest mini Notebook and refactor previous code to enable it
+* Add zstats-like good/fail/miss/list QA method from desitest mini
+  Notebook and refactor previous code to enable it (`PR #351`_).
 * Update QA to use qaprod_dir
-* Enable redshift QA using input summary catalogs of truth and redshifts (`PR #349`_)
+* Enable redshift QA using input summary catalogs of truth and redshifts
+  (`PR #349`_)
 
 .. _`PR #349`: https://github.com/desihub/desisim/pull/349
+.. _`PR #351`: https://github.com/desihub/desisim/pull/351
 
 0.27.0 (2018-03-29)
 -------------------

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -265,383 +265,252 @@ def write_simspec_arc(filename, wave, phot, header, fibermap, overwrite=False):
     hx.writeto(filename, clobber=overwrite)
     return filename
 
+class SimSpecCamera(object):
+    """Wrapper of per-camera photon data from a simspec file"""
+    def __init__(self, camera, wave, phot, skyphot=None):
+        """
+        Create a SimSpecCamera object
 
-class SimSpec(object):
-    """Lightweight wrapper object for simspec data.
+        Args:
+            camera: camera name, e.g. b0, r1, z9
+            wave: 1D[nwave] array of wavelengths [Angstrom]
+            phot: 2D[nspec, nwave] photon counts per bin (not per Angstrom)
 
-    Args:
-        flavor (str): e.g. 'arc', 'flat', 'dark', 'mws', ...
-        wave : dictionary with per-channel wavelength grids, keyed by
-            'b', 'r', 'z'.  Optionally also has 'brz' key for channel
-            independent wavelength grid
-        phot : dictionary with per-channel photon counts per bin
+        Options:
+            skyphot: 2D[nspec, nwave] sky photon counts per bin
+        """
+        #- Check inputs
+        assert camera in [
+            'b0', 'r0', 'z0', 'b1', 'r1', 'z1',
+            'b2', 'r2', 'z2', 'b3', 'r3', 'z3',
+            'b4', 'r4', 'z4', 'b5', 'r5', 'z5',
+            'b6', 'r6', 'z6', 'b7', 'r7', 'z7',
+            'b8', 'r8', 'z8', 'b9', 'r9', 'z9',
+        ]
+        assert wave.ndim == 1, 'wave.ndim should be 1 not {}'.format(wave.ndim)
+        assert phot.ndim == 2, 'phot.ndim should be 2 not {}'.format(phot.ndim)
+        assert phot.shape[1] == wave.shape[0]
+        if skyphot is not None:
+            assert skyphot.ndim == 2, \
+                'skyphot.ndim should be 2 not {}'.format(skyphot.ndim)
+            assert skyphot.shape == phot.shape, \
+                'skyphot.shape {} != phot.shape {}'.format(skyphot.shape, phot.shape)
 
-    Optional:
-        flux : channel-independent flux [erg/s/cm^2/A]
-        skyflux : channel-indepenent sky flux [erg/s/cm^2/A/arcsec^2]
-        skyphot : dictionary with per-channel sky photon counts per bin
-        metadata : table of metadata information about these spectra
-        header : FITS header from HDU0
-        fibermap : fibermap Table
-        obs : (dict-like) observing conditions; see keys in notes below
-
-    Notes:
-      * input arguments become attributes
-      * wave[channel] is the wavelength grid for phot[channel] and
-            skyphot[channel] where channel = 'b', 'r', or 'z'
-      * wave['brz'] is the wavelength grid for flux and skyflux
-      * obsconditions keys SEEING (arcsec), EXPTIME (sec), AIRMASS,
-        MOONFRAC (0-1), MOONALT (deg), MOONSEP (deg)
-    """
-    def __init__(self, flavor, wave, phot, flux=None, skyflux=None,
-                 skyphot=None, metadata=None, fibermap=None, obs=None, header=None):
-
-        #change to a new testing procedure since channel is now an input
-        for channel in phot.keys():
-            nspec=phot[channel].shape[0]
-
-        for channel in phot.keys():
-            assert phot[channel].shape[0]==nspec
-
-        #commented in the case that channel is fed as an input, one at a time
-        #assert phot['b'].shape[0] == phot['r'].shape[0] == phot['z'].shape[0]
-
-        self.flavor = flavor
-        self.nspec = nspec
+        self.camera = camera
         self.wave = wave
         self.phot = phot
-
-        #- Optional items; may be None
         self.skyphot = skyphot
+
+class SimSpec(object):
+    """Lightweight wrapper object for simspec data
+
+    Object has properties flavor, nspec, wave, flux, skyflux, fibermap, truth,
+    obsconditions, header, cameras.
+
+    cameras is dict, keyed by camera name, of SimSpecCameras objects with
+    properies wave, phot, skyphot.
+
+    """
+    def __init__(self, flavor, wave, flux, skyflux, fibermap,
+                 truth, obsconditions, header):
+        """
+        Create a SimSpec object
+
+        Args:
+            flavor (str): e.g. 'arc', 'flat', 'science'
+            wave : 1D[nwave] array of wavelengths in Angstroms
+            flux : 2D[nspec, nwave] flux in 1e-17 erg/s/cm2/Angstrom
+            skyflux : 2D[nspec, nwave] flux in 1e-17 erg/s/cm2/Angstrom
+            fibermap: fibermap table
+            truth: table of truth metadata information about these spectra
+            obsconditions (dict-like): observing conditions; see notes below
+            header : FITS header from HDU0
+
+        Notes:
+          * all inputs must be specified but can be None, depending upon flavor,
+            e.g. arc and flat don't have skyflux or obsconditions
+          * obsconditions keys SEEING (arcsec), EXPTIME (sec), AIRMASS,
+            MOONFRAC (0-1), MOONALT (deg), MOONSEP (deg)
+          * use self.add_camera to add per-camera photons
+        """
+
+        if wave is not None and flux is not None:
+            assert wave.ndim == 1, 'wave.ndim should be 1 not {}'.format(wave.ndim)
+            assert flux.ndim == 2, 'flux.ndim should be 2 not {}'.format(flux.ndim)
+            assert flux.shape[1] == wave.shape[0]
+        if skyflux is not None:
+            assert wave is not None
+            assert flux is not None
+            assert skyflux.ndim == 2, \
+                'skyflux.ndim should be 2 not {}'.format(skyflux.ndim)
+            assert skyflux.shape == flux.shape, \
+                'skyflux.shape {} != flux.shape {}'.format(skyflux.shape, flux.shape)
+
+        self.flavor = flavor
+        self.nspec = len(fibermap)
+        self.wave = wave
         self.flux = flux
         self.skyflux = skyflux
-        self.metadata = metadata
         self.fibermap = fibermap
-        self.obs = obs
+        self.truth = truth
+        self.obsconditions = obsconditions
         self.header = header
 
-def read_simspec_mpi(filename, comm, channel, spectrographs=None):
+        self.cameras = dict()
+
+    def add_camera(self, camera, wave, phot, skyphot=None):
+        """
+        Add per-camera photons to this SimSpec object, using SimSpecCamera
+
+        Args:
+            camera: camera name, e.g. b0, r1, z9
+            wave: 1D[nwave] array of wavelengths
+            phot: 2D[nspec, nwave] array of photons per bin (not per Angstrom)
+
+        Optional:
+            skyphot: 2D[nspec, nwave] array of sky photons per bin
+        """
+        self.cameras[camera] = SimSpecCamera(camera, wave, phot, skyphot)
+
+def read_simspec(filename, camera=None, comm=None, readflux=True, readphot=True):
     """
-    Read simspec data from filename and return SimSpec object.
+    Read a simspec file and return a SimSpec object
+
+    Args:
+        filename: input simspec file name
+
+    Options:
+        camera: camera name or list of names, e.g. b0, r1, z9
+        comm: MPI communicator
+        readflux: if True (default), include flux
+        readphot: if True (default), include per-camera photons
     """
-    import astropy.table
-    from mpi4py import MPI #need to reimport this so MPI.DOUBLE can be used
-
-    # rank 0 opens file and gets the metadata and wavelength
-    # grids, which will be kept on all processes.
-
-    hdr = None
-    flavor = None
-    fibermap = None
-    obs = None
-    wave = dict()
-    totalspec = None
-
-    if comm.rank == 0:
-        fx = fits.open(filename, memmap=True)
-        hdr = fx[0].header.copy()
-        flavor = hdr['FLAVOR']
-        if 'WAVE' in fx:
-            wave['brz'] = native_endian(fx['WAVE'].data.copy())
-        #for channel in ('b', 'r', 'z'):
-        hname = 'WAVE_'+channel.upper()
-        wave[channel] = native_endian(fx[hname].data.copy())
-        if 'FIBERMAP' in fx:
-            fibermap = astropy.table.Table(fx['FIBERMAP'].data.copy())
-            totalspec = len(fibermap)
-        else:
-            # Get the number of spectra from one of the photon HDUs
-            totalspec = fx['PHOT_B'].header['NAXIS2']
-        if 'OBSCONDITIONS' in fx:
-            obs = astropy.table.Table(fx['OBSCONDITIONS'].data.copy())[0]
-        fx.close()
-        # Memmap file handle should close here when fx goes out of scope...
-
-    hdr = comm.bcast(hdr, root=0)
-    flavor = comm.bcast(flavor, root=0)
-    obs = comm.bcast(obs, root=0)
-    totalspec = comm.bcast(totalspec, root=0)
-    wave = comm.bcast(wave, root=0)
-    fibermap = comm.bcast(fibermap, root=0)
-
-    # Based on the spectrographs for this process, compute the range of
-    # spectra we need to store.  The number of spectra per spectrograph (500)
-    # is hard-coded several places in desisim.  This should be put in desimodel
-    # somewhere...
-
-    fibers = None
-    if fibermap is not None:
-        fibers = np.array(fibermap['FIBER'], dtype=np.int32)
+    if comm is not None:
+        rank, size == comm.rank, comm.size
     else:
-        fibers = np.arange(totalspec, dtype=np.int32)
+        rank, size = 0, 1
 
-    #this comes in as an input, spectrographs=group_spectra[i]
-    #just simulate and write one spectrograph at a time
-    if spectrographs is None:
-        spectrographs = np.arange(10, dtype=np.int32)
+    if camera is None:
+        #- Build the potential cameras list based upon the fibermap
+        cameras = list()
+        minfiber = np.min(fibermap['FIBER'])
+        maxfiber = np.max(fibermap['FIBER'])
+        for spectrograph in range(10):
+            fibers = np.arange(500) + spectrograph*500
+            if np.any(np.in1d(fibers, fibermap['FIBER'])):
+                for channel in ['b', 'r', 'z']:
+                    cameras.append(channel + str(spectrograph))
 
-    specslice = np.in1d(fibers//500, spectrographs)
-
-    if fibermap is not None:
-        fibermap = fibermap[specslice]
-
-    # Now read one HDU at a time, broadcast, and every process grabs its slice.
-
-    # Note: this is global scope within the function, so memmap file handle
-    # will not close until the function returns (which is fine).
-    # only want to open file for rank 0 to cut down on I/O
-    if comm.rank ==0:
-        hdus = None
-        hdus = fits.open(filename, memmap=True)
-
-    #in these next blocks, we fix the endian-ness of the data for each type
-    #we also extract the data for later broadcast if comm.rank == 0
-    #and we store the shape of the data to allocate numpy arrays if comm_rank !=0
-    #it looks a little silly but it's better than trying to convert from a python
-    #dictionary back to a numpy array later
-
-    #preallocate shape_dict
-    shape_dict=dict()
-
-    #have to check in a different way than read_simspec since we don't
-    #have fx availble on all ranks
-
-    #we will sort according to flavor in the mpi version
-    #flavor = flat has phot and flux
-    #flavor = arc has phot
-    #flavor = science has phot, flux, skyphot, and skyflux
-
-    #all flavors have photons
-    hname = 'PHOT_'+channel.upper()
-    if comm.rank == 0:
-        phot_hdata=np.empty(1,dtype=np.float64)
-        phot_hdata=native_endian(hdus[hname].data.copy().astype('f8'))
-        shape_dict[hname]=hdus[hname].shape
-    del hname
-
-    #flavors=science and flat have flux
-    hname = 'FLUX'
-    if comm.rank == 0:
-        flux_hdata=np.empty(1,dtype=np.float64)
-        if (flavor == 'science') or (flavor == 'flat'):
-            flux_hdata=native_endian(hdus[hname].data.copy().astype('f8'))
-            shape_dict[hname]=hdus[hname].shape
-    del hname
-
-    #only flavor=science has skyphot
-    hname = 'SKYPHOT_'+channel.upper()
-    if comm.rank ==0:
-        sky_hdata=np.empty(1,dtype=np.float64)
-        if flavor == 'science':
-            sky_hdata=native_endian(hdus[hname].data.copy().astype('f8'))
-            shape_dict[hname]=hdus[hname].shape
-    del hname
-
-    #only flavor=science has skyflux
-    hname = 'SKYFLUX'
-    if comm.rank ==0:
-        skyflux_hdata=np.empty(1,dtype=np.float64)
-        if flavor == 'science':
-            skyflux_hdata=native_endian(hdus[hname].data.copy().astype('f8'))
-            shape_dict[hname]=hdus[hname].shape
-    del hname
-
-    #now put shape tuples into a dict so we can broadcast them
-    #one broadcast is more efficienct than many broadcasts
-    #this allows the ranks to know what size to preallocate
-    shape_dict= comm.bcast(shape_dict, root=0)
-    #add a barrier so we can make sure these data have been broadcast
-    #to all ranks before we start the next process
-    comm.Barrier()
-
-    #we will sort according to flavor in the mpi version
-    #flavor = flat has phot and flux
-    #flavor = arc has phot
-    #flavor = science has phot, flux, skyphot, and skyflux
-
-    # Read photons
-    # all flavors have photons
-    phot = dict()
-    if comm.rank == 0:
-        #hdata=phot_hdata
-        phot[channel]=phot_hdata[specslice]
-    phot = comm.bcast(phot, root=0)
-
-    # Read flux
-    #flavors science and flat have flux
-    flux = dict()
-    if (flavor == 'science') or (flavor == 'flat'):
-        if comm.rank == 0:
-            flux[channel]  = flux_hdata[specslice]
-        flux = comm.bcast(flux, root=0)
-
-    # Read sky photons
-    #only flavor=science has skyphot
-    skyphot = dict()
-    if flavor == 'science':
-        if comm.rank == 0:
-            skyphot[channel] = sky_hdata[specslice]
-        skyphot = comm.bcast(skyphot,root=0)
+    elif isinstance(camera, str):
+        cameras = [camera,]
     else:
-        skyphot[channel] = np.zeros_like(phot[channel])
-    assert phot[channel].shape == skyphot[channel].shape
+        cameras = camera
 
-    # Read skyflux
-    #only flavor science has skyflux
-    skyflux = np.empty(1,dtype=np.float64)
-    if flavor == 'science':
-        if comm.rank == 0:
-            skyflux=skyflux_hdata[specslice]
-        elif comm.rank != 0:
-            skyflux=np.empty(shape_dict['SKYFLUX'],dtype=np.float64)[specslice]
-        comm.Bcast([skyflux,MPI.DOUBLE],root=0)
+    #- Read and broadcast data that are common across cameras
+    header = flavor = truth = fibermap = obsconditions = None
+    wave = flux = skyflux = None
+    if rank == 0:
+        with fits.open(filename, memmap=False) as fx:
+            header = fx[0].header.copy()
+            flavor = header['FLAVOR']
 
-    # metadata / truth
-    metadata = None
-    hname = 'TRUTH'
-    found = False
-    if comm.rank == 0:
-        if hname in hdus:
-            found = True
-    found = comm.bcast(found, root=0)
-    if not found:
-        hname = 'METADATA'
-        if comm.rank == 0:
-            if hname in hdus:
-                found = True
-        found = comm.bcast(found, root=0)
-    if found:
-        hdata = None
-        if comm.rank == 0:
-            hdata = astropy.table.Table(hdus[hname].data.copy())
-        hdata = comm.bcast(hdata, root=0) #leaving this call alone because hdata is not a numpy array
-        metadata = hdata[specslice].copy()
-        del hdata
+            if 'WAVE' in fx and readflux:
+                wave = native_endian(fx['WAVE'].data.copy())
 
-        if comm.rank == 0:
-            hdus.close()
+            if 'FLUX' in fx and readflux:
+                flux = native_endian(fx['FLUX'].data.astype('f8'))
 
-    return SimSpec(flavor, wave, phot, flux=flux, skyflux=skyflux,
-        skyphot=skyphot, metadata=metadata, fibermap=fibermap, obs=obs,
-        header=hdr)
+            if 'SKYFLUX' in fx and readflux:
+                skyflux = native_endian(fx['SKYFLUX'].data.astype('f8'))
 
-def read_simspec(filename, nspec=None, firstspec=0):
-    """Read simspec data from filename and return SimSpec object.
-    """
-    import astropy.table
-    with fits.open(filename, memmap=False) as fx:
-        hdr = fx[0].header
-        flavor = hdr['FLAVOR']
+            if 'TRUTH' in fx:
+                truth = Table(fx['TRUTH'].data)
 
-        #- All flavors have photons
-        wave = dict()
-        phot = dict()
-        skyphot = dict()
-        for channel in ('b', 'r', 'z'):
-            wave[channel] = native_endian(fx['WAVE_'+channel.upper()].data)
-            phot[channel] = native_endian(fx['PHOT_'+channel.upper()].data.astype('f8'))
+            if 'FIBERMAP' in fx:
+                fibermap = Table(fx['FIBERMAP'].data)
 
-            skyext = 'SKYPHOT_'+channel.upper()
-            if skyext in fx:
-                skyphot[channel] = native_endian(fx[skyext].data.astype('f8'))
+            if 'OBSCONDITIONS' in fx:
+                obsconditions = Table(fx['OBSCONDITIONS'].data)[0]
+
+    if comm is not None:
+        header = comm.bcast(header, root=0)
+        flavor = comm.bcast(flavor, root=0)
+        truth = comm.bcast(truth, root=0)
+        fibermap = comm.bcast(fibermap, root=0)
+        obsconditions = comm.bcast(obsconditions, root=0)
+
+        wave = comm.Bcast(wave, root=0)
+        flux = comm.Bcast(flux, root=0)
+        skyflux = comm.Bcast(skyflux, root=0)
+
+    #- Trim arrays to match camera
+    #- Note: we do this after the MPI broadcast because rank 0 doesn't know
+    #- which ranks need which cameras.  Although inefficient, in practice
+    #- this doesn't matter (yet?) because the place we use parallelism is
+    #- pixsim which uses readflux=False and thus doesn't broadcast flux anyway
+    ii = np.zeros(len(fibermap), dtype=bool)
+    for camera in cameras:
+        spectrograph = int(camera[1])   #- e.g. b0
+        fibers = np.arange(500, dtype=int) + spectrograph*500
+        ii |= np.in1d(fibermap['FIBER'], fibers)
+
+    assert np.any(ii), "input simspec doesn't cover cameras {}".format(cameras)
+
+    fibermap = fibermap[ii]
+    if flux is not None:
+        flux = flux[ii]
+    if skyflux is not None:
+        skyflux = skyflux[ii]
+    if truth is not None:
+        truth = truth[ii]
+
+    simspec = SimSpec(flavor, wave, flux, skyflux,
+                fibermap, truth, obsconditions, header)
+
+    #- Now read individual camera photons
+    #- NOTE: this is somewhat inefficient since the same PHOT_B/R/Z HDUs
+    #- are read multiple times by different nodes for different cameras,
+    #- though at least only one reader per camera (node) not per rank.
+    #- If this is slow, this would be an area for optimization.
+    if readphot:
+        for camera in cameras:
+            channel = camera[0].upper()
+            spectrograph = int(camera[1])
+            fiber = fibermap['FIBER']
+            ii = (spectrograph*500 <= fiber) & (fiber < (spectrograph+1)*500)
+            assert np.any(ii), 'Camera {} is not in fibers {}-{}'.format(
+                                            camera, np.min(fiber), np.max(fiber) )
+
+            #- Split MPI communicator by camera
+            #- read and broadcast each camera
+            if comm is not None:
+                camcomm = comm.split(color=camera)
+                camrank = camcomm.rank
             else:
-                skyphot[channel] = np.zeros_like(phot[channel])
+                camcomm = None
+                camrank = 0
 
-            assert phot[channel].shape == skyphot[channel].shape
+            wave = phot = skyphot = None
+            if camrank == 0:
+                with fits.open(filename, memmap=False) as fx:
+                    wave = native_endian(fx['WAVE_'+channel].data.copy())
+                    phot = native_endian(fx['PHOT_'+channel].data[ii].astype('f8'))
+                    if 'SKYPHOT_'+channel in fx:
+                        skyphot = native_endian(fx['SKYPHOT_'+channel].data[ii].astype('f8'))
+                    else:
+                        skyphot = None
 
-        #- Check for flux, skyflux, and metadata
-        flux = None
-        skyflux = None
-        if 'WAVE' in fx:
-            wave['brz'] = native_endian(fx['WAVE'].data)
-        if 'FLUX' in fx:
-            flux = native_endian(fx['FLUX'].data.astype('f8'))
-        if 'SKYFLUX' in fx:
-            skyflux = native_endian(fx['SKYFLUX'].data.astype('f8'))
+            if camcomm is not None:
+                wave = camcomm.Bcast(wave, root=0)
+                phot = camcomm.Bcast(phot, root=0)
+                skyphot = camcomm.Bcast(skyphot, root=0)
 
-        if 'TRUTH' in fx:
-            metadata = astropy.table.Table(fx['TRUTH'].data)
-        #- For backwards compatibility
-        elif 'METADATA' in fx:
-            metadata = astropy.table.Table(fx['METADATA'].data)
-        else:
-            metadata = None
+            simspec.add_camera(camera, wave, phot, skyphot)
 
-        if 'FIBERMAP' in fx:
-            fibermap = astropy.table.Table(fx['FIBERMAP'].data)
-        else:
-            fibermap = None
+    return simspec
 
-        if 'OBSCONDITIONS' in fx:
-            obs = astropy.table.Table(fx['OBSCONDITIONS'].data)[0]
-        else:
-            obs = None
-
-    #- Trim down if requested
-    if nspec is None:
-        nspec = phot['b'].shape[0]
-
-    if firstspec > 0 or firstspec+nspec<phot['b'].shape[0]:
-        for channel in ('b', 'r', 'z'):
-            phot[channel] = phot[channel][firstspec:firstspec+nspec]
-            skyphot[channel] = skyphot[channel][firstspec:firstspec+nspec]
-        if flux is not None:
-            flux = flux[firstspec:firstspec+nspec]
-        if skyflux is not None:
-            skyflux = skyflux[firstspec:firstspec+nspec]
-        if metadata is not None:
-            metadata = metadata[firstspec:firstspec+nspec]
-
-    return SimSpec(flavor, wave, phot, flux=flux, skyflux=skyflux,
-        skyphot=skyphot, metadata=metadata, fibermap=fibermap, obs=obs,
-        header=hdr)
-
-
-def _read_simspec_orig(filename):
-    """Read simspec data from filename and return SimSpec object.
-    """
-
-    fx = fits.open(filename)
-    hdr = fx[0].header
-    flavor = hdr['FLAVOR']
-
-    #- All flavors have photons
-    wave = dict()
-    phot = dict()
-    skyphot = dict()
-    for channel in ('b', 'r', 'z'):
-        wave[channel] = fx['WAVE_'+channel.upper()].data
-        phot[channel] = fx['PHOT_'+channel.upper()].data
-        skyext = 'SKYPHOT_'+channel.upper()
-        if skyext in fx:
-            skyphot[channel] = fx[skyext].data
-        else:
-            skyphot[channel] = np.zeros_like(phot[channel])
-
-    if flavor == 'arc':
-        fx.close()
-        return SimSpec(flavor, wave, phot, skyphot=skyphot, header=hdr)
-
-    elif flavor == 'flat':
-        wave['brz'] = fx['WAVE'].data
-        flux = fx['FLUX'].data
-        fx.close()
-        return SimSpec(flavor, wave, phot, skyphot=skyphot, flux=flux, header=hdr)
-
-    else:  #- multiple science flavors: dark, bright, bgs, mws, etc.
-        wave['brz'] = fx['WAVE'].data
-        flux = fx['FLUX'].data
-        metadata = fx['METADATA'].data
-        skyflux = fx['SKYFLUX'].data
-        skyphot = dict()
-        for channel in ('b', 'r', 'z'):
-            extname = 'SKYPHOT_'+channel.upper()
-            skyphot[channel] = fx[extname].data
-
-        fx.close()
-        return SimSpec(flavor, wave, phot, flux=flux, skyflux=skyflux,
-            skyphot=skyphot, metadata=metadata, header=hdr)
-
+#-------------------------------------------------------------------------
+#- simpix
 
 def write_simpix(outfile, image, camera, meta):
     """Write simpix data to outfile.

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -208,6 +208,9 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
     simfile = io.write_simspec(sim, meta, fibermap, obsconditions,
         expid, night, header=hdr, filename=outsimspec)
 
+    if not isinstance(fibermap, table.Table):
+        fibermap = table.Table(fibermap)
+
     fibermap.meta.update(hdr)
     desispec.io.write_fibermap(outfibermap, fibermap)
     log.info('Wrote '+outfibermap)

--- a/py/desisim/scripts/fastframe.py
+++ b/py/desisim/scripts/fastframe.py
@@ -47,14 +47,14 @@ def main(args=None):
         args = parse(args)
     
     print('Reading files')
-    simspec = desisim.io.read_simspec(args.simspec)
+    simspec = desisim.io.read_simspec(args.simspec, readphot=False)
 
     if simspec.flavor == 'arc':
         print('arc exposure; no frames to output')
         return
 
     fibermap = simspec.fibermap
-    obs = simspec.obs
+    obs = simspec.obsconditions
     night = simspec.header['NIGHT']
     expid = simspec.header['EXPID']
 
@@ -62,7 +62,7 @@ def main(args=None):
     nspec = min(args.nspec, len(fibermap)-firstspec)
 
     print('Simulating spectra {}-{}'.format(firstspec, firstspec+nspec))
-    wave = simspec.wave['brz']
+    wave = simspec.wave
     flux = simspec.flux
     ii = slice(firstspec, firstspec+nspec)
     if simspec.flavor == 'science':

--- a/py/desisim/scripts/pixsim.py
+++ b/py/desisim/scripts/pixsim.py
@@ -372,8 +372,7 @@ def main(args, comm=None):
             truepix = {}
 
             #since we handle only one spectra at a time, just load the one we need 
-            simspec = io.read_simspec_mpi(args.simspec, comm_group, channel,
-                          spectrographs=group_spectro[i])
+            simspec = io.read_simspec(args.simspec, camera, comm=comm_group)
 
             if group_rank == 0:
                 log.debug('Processing camera {}'.format(camera))
@@ -426,7 +425,7 @@ def main(args, comm=None):
             group_fibers = fibers[fs]
 
             image[camera], rawpix[camera], truepix[camera] = \
-                simulate(camera, simspec, psf, fibers=group_fibers,
+                simulate(camera, simspec, psf,
                     ncpu=args.ncpu, nspec=args.nspec, cosmics=cosmics,
                     wavemin=args.wavemin, wavemax=args.wavemax, preproc=False,
                     comm=comm_group)
@@ -462,12 +461,11 @@ def main(args, comm=None):
     #initalize random number seeds
     seed_counter=0 #need to initialize counter
     if comm is None:
-        simspec = io.read_simspec(args.simspec)
         previous_camera='a'
         for i in range(len(node_cameras)):
-
             current_camera=node_cameras[i]
             camera=current_camera[0] + current_camera[1]
+            simspec = io.read_simspec(args.simspec, camera)
             channel=current_camera[0]
 
             if group_rank == 0:
@@ -519,7 +517,7 @@ def main(args, comm=None):
                     "{}".format(group, group_size, camera))
 
             image[camera], rawpix[camera], truepix[camera] = \
-                simulate(camera, simspec, psf, fibers=group_fibers, 
+                simulate(camera, simspec, psf,
                     ncpu=args.ncpu, nspec=args.nspec, cosmics=cosmics, 
                     wavemin=args.wavemin, wavemax=args.wavemax, preproc=False,
                     comm=comm_group)

--- a/py/desisim/scripts/qa_s2n.py
+++ b/py/desisim/scripts/qa_s2n.py
@@ -17,7 +17,7 @@ def parse(options=None):
     parser = argparse.ArgumentParser(description="Generate S/N QA for a production [v{:s}]".format(__qa_version__), formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     #parser.add_argument('--rawdir', type = str, default = None, metavar = 'PATH',
     #                    help = 'Override default path ($DESI_SPECTRO_DATA) to processed data.')
-    parser.add_argument('--qafig_path', type=str, default=None, help = 'Path to where QA figure files are generated.  Default is qaprod_dir')
+    parser.add_argument('--qaprod_dir', type=str, default=None, help = 'Path to where QA figure files are generated.  Default is qaprod_dir')
 
     if options is None:
         args = parser.parse_args()
@@ -35,10 +35,10 @@ def main(args):
     from desisim.spec_qa.s2n import load_s2n_values, obj_s2n_wave, obj_s2n_z
 
     # Initialize
-    if args.qafig_path is not None:
-        qafig_path = args.qafig_path
+    if args.qaprod_dir is not None:
+        qaprod_dir = args.qaprod_dir
     else:
-        qafig_path = desispec.io.meta.qaprod_root()
+        qaprod_dir = desispec.io.meta.qaprod_root()
     # Generate the path
     # Grab nights
     nights = desispec.io.get_nights()
@@ -66,12 +66,12 @@ def main(args):
             # Load
             s2n_values = load_s2n_values(objtype, nights, channel)#, sub_exposures=exposures)
             # Plot
-            outfile = qafig_path+'/QA_s2n_{:s}_{:s}.png'.format(objtype, channel)
+            outfile = qaprod_dir+'/QA_s2n_{:s}_{:s}.png'.format(objtype, channel)
             desispec.io.util.makepath(outfile)
             obj_s2n_wave(s2n_values, wv_bins, flux_bins, objtype, outfile=outfile)
             # S/N vs. z for ELG
             if (channel == 'z') & (objtype=='ELG'):
-                outfile = qafig_path+'/QA_s2n_{:s}_{:s}_redshift.png'.format(objtype,channel)
+                outfile = qaprod_dir+'/QA_s2n_{:s}_{:s}_redshift.png'.format(objtype,channel)
                 desispec.io.util.makepath(outfile)
                 obj_s2n_z(s2n_values, z_bins, oii_bins, objtype, outfile=outfile)
 

--- a/py/desisim/scripts/qa_zfind.py
+++ b/py/desisim/scripts/qa_zfind.py
@@ -26,7 +26,7 @@ def parse(options=None):
     parser.add_argument('--yaml_file', type = str, default = None, required=False,
                         help = 'YAML file for debugging (primarily).')
     parser.add_argument('--write_simz_table', type=str, default=None, help = 'Write simz to this filename')
-    parser.add_argument('--qafig_path', type=str, default=None, help = 'Path to where QA figure files are generated.  Default is specprod_dir+/QA')
+    parser.add_argument('--qaprod_dir', type=str, default=None, help = 'Path to where QA figure files are generated.  Default is specprod_dir+/QA')
 
     if options is None:
         args = parser.parse_args()
@@ -53,12 +53,10 @@ def main(args):
     log = get_logger()
 
     # Initialize
-    specprod_dir = desispec.io.meta.specprod_root()
-
-    if args.qafig_path is not None:
-        qafig_path = args.qafig_path
+    if args.qaprod_dir is not None:
+        qaprod_dir = args.qaprod_dir
     else:
-        qafig_path = desispec.io.meta.qaprod_root()
+        qaprod_dir = desispec.io.meta.qaprod_root()
 
 
     if args.load_simz_table is not None:
@@ -132,14 +130,14 @@ def main(args):
 
     log.info("Generating QA files")
     # Summary for dz of all types
-    outfile = qafig_path+'/QA_dzsumm.png'
+    outfile = qaprod_dir+'/QA_dzsumm.png'
     desispec.io.util.makepath(outfile)
     dsqa_z.dz_summ(simz_tab, outfile=outfile)
     # Summary of individual types
     #outfile = args.qafig_root+'_summ_fig.png'
     #dsqa_z.summ_fig(simz_tab, summ_dict, meta, outfile=outfile)
     for objtype in ['BGS', 'MWS', 'ELG','LRG', 'QSO_T', 'QSO_L']:
-        outfile = qafig_path+'/QA_zfind_{:s}.png'.format(objtype)
+        outfile = qaprod_dir+'/QA_zfind_{:s}.png'.format(objtype)
         desispec.io.util.makepath(outfile)
         dsqa_z.obj_fig(simz_tab, objtype, summ_dict, outfile=outfile)
 

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -347,9 +347,9 @@ def obj_requirements(zstats, objtype):
 def zstats(simz_tab, objtype=None, dvlimit=None, count=False, survey=False):
     """ Perform statistics on the input truth+z table
     good = Satisfies dv criteria and ZWARN==0
-    cat = Fails dv criteria with ZWARN==0
-    miss = Fails dv criteria but ZWARN!=0
-    lost = Fails dv criteria and ZWARN!=0
+    fail = Fails dv criteria with ZWARN==0 (catastrophic failures)
+    miss = Satisfies dv criteria but ZWARN!=0 (missed opportunities)
+    lost = Fails dv criteria and ZWARN!=0 (lost, but at least we knew it)
 
     Args:
         simz_tab:
@@ -360,7 +360,7 @@ def zstats(simz_tab, objtype=None, dvlimit=None, count=False, survey=False):
 
     Returns:
         if count=True: just the raw counts of each category :: ngood, nfail, nmiss, nlost
-        else: precentile of each relative to ntot and ntot
+        else: percentile of each relative to ntot, and ntot
 
     """
     # Grab the masks

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -367,12 +367,12 @@ def zstats(simz_tab, objtype=None, dvlimit=None, count=False, survey=False):
     objtype_mask, z_mask, survey_mask, dv_mask, zwarn_mask = criteria(
         simz_tab, dvlimit=dvlimit, objtype=objtype)
     # Score-card
-    good = zwarn_mask & dv_mask & objtype_mask
-    cat = zwarn_mask & (~dv_mask) & objtype_mask
-    miss = (~zwarn_mask) & dv_mask & objtype_mask
-    lost = (~zwarn_mask) & (~dv_mask) & objtype_mask
+    good = zwarn_mask & dv_mask & objtype_mask & z_mask
+    cat = zwarn_mask & (~dv_mask) & objtype_mask & z_mask
+    miss = (~zwarn_mask) & dv_mask & objtype_mask & z_mask
+    lost = (~zwarn_mask) & (~dv_mask) & objtype_mask & z_mask
     # Restrict to the Survey design?
-    tot_msk = objtype_mask
+    tot_msk = objtype_mask & z_mask
     if survey:
         good &= survey_mask
         cat &= survey_mask
@@ -426,10 +426,10 @@ def criteria(simz_tab, objtype=None, dvlimit=None):
     if objtype is None:
         objtype_mask = np.array([True]*nrow)
     else:
-        try:
-            objtype_mask = match_otype(simz_tab, objtype)  # Use DESI_TARGET when possible
-        except KeyError:
+        if objtype in ['STAR', 'WD', 'QSO']:
             objtype_mask = stypes == objtype
+        else:
+            objtype_mask = match_otype(simz_tab, objtype)  # Use DESI_TARGET when possible
     # Redshift analysis
     z_mask = simz_tab['Z'].mask == False  # Not masked in Table
     # Survey

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -375,7 +375,8 @@ def zstats(simz_tab, objtype=None, dvlimit=None, count=False):
     nfail = np.count_nonzero(cat)
     nmiss = np.count_nonzero(miss)
     nlost = np.count_nonzero(lost)
-    ntot = len(good)
+    ntot = np.count_nonzero(objtype_mask)
+    # Check
     assert(ntot == ngood+nfail+nmiss+nlost)
     # Return
     if count:

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -360,7 +360,7 @@ def zstats(simz_tab, objtype=None, dvlimit=None, count=False, survey=False):
 
     Returns:
         if count=True: just the raw counts of each category :: ngood, nfail, nmiss, nlost
-        else: precentile of each relative to ntot
+        else: precentile of each relative to ntot and ntot
 
     """
     # Grab the masks
@@ -393,7 +393,7 @@ def zstats(simz_tab, objtype=None, dvlimit=None, count=False, survey=False):
     elif ntot == 0:
         return (np.nan, np.nan, np.nan, np.nan)
     else:
-        return 100*ngood/ntot, 100*nfail/ntot, 100*nmiss/ntot, 100*nlost/ntot
+        return 100*ngood/ntot, 100*nfail/ntot, 100*nmiss/ntot, 100*nlost/ntot, ntot
 
 
 def criteria(simz_tab, objtype=None, dvlimit=None):

--- a/py/desisim/spec_qa/utils.py
+++ b/py/desisim/spec_qa/utils.py
@@ -59,7 +59,7 @@ def catastrophic_dv(objtype):
     objtype : str
       Object type, e.g. 'ELG', 'LRG'
     '''
-    cat_dict = dict(ELG=1000., LRG=1000., QSO_L=1000., QSO_T=1000.)
+    cat_dict = dict(ELG=1000., LRG=1000., QSO_L=1000., QSO_T=1000., STAR=1000., WD=1000.)
     #
     return cat_dict[objtype]
 

--- a/py/desisim/test/test_io.py
+++ b/py/desisim/test/test_io.py
@@ -143,7 +143,7 @@ class TestIO(unittest.TestCase):
         self.assertEqual(expid, 3)
 
     #- TODO
-    #- simspec_io
+    #- simspec_io (ok - covered by desisim.test.test_pixsim)
     #- read_cosmics
 
 
@@ -151,3 +151,10 @@ class TestIO(unittest.TestCase):
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':
     unittest.main()
+
+def test_suite():
+    """Allows testing of only this module with the command::
+
+        python setup.py test -m desisim.test.test_io
+    """
+    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desisim/test/test_obs.py
+++ b/py/desisim/test/test_obs.py
@@ -75,13 +75,14 @@ class TestObs(unittest.TestCase):
                 self.assertEqual(simspec.flavor, 'science')
 
             #- Check that photons are in a reasonable range
-            for channel in ('b', 'r', 'z'):
-                maxphot = simspec.phot[channel].max()
+            self.assertGreater(len(simspec.cameras), 0)
+            for camera in simspec.cameras.values():
+                maxphot = camera.phot.max()
                 self.assertTrue(maxphot > 1, 'suspiciously few {} photons ({}); wrong units?'.format(program, maxphot))
                 self.assertTrue(maxphot < 1e6, 'suspiciously many {} photons ({}); wrong units?'.format(program, maxphot))
                 if program not in ('arc', 'flat'):
-                    self.assertTrue(simspec.skyphot[channel].max() > 1, 'suspiciously few sky photons; wrong units?')
-                    self.assertTrue(simspec.skyphot[channel].max() < 1e6, 'suspiciously many sky photons; wrong units?')
+                    self.assertTrue(camera.skyphot.max() > 1, 'suspiciously few sky photons; wrong units?')
+                    self.assertTrue(camera.skyphot.max() < 1e6, 'suspiciously many sky photons; wrong units?')
 
             if program in ('arc', 'flat'):
                 self.assertTrue(meta is None)
@@ -92,7 +93,7 @@ class TestObs(unittest.TestCase):
                 self.assertTrue(fluxhdr['BUNIT'].startswith('1e-17'))
                 self.assertTrue(skyfluxhdr['BUNIT'].startswith('1e-17'))
                 for i in range(flux.shape[0]):
-                    objtype = simspec.metadata['OBJTYPE'][i]
+                    objtype = simspec.truth['OBJTYPE'][i]
                     maxflux = flux[i].max()
                     maxsky = skyflux[i].max()
                     self.assertTrue(maxsky > 1, 'suspiciously low {} sky flux ({}); wrong units?'.format(objtype, maxsky))

--- a/py/desisim/test/test_quickgen.py
+++ b/py/desisim/test/test_quickgen.py
@@ -164,7 +164,7 @@ class TestQuickgen(unittest.TestCase):
         expid = self.expid
         camera = 'r0'
         # flavors = ['flat','dark','gray','bright','bgs','mws','elg','lrg','qso','arc']
-        flavors = ['arc', 'flat', 'dark', 'bright']
+        flavors = ['flat', 'dark', 'bright']
         for i in range(len(flavors)):
             flavor = flavors[i]
             obs.new_exposure(flavor, night=night, expid=expid, nspec=2)
@@ -189,17 +189,6 @@ class TestQuickgen(unittest.TestCase):
                 #- verify flat outputs
                 fiberflatfile = desispec.io.findfile('fiberflat', night, expid, camera)
                 self.assertTrue(os.path.exists(fiberflatfile))
-
-            elif flavor == 'arc':
-                try:
-                    cmd = "quickgen --simspec {} --fibermap {}".format(simspec,fibermap)
-                    quickgen.main(quickgen.parse(cmd.split()[1:]))
-                except SystemExit:
-                    pass
-
-                #- verify arc outputs
-                framefile = desispec.io.findfile('frame', night, expid, camera)
-                self.assertTrue(os.path.exists(framefile))
 
             else:
                 cmd = "quickgen --simspec {} --fibermap {}".format(simspec,fibermap)


### PR DESCRIPTION
Integrates the ztests method from desitest mini-Notebook within
the existing redshift QA.  Tested against the summary tables from
18.3 with code like this:

```
from desisim.spec_qa import redshifts as dsqa_z

truth = Table.read('truth.fits')
zcat = Table.read('zcatalog-mini.fits')

dsqa_z.match_truth_z(truth, zcat, mini_read=True)
good, fail, miss, lost = dsqa_z.zstats(truth, objtype='STAR')
```

Also refactored scripts to use qaprod_dir 
and cleaned up several of the summary 
redshift stats.
