### PR TITLE
working pixsim_nights

### DIFF
--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -200,7 +200,6 @@ def simulate(camera, simspec, psf, nspec=None, ncpu=None,
             asctime()))
     #- parse camera name into channel and spectrograph number
     channel = camera[0].lower()
-
     ispec = int(camera[1])
     assert channel in 'brz', \
         'unrecognized channel {} camera {}'.format(channel, camera)
@@ -590,12 +589,13 @@ def get_nodes_per_exp(nnodes,nexposures,ncameras,user_nodes_per_comm_exp=None):
     #greatest common divisor = greatest common factor    
     #we use python's built in gcd
     greatest_common_factor=gcd(nnodes,ncameras) 
-    #the greatest common factor must be greater than one
-    if greatest_common_factor == 1:
-        msg=("greatest common factor {} between nnodes {} and nframes {} must be larger than one, try again".format(greatest_common_factor, nnodes, nframes))
-        raise ValueError(msg)
-    else:
-        log.debug("greatest common factor {} between nnodes {} and nframes {} is greater than one, check passed".format(greatest_common_factor, nnodes, nframes))
+    #the greatest common factor must be greater than one UNLESS we are on one node
+    if nnodes > 1:
+        if greatest_common_factor == 1:
+            msg=("greatest common factor {} between nnodes {} and nframes {} must be larger than one, try again".format(greatest_common_factor, nnodes, nframes))
+            raise ValueError(msg)
+        else:
+            log.debug("greatest common factor {} between nnodes {} and nframes {} is greater than one, check passed".format(greatest_common_factor, nnodes, nframes))
         
     #check to make sure the user hasn't specified a really asinine value of user_nodes_per_comm_exp    
     if user_nodes_per_comm_exp is not None:

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -80,8 +80,8 @@ def simulate_exposure(simspecfile, rawfile, cameras=None,
                 raise ValueError('Number of cameras {} should be evenly divisible by number of nodes {}'.format(
                     len(cameras), num_nodes))
 
-        if comm is not None:
-            cameras = comm.bcast(cameras, root=0)
+    if comm is not None:
+        cameras = comm.bcast(cameras, root=0)
 
     #- Fail early if camera alreaady in output file
     if rank == 0 and os.path.exists(rawfile):
@@ -142,8 +142,7 @@ def simulate_exposure(simspecfile, rawfile, cameras=None,
 
         if node_rank == 0: 
             log.info("Starting simulate for camera {} on node {}".format(camera,node_index)) 
-        image, rawpix, truepix = simulate(camera, simspec, psf, comm=comm_node,
-            preproc=False, cosmics=cosmics, **kwargs)
+        image, rawpix, truepix = simulate(camera, simspec, psf, comm=comm_node, preproc=False, cosmics=cosmics, **kwargs)
 
         #- Use input communicator as barrier since multiple sub-communicators
         #- will write to the same output file

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -26,7 +26,7 @@ from desiutil.log import get_logger
 log = get_logger()
 
 def simulate_exposure(simspecfile, rawfile, cameras=None,
-        ccdshape=None, simpixfile=None, addcosmics=True, comm=None,
+        ccdshape=None, simpixfile=None, addcosmics=None, comm=None,
         **kwargs):
     """
     Simulate frames from an exposure, including I/O
@@ -39,7 +39,7 @@ def simulate_exposure(simspecfile, rawfile, cameras=None,
         cameras: str or list of str, e.g. b0, r1, .. z9
         ccdshape: (npix_y, npix_x) primarily used to limit memory while testing
         simpixfile: output file for noiseless truth pixels
-        addcosmics: if True (default), add cosmics from real data
+        addcosmics: if True (must be specified via command input), add cosmics from real data
         comm: MPI communicator object
 
     Additional keyword args are passed to pixsim.simulate()
@@ -66,7 +66,7 @@ def simulate_exposure(simspecfile, rawfile, cameras=None,
         num_nodes = 1
         node_rank = 0
         node_size = 1
-
+    
     if rank == 0:
         log.debug('Starting simulate_exposure at {}'.format(asctime()))
 
@@ -82,9 +82,6 @@ def simulate_exposure(simspecfile, rawfile, cameras=None,
 
         if comm is not None:
             cameras = comm.bcast(cameras, root=0)
-
-    elif isinstance(cameras, str):
-        cameras = [cameras,]
 
     #- Fail early if camera alreaady in output file
     if rank == 0 and os.path.exists(rawfile):
@@ -104,7 +101,8 @@ def simulate_exposure(simspecfile, rawfile, cameras=None,
 
     mycameras = cameras[node_index::num_nodes]
     if node_rank == 0:
-        log.debug('Node {} cameras {}'.format(node_index, mycameras))
+        log.info("Assigning cameras {} to comm_exp node {}".format(mycameras, node_index))
+
     simspec = io.read_simspec(simspecfile, cameras=mycameras,
         readflux=False, comm=comm)
     night = simspec.header['NIGHT']
@@ -114,6 +112,8 @@ def simulate_exposure(simspecfile, rawfile, cameras=None,
         log.debug('Reading PSFs at {}'.format(asctime()))
 
     psfs = dict()
+    #need to initialize previous channel
+    previous_channel = 'a'
     for camera in mycameras:
         #- Note: current PSF object can't be pickled and thus every
         #- rank must read it instead of rank 0 read + bcast
@@ -128,15 +128,20 @@ def simulate_exposure(simspecfile, rawfile, cameras=None,
         psf = psfs[channel]
 
         cosmics=None
-        if addcosmics and node_rank == 0:
-            cosmics_file = io.find_cosmics(camera, simspec.header['EXPTIME'])
-            log.info('cosmics templates {}'.format(cosmics_file))
-            shape = (psf.npix_y, psf.npix_x)
-            cosmics = io.read_cosmics(cosmics_file, expid, shape=shape)
+        #avoid re-broadcasting cosmics if we can
+        if previous_channel != channel:
+            if (addcosmics is True) and (node_rank == 0):
+                cosmics_file = io.find_cosmics(camera, simspec.header['EXPTIME'])
+                log.info('cosmics templates {}'.format(cosmics_file))
+                shape = (psf.npix_y, psf.npix_x)
+                cosmics = io.read_cosmics(cosmics_file, expid, shape=shape)
+            if (addcosmics is True) and (comm_node is not None):
+                cosmics = comm_node.bcast(cosmics, root=0)
+            else:
+                log.debug("Cosmics not requested")
 
-        if comm_node is not None:
-            cosmics = comm_node.bcast(cosmics, root=0)
-
+        if node_rank == 0: 
+            log.info("Starting simulate for camera {} on node {}".format(camera,node_index)) 
         image, rawpix, truepix = simulate(camera, simspec, psf, comm=comm_node,
             preproc=False, cosmics=cosmics, **kwargs)
 
@@ -163,6 +168,8 @@ def simulate_exposure(simspecfile, rawfile, cameras=None,
         if rank == 0:
             log.info('Wrote {}'.format(rawfile))
             log.debug('done at {}'.format(asctime()))
+
+        previous_channel = channel
 
 def simulate(camera, simspec, psf, nspec=None, ncpu=None,
     cosmics=None, wavemin=None, wavemax=None, preproc=True, comm=None):
@@ -597,7 +604,7 @@ def get_nodes_per_exp(nnodes,nexposures,ncameras,user_nodes_per_comm_exp=None):
             raise ValueError(msg)
         else:
             log.debug("user-specified value of user_nodes_per_comm_exp {} is good, check passed".format(user_nodes_per_comm_exp))
-            n_exp_comm=nodes_per_comm_exp
+            nodes_per_comm_exp=user_nodes_per_comm_exp
     #if the user didn't specify anything, use the greatest common factor
     if user_nodes_per_comm_exp is None:
         nodes_per_comm_exp=greatest_common_factor        
@@ -623,12 +630,8 @@ def mpi_count_nodes(comm):
     '''
     Return the number of nodes in this communicator
     '''
-    nodenames = comm.gather(socket.gethostname(), root=0)
-    if comm.rank == 0:
-        num_nodes = len(set(nodenames))
-    else:
-        num_nodes = None
-    num_nodes = comm.bcast(num_nodes, root=0)
+    nodenames = comm.allgather(socket.gethostname())
+    num_nodes=len(set(nodenames))
     return num_nodes
 
 def mpi_split_by_node(comm, nodes_per_communicator):

--- a/py/desisim/scripts/pixsim_nights.py
+++ b/py/desisim/scripts/pixsim_nights.py
@@ -22,7 +22,11 @@ from desispec.parallel import stdouterr_redirected
 
 from . import pixsim
 
-from ..pixsim import simulate
+from ..pixsim import simulate_exposure
+from ..pixsim import get_nodes_per_exp
+from ..pixsim import mpi_count_nodes
+from ..pixsim import mpi_split_by_node
+
 from ..io import SimSpec
 from .. import obs, io
 
@@ -43,23 +47,15 @@ def parse(options=None):
     parser.add_argument("--nights", type=str, default=None, required=False, help="YEARMMDD,YEARMMDD,YEARMMDD")
     parser.add_argument("--verbose", action="store_true", help="Include debug log info")
     parser.add_argument("--overwrite", action="store_true", help="Overwrite existing raw and simpix files")
-    parser.add_argument("--cosmics_dir", type=str, help="Input directory with cosmics templates") 
-    parser.add_argument("--cosmics", action="store_true", help="Add simulated cosmics")
-    parser.add_argument("--preproc", action="store_true", help="Run the preprocessing")
+    parser.add_argument("--cosmics", default=None, action="store_true", required=False, help="Add simulated cosmics")
     parser.add_argument("--seed", type=int, default=123456, required=False, help="random number seed")
-    parser.add_argument("--rawfile", type=str, help="output raw data file")
-    parser.add_argument("--simpixfile", type=str, help="output truth image file")
 
-    #need these so simulate will run, but they won't really work properly
     parser.add_argument("--ncpu", type=int, help="Number of cpu cores per thread to use", default=0)
     parser.add_argument("--nspec", type=int, help="Number of spectra to simulate per camera", default=0)
     parser.add_argument("--wavemin", type=float, help="Minimum wavelength to simulate")
     parser.add_argument("--wavemax", type=float, help="Maximum wavelength to simulate")
-
-    #cameras may be specified, but camera_procs must be specified!
     parser.add_argument("--cameras", type=str, default=None, help="cameras, e.g. b0,r5,z9")
-    parser.add_argument("--camera_procs", type=int, default=1, required=True,
-        help="Number of MPI processes to use per camera")
+    parser.add_argument("--user_nodes_per_comm_exp", type=int, default=None, help="user specified value of nnodes per exposure communicator")
 
     args = None
     if options is None:
@@ -89,7 +85,6 @@ def main(args, comm=None):
     if rank == 0:
         log.info('Starting pixsim at {}'.format(asctime()))
 
-
     #no preflight check here, too complicated.   
     #we'll assume the user knows what he or she is doing...
 
@@ -114,227 +109,88 @@ def main(args, comm=None):
     for nt in nights:
         night_expid[nt] = specio.get_exposures(nt, raw=True)
 
-    #this is currently a dict, which is all well and good, but we need 
-    #a list of tuples of (night,expid) that we can evenly divide between communicators
+    #get a list of tuples of (night,expid) that we can evenly divide between communicators
     night_exposure_list=list()
     for nt in nights:
         for exp in night_expid[nt]:
             night_exposure_list.append([nt,exp])              
 
-    #then this sub communicator will be split into the number of exposures per node
-    #instead of mpi_cameras we will use camera_procs... but maybe we also need to specify
-    #a finer grain paralleism, we'll see...
-    comm_group = comm
-    comm_rank = None
-    group = 0
-    ngroup = 1
-    group_rank = 0
-    if comm is not None:
-        if args.camera_procs > 1:
-            ngroup = int(comm.size / args.camera_procs)
-            group = int(comm.rank / args.camera_procs)
-            group_rank = comm.rank % args.camera_procs
-            comm_group = comm.Split(color=group, key=group_rank)
-            comm_rank = comm.Split(color=group_rank, key=group)
-        else:
-            group = comm.rank
-            ngroup = comm.size
-            comm_group = MPI.COMM_SELF
-            comm_rank = comm
-
-    #divide lists of exposures between split communicators
-    #this is where the magic happens
-    if ngroup > 1:
-        node_exposures=None
-        for i in range(ngroup):
-            if i == group: 
-                node_exposures=night_exposure_list[i::ngroup]
-    if ngroup == 1:
-        node_exposures=night_exposure_list
-
-    #the way we are splitting the exposures assumes that they can be evenly 
-    #divided between the nodes. if this is not the case, the barrier logic
-    #will cause a hang during the file write (i think)
-    #first let's check to see if it is a problem
-    nexposures=len(night_exposure_list)
-    if nexposures % ngroup != 0:
-        if comm.rank == 0:
-            msg = ("nexposures {} does not divide evenly into ngroup {}, simulation aborting".format(nexposures, ngroup))
-            log.error(msg)
-            raise ValueError(msg)
-            comm.Abort()
-    elif nexposures % ngroup == 0:
-        if comm.rank == 0:
-            log.info("nexposures {} divides evenly into ngroup {}, simulation will proceed".format(nexposures, ngroup))         
-
-    comm.Barrier()
-    #print("node_exposures=  %s for comm_group %s" %(node_exposures,comm_group))
-
-    # Get the list of cameras
-    # should be the same on every node
-    cams = None
+    # Get the list of cameras and make sure it's in the right format
+    cams = []
     if args.cameras is not None:
-        cams = args.cameras
+        entry = args.cameras.split(',')
+        for i in entry:
+            cams.append(i)
     else:
-        cams = []
         #do this with band first so we can avoid re-broadcasting cosmics
         for band in ['b', 'r', 'z']:
             for spec in range(10):
-                cams.append('{}{}'.format(band, spec))
+                cams.append('{}{}'.format(band, spec)) 
 
-    for j in range(len(node_exposures)):
+    #are we using cosmics?
+    if args.cosmics is not None:
+        addcosmics = True
+    else:
+        addcosmics = False
 
-        #for each exposure, handle group spectro
-        group_spectro = np.array([ int(c[1]) for c in cams], dtype=np.int32)
+    ncameras=len(cams)
+    nexposures=len(night_exposure_list)
+    #call ultity function to figure out how many nodes we have
+    nnodes=mpi_count_nodes(comm)
 
-        # Use original seed to generate different random seeds for each camera
-        np.random.seed(args.seed)
-        seeds = np.random.randint(0, 2**32-1, size=len(cams))
-        seed_counter=0 #need to initialize counter
-       
-        #now that each communicator (group) knows which cameras it
-        #is supposed to process, we can get started
-        previous_camera='a' #need to initialize
+    #call utility functions to divide our workload
+    if args.user_nodes_per_comm_exp is not None:
+        user_specified_nodes=args.user_nodes_per_comm_exp
+    else:
+        user_specified_nodes=None
 
-        #the inner loop handles the frames for each exposure
-        for i in range(len(cams)):
-            if i > 1:
-                #keep track in case we can avoid re-broadcasting stuff
-                previous_camera=cams[i-1]
-            current_camera=cams[i]
-            camera=current_camera[0] + current_camera[1]
-            channel=current_camera[0]
+    nodes_per_comm_exp=get_nodes_per_exp(nnodes,nexposures,ncameras,user_specified_nodes)    
+    #also figure out how many exposure communicators we have
+    num_exp_comm = nnodes // nodes_per_comm_exp 
+ 
+    #split the communicator into exposure communicators
+    comm_exp, node_index_exp, num_nodes_exp = mpi_split_by_node(comm, nodes_per_comm_exp)
+    #further splitting will happen automatically in simulate_exposure
 
-            #since we clear, we need to pre-allocate every time
-            simspec = None
-            image = {}
-            rawpix = {}
-            truepix = {}
-            fibers = None
-          
-            #figure out which simspec file we need
-            args.simspec=io.findfile('simspec',node_exposures[j][0], node_exposures[j][1])
-
-            #need to sort out raw and simpix files
-            if args.rawfile is None:
-                rawfile = os.path.basename(desispec.io.findfile('raw', node_exposures[j][0], node_exposures[j][1]))
-                args.rawfile = os.path.join(os.path.dirname(args.simspec), rawfile)
-
-            if args.simpixfile is None:
-                args.simpixfile = io.findfile(
-                    'simpix', night=node_exposures[j][0], expid=node_exposures[j][1],
-                    outdir=os.path.dirname(os.path.abspath(args.rawfile)))
-
-            #establish temp files
-            #be careful here because we don't clean them up
-            rawtemp = "{}.tmp".format(args.rawfile)
-            simpixtemp = "{}.tmp".format(args.simpixfile)
-
-            #since we handle only one spectra at a time, just load the one we need 
-            simspec = io.read_simspec_mpi(args.simspec, comm_group, channel,
-                          spectrographs=group_spectro[i])
-
-            #then get the fibers, which requires simspec
-            if group_rank == 0:
-                # Get the fiber list from the simspec file
-                from astropy.io import fits
-                from astropy.table import Table
-                fx = fits.open(args.simspec, memmap=True)
-                if 'FIBERMAP' in fx:
-                    fibermap = Table(fx['FIBERMAP'].data)
-                    fibers = np.array(fibermap['FIBER'], dtype=np.int32)
-                else:
-                    # Get the number of fibers from one of the photon HDUs
-                    fibers = np.arange(fx['PHOT_B'].header['NAXIS2'], 
-                        dtype=np.int32)
-                fx.close()
-            #then need to broadcast within communicator so all ranks have fibers
-            fibers = comm_group.bcast(fibers, root=0)
-
-            if group_rank == 0:
-                log.debug('Processing camera {}'.format(camera))
+    #based on this, figure out which simspecfiles and rawfiles are assigned to each communicator
+    #find all specfiles
+    #find all rawfiles
+    rawfile_list=[]
+    simspecfile_list=[]
+    night_list=[]
+    expid_list=[]
+    for i in range(len(night_exposure_list)):
+        night_list.append(night_exposure_list[i][0])
+        expid_list.append(night_exposure_list[i][1])
+        rawfile_list.append(desispec.io.findfile('raw', night_list[i], expid_list[i]))
+        simspecfile_list.append(io.findfile('simspec', night_list[i], expid_list[i]))
+ 
+    #now divy the rawfiles and specfiles between node communicators
+    #there is onerawfile and one specfile for each exposure
+    rawfile_comm_exp=[]
+    simspecfile_comm_exp=[]
+    for i in range(num_exp_comm):
+        if node_index_exp == i: #assign rawfile, simspec file to one communicator at a time
+            rawfile_comm_exp=rawfile_list[i::num_exp_comm]
+            simspecfile_comm_exp=simspecfile_list[i::num_exp_comm] 
+            night_comm_exp=night_list[i::num_exp_comm]
+            expid_comm_exp=expid_list[i::num_exp_comm]
     
-            # Set the seed for this camera (regardless of which process is
-            # performing the simulation).
-            np.random.seed(seeds[(seed_counter)])
-    
-            # Get the random cosmic expids.  The actual values will be
-            # remapped internally with the modulus operator.
-            cosexpid = np.random.randint(0, 100, size=1)[0]
-    
-            # Read inputs for this camera.  Unfortunately psf
-            # objects are not serializable, so we read it on all
-            # processes.
-            psf = desimodel.io.load_psf(channel)
-            
-            #if we have already loaded the right cosmics camera, don't bcast again
-            cosmics=None
-            if args.cosmics:
-                if current_camera[0] != previous_camera[0]:
-                    cosmics=None
-                    if group_rank == 0:
-                        cosmics_file = io.find_cosmics(camera, 
-                            simspec.header['EXPTIME'],
-                            cosmics_dir=args.cosmics_dir)
-                        log.info('cosmics templates {}'.format(cosmics_file))
-    
-                        shape = (psf.npix_y, psf.npix_x)
-                        cosmics = io.read_cosmics(cosmics_file, cosexpid, shape=shape)
-                
-                    cosmics = comm_group.bcast(cosmics, root=0)
+    comm.Barrier()
 
-            if group_rank == 0:
-                group_size = comm_group.size
-                log.info("Group {} ({} processes) simulating camera "
-                    "{} exposure {} night {}".format(group, group_size, camera, 
-                    node_exposures[j][1], node_exposures[j][0]))
+    #now wrap pixsim.simulate_exposure for each exposure (in desisim.pixsim)
+    if comm_exp.rank == 0:
+        log.info("Starting simulate_exposure for night {} expid {}".format(night_comm_exp, expid_comm_exp))
+    for i in range(len(rawfile_comm_exp)):
+        simulate_exposure(simspecfile_comm_exp[i], rawfile_comm_exp[i], cameras=cams,
+            ccdshape=None, simpixfile=None, addcosmics=addcosmics, comm=comm_exp)
 
-            #calc group_fibers inside the loop
-            fs = np.in1d(fibers//500, group_spectro[i])
-            group_fibers = fibers[fs]
-
-            image[camera], rawpix[camera], truepix[camera] = \
-                simulate(camera, simspec, psf, fibers=group_fibers,
-                    ncpu=args.ncpu, nspec=args.nspec, cosmics=cosmics,
-                    wavemin=args.wavemin, wavemax=args.wavemax, preproc=False,
-                    comm=comm_group)
-
-            #to avoid overflowing the memory let's write after each instance of simulate
-            #the data are already at rank 0 in each communicator
-            #then have each communicator open and write to the file one at a time
-            #this is the part that will fail if the number of nodes divided by number of frames 
-            #is not evenly divisible (hence the check above)
-            for i in range(ngroup):#number of total communicators
-                if group == i:#only one group at a time should open/write/close
-                    if group_rank == 0: #write only from rank 0 where the data are
-                        #write the raw file using desispec write_raw in raw.py
-                        desispec.io.write_raw(rawtemp, rawpix[camera],
-                           camera=camera, header=image[camera].meta,
-                           primary_header=simspec.header)
-                        log.info('Wrote {} image {} exposure {} night to {} at time {}'
-                            .format(camera, node_exposures[j][1], node_exposures[j][0], 
-                            rawtemp, time.asctime()))
-                        #write the simpix file using desisim write_simpix in io.py 
-                        io.write_simpix(simpixtemp, truepix[camera],camera=camera, meta=simspec.header)
-                        log.info('Wrote {} image {} exposure {} night to {} at time {}'
-                            .format(camera, node_exposures[j][1], node_exposures[j][0],
-                            simpixtemp, time.asctime()))
-                        #delete for each group after we have written the output files
-                    del rawpix, image, truepix, simspec
-                #to avoid bugs this barrier statement must align with if group==i!! 
-                comm.Barrier()#all ranks should be done writing
-
-            #iterate random number counter
-            seed_counter=seed_counter+1
-            #end of inner loop
-
-        #in outerloop, rename files once for each exposure
-        if group_rank == 0:
-            os.rename(simpixtemp, args.simpixfile)
-            os.rename(rawtemp, args.rawfile)
-        comm.Barrier()        
 
     comm.Barrier()
 
     if rank == 0:
         log.info('Finished pixsim nights {}'.format(args.nights, asctime()))
+
+
+
+

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -102,7 +102,7 @@ class TestPixsim(unittest.TestCase):
     def test_pixsim(self):
         night = self.night
         expid = self.expid
-        camera = 'r0'
+        cameras = 'r0'
         obs.new_exposure('arc', night=night, expid=expid, nspec=3)
         self.assertTrue(os.path.exists(io.findfile('simspec', night, expid)))
 
@@ -113,7 +113,7 @@ class TestPixsim(unittest.TestCase):
         self.assertFalse(os.path.exists(simpixfile))
         self.assertFalse(os.path.exists(rawfile))
 
-        pixsim.simulate_exposure(simspecfile, rawfile, camera, nspec=3,
+        pixsim.simulate_exposure(simspecfile, rawfile, cameras, nspec=3,
             wavemin=6000, wavemax=6050, ccdshape=self.ccdshape,
             addcosmics=False, simpixfile=simpixfile)
 
@@ -124,7 +124,7 @@ class TestPixsim(unittest.TestCase):
     def test_pixsim_cosmics(self):
         night = self.night
         expid = self.expid
-        camera = 'r0'
+        cameras = 'r0'
         obs.new_exposure('arc', night=night, expid=expid, nspec=3)
         simspecfile = io.findfile('simspec', night, expid)
         rawfile = desispec.io.findfile('desi', night, expid)
@@ -133,7 +133,7 @@ class TestPixsim(unittest.TestCase):
         self.assertFalse(os.path.exists(simpixfile))
         self.assertFalse(os.path.exists(rawfile))
 
-        pixsim.simulate_exposure(simspecfile, rawfile, camera, nspec=3,
+        pixsim.simulate_exposure(simspecfile, rawfile, cameras, nspec=3,
                 wavemin=6000, wavemax=6050,
                 addcosmics=True, ccdshape=self.ccdshape)
 

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -102,7 +102,7 @@ class TestPixsim(unittest.TestCase):
     def test_pixsim(self):
         night = self.night
         expid = self.expid
-        cameras = 'r0'
+        cameras = ['r0']
         obs.new_exposure('arc', night=night, expid=expid, nspec=3)
         self.assertTrue(os.path.exists(io.findfile('simspec', night, expid)))
 
@@ -124,7 +124,7 @@ class TestPixsim(unittest.TestCase):
     def test_pixsim_cosmics(self):
         night = self.night
         expid = self.expid
-        cameras = 'r0'
+        cameras = ['r0']
         obs.new_exposure('arc', night=night, expid=expid, nspec=3)
         simspecfile = io.findfile('simspec', night, expid)
         rawfile = desispec.io.findfile('desi', night, expid)
@@ -134,8 +134,7 @@ class TestPixsim(unittest.TestCase):
         self.assertFalse(os.path.exists(rawfile))
 
         pixsim.simulate_exposure(simspecfile, rawfile, cameras,
-                addcosmics=True, ccdshape=self.ccdshape,
-                simpixfile=simpixfile)
+                addcosmics=True, ccdshape=self.ccdshape)
 
         self.assertTrue(os.path.exists(rawfile))
 

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -113,8 +113,8 @@ class TestPixsim(unittest.TestCase):
         self.assertFalse(os.path.exists(simpixfile))
         self.assertFalse(os.path.exists(rawfile))
 
-        pixsim.simulate_exposure(simspecfile, rawfile, cameras, nspec=3,
-            wavemin=6000, wavemax=6050, ccdshape=self.ccdshape,
+        pixsim.simulate_exposure(simspecfile, rawfile, cameras,
+            ccdshape=self.ccdshape,
             addcosmics=False, simpixfile=simpixfile)
 
         self.assertTrue(os.path.exists(simpixfile))
@@ -128,14 +128,14 @@ class TestPixsim(unittest.TestCase):
         obs.new_exposure('arc', night=night, expid=expid, nspec=3)
         simspecfile = io.findfile('simspec', night, expid)
         rawfile = desispec.io.findfile('desi', night, expid)
-        simpixfile = io.findfile('simpix', night, expid, camera)
+        simpixfile = io.findfile('simpix', night, expid, cameras)
 
         self.assertFalse(os.path.exists(simpixfile))
         self.assertFalse(os.path.exists(rawfile))
 
-        pixsim.simulate_exposure(simspecfile, rawfile, cameras, nspec=3,
-                wavemin=6000, wavemax=6050,
-                addcosmics=True, ccdshape=self.ccdshape)
+        pixsim.simulate_exposure(simspecfile, rawfile, cameras,
+                addcosmics=True, ccdshape=self.ccdshape,
+                simpixfile=simpixfile)
 
         self.assertTrue(os.path.exists(rawfile))
 


### PR DESCRIPTION
This pull request makes use of the newly implemented simulate_exposure function which handles all the MPI I/O for pixsim. Pixsim_nights enables the user to specify the nights they would like to simulate and optionally specific cameras and cosmics for each exposure. Several utility functions allow the exposures and frames to be divided among the nodes in a sensible way. The job will fail with a helpful error message if the nodes cannot be filled appropriately. 