### PR TITLE
Generate Confusion matrix related to spectral types

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -10,6 +10,7 @@ desisim change log
 * Update QA to use qaprod_dir
 * Enable redshift QA using input summary catalogs of truth and redshifts
   (`PR #349`_)
+* Generate confusion matrix related to Spectype
 
 .. _`PR #349`: https://github.com/desihub/desisim/pull/349
 .. _`PR #351`: https://github.com/desihub/desisim/pull/351

--- a/doc/nb/Confusion_matrix_spectypes.ipynb
+++ b/doc/nb/Confusion_matrix_spectypes.ipynb
@@ -1,0 +1,1333 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Develop/test confusion matrix code for spectral types [v0.1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "%matplotlib notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# imports\n",
+    "import numpy as np\n",
+    "from matplotlib import pyplot as plt\n",
+    "\n",
+    "from astropy.table import Table\n",
+    "from desisim.spec_qa.redshifts import match_truth_z"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load Tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "path = '/scratch/DESI_SCRATCH/18.3/'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "simz_tab = Table.read(path+'truth.fits')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "zb_tab = Table.read(path+'zcatalog-mini.fits')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Match"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO: Upgrading Table to masked Table. Use Table.filled() to convert to unmasked table. [astropy.table.table]\n"
+     ]
+    }
+   ],
+   "source": [
+    "match_truth_z(simz_tab, zb_tab, mini_read=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Now what?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "&lt;Table masked=True length=240902&gt;\n",
+       "<table id=\"table140649856306144\" class=\"table-striped table-bordered table-condensed\">\n",
+       "<thead><tr><th>TARGETID</th><th>MOCKID</th><th>CONTAM_TARGET</th><th>TRUEZ</th><th>TRUESPECTYPE</th><th>TEMPLATETYPE</th><th>TEMPLATESUBTYPE</th><th>TEMPLATEID</th><th>SEED</th><th>MAG</th><th>VDISP</th><th>FLUX_G</th><th>FLUX_R</th><th>FLUX_Z</th><th>FLUX_W1</th><th>FLUX_W2</th><th>OIIFLUX</th><th>HBETAFLUX</th><th>TEFF</th><th>LOGG</th><th>FEH</th><th>Z</th><th>ZERR</th><th>ZWARN</th><th>SPECTYPE</th><th>DESI_TARGET</th></tr></thead>\n",
+       "<thead><tr><th>int64</th><th>int64</th><th>int64</th><th>float32</th><th>str10</th><th>str10</th><th>str10</th><th>int32</th><th>int64</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float32</th><th>float64</th><th>float64</th><th>int64</th><th>str6</th><th>int64</th></tr></thead>\n",
+       "<tr><td>288230398217945088</td><td>15594312</td><td>0</td><td>0.134829</td><td>GALAXY</td><td>BGS</td><td></td><td>3627</td><td>1482857632</td><td>19.8104</td><td>61.5363</td><td>5.24496</td><td>13.0271</td><td>22.0723</td><td>17.0456</td><td>11.0778</td><td>-1.0</td><td>0.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230398217945089</td><td>19713506</td><td>0</td><td>0.131031</td><td>GALAXY</td><td>BGS</td><td></td><td>3100</td><td>1847516324</td><td>18.5536</td><td>61.5363</td><td>23.2365</td><td>39.1643</td><td>57.4299</td><td>52.1437</td><td>38.0304</td><td>-1.0</td><td>1.62485e-15</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230398217945090</td><td>17928726</td><td>0</td><td>0.145801</td><td>GALAXY</td><td>BGS</td><td></td><td>1281</td><td>1159188526</td><td>18.3514</td><td>61.5363</td><td>19.8501</td><td>50.1084</td><td>86.5181</td><td>74.6362</td><td>51.4383</td><td>-1.0</td><td>0.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230398217945091</td><td>19762079</td><td>0</td><td>0.295097</td><td>GALAXY</td><td>BGS</td><td></td><td>5168</td><td>1664239784</td><td>17.9932</td><td>61.5363</td><td>18.4524</td><td>71.9985</td><td>149.989</td><td>178.462</td><td>126.497</td><td>-1.0</td><td>0.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230398217945092</td><td>13979089</td><td>0</td><td>0.404595</td><td>GALAXY</td><td>BGS</td><td></td><td>6077</td><td>236582212</td><td>20.1547</td><td>61.5363</td><td>2.09978</td><td>9.95809</td><td>21.8389</td><td>36.396</td><td>28.0412</td><td>-1.0</td><td>0.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230398217945093</td><td>16459200</td><td>0</td><td>0.264106</td><td>GALAXY</td><td>BGS</td><td></td><td>1126</td><td>1991162537</td><td>19.1176</td><td>61.5363</td><td>11.3866</td><td>23.7894</td><td>35.4239</td><td>33.6405</td><td>26.4355</td><td>-1.0</td><td>6.34972e-16</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230398217945094</td><td>18522434</td><td>0</td><td>0.124415</td><td>GALAXY</td><td>BGS</td><td></td><td>5431</td><td>266394818</td><td>18.6124</td><td>61.5363</td><td>15.305</td><td>39.5149</td><td>73.9385</td><td>79.3565</td><td>54.7434</td><td>-1.0</td><td>1.20094e-16</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230398217945095</td><td>17843316</td><td>0</td><td>0.32049</td><td>GALAXY</td><td>BGS</td><td></td><td>891</td><td>465634076</td><td>19.9593</td><td>61.5363</td><td>3.73762</td><td>11.398</td><td>21.8683</td><td>27.3294</td><td>20.5494</td><td>-1.0</td><td>8.81773e-17</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230398217945096</td><td>16440187</td><td>0</td><td>0.294273</td><td>GALAXY</td><td>BGS</td><td></td><td>3795</td><td>1715747948</td><td>18.0603</td><td>61.5363</td><td>16.0364</td><td>68.1686</td><td>149.188</td><td>206.879</td><td>152.196</td><td>-1.0</td><td>0.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230398217945097</td><td>12968431</td><td>0</td><td>0.206353</td><td>GALAXY</td><td>BGS</td><td></td><td>674</td><td>111129886</td><td>19.6587</td><td>61.5363</td><td>4.83601</td><td>15.3217</td><td>29.3135</td><td>29.3734</td><td>20.7506</td><td>-1.0</td><td>0.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td><td>...</td></tr>\n",
+       "<tr><td>288230399866311538</td><td>1298455</td><td>0</td><td>1.26878</td><td>QSO</td><td>QSO_T</td><td></td><td>1</td><td>2384036795</td><td>22.0308</td><td>-1.0</td><td>1.54059</td><td>1.98264</td><td>1.96187</td><td>3.59039</td><td>6.32289</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230399866311539</td><td>1230927</td><td>0</td><td>1.64302</td><td>QSO</td><td>QSO_T</td><td></td><td>2</td><td>2384036795</td><td>21.7264</td><td>-1.0</td><td>2.0392</td><td>2.03655</td><td>2.25573</td><td>4.23249</td><td>7.84327</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230399866311540</td><td>1205543</td><td>0</td><td>1.38468</td><td>QSO</td><td>QSO_T</td><td></td><td>3</td><td>2384036795</td><td>20.8983</td><td>-1.0</td><td>4.37204</td><td>5.87057</td><td>5.69542</td><td>12.1566</td><td>20.079</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230399866311541</td><td>33687</td><td>0</td><td>4.73661e-05</td><td>WD</td><td>WD</td><td>DA</td><td>963</td><td>2070350110</td><td>18.422</td><td>-1.0</td><td>41.627</td><td>26.8096</td><td>14.5254</td><td>1.29899</td><td>0.688422</td><td>-1.0</td><td>-1.0</td><td>27000.0</td><td>8.5</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230399866311542</td><td>389682</td><td>0</td><td>0.000110076</td><td>WD</td><td>WD</td><td>DA</td><td>741</td><td>518543222</td><td>19.612</td><td>-1.0</td><td>14.169</td><td>10.1428</td><td>6.00472</td><td>0.652523</td><td>0.353166</td><td>-1.0</td><td>-1.0</td><td>16750.0</td><td>8.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230399866311543</td><td>86008</td><td>0</td><td>-0.000210479</td><td>WD</td><td>WD</td><td>DA</td><td>27</td><td>1800679340</td><td>19.832</td><td>-1.0</td><td>12.1565</td><td>15.5293</td><td>15.9602</td><td>3.60637</td><td>2.02437</td><td>-1.0</td><td>-1.0</td><td>6500.0</td><td>8.25</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230399866311544</td><td>389524</td><td>0</td><td>0.000193467</td><td>WD</td><td>WD</td><td>DB</td><td>22</td><td>2127151900</td><td>19.843</td><td>-1.0</td><td>11.4293</td><td>9.42563</td><td>6.38046</td><td>34.0481</td><td>63.9958</td><td>-1.0</td><td>-1.0</td><td>12000.0</td><td>8.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230399866311545</td><td>389964</td><td>0</td><td>-3.33564e-06</td><td>WD</td><td>WD</td><td>DA</td><td>4</td><td>1314073242</td><td>19.202</td><td>-1.0</td><td>21.9766</td><td>30.8796</td><td>34.1473</td><td>8.65843</td><td>4.92947</td><td>-1.0</td><td>-1.0</td><td>6000.0</td><td>8.0</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230399866311546</td><td>86073</td><td>0</td><td>-5.00346e-06</td><td>WD</td><td>WD</td><td>DA</td><td>27</td><td>1458464403</td><td>19.832</td><td>-1.0</td><td>12.1597</td><td>15.5322</td><td>15.9737</td><td>3.60833</td><td>2.02574</td><td>-1.0</td><td>-1.0</td><td>6500.0</td><td>8.25</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "<tr><td>288230399866311547</td><td>86072</td><td>0</td><td>-1.10076e-05</td><td>WD</td><td>WD</td><td>DA</td><td>27</td><td>583685678</td><td>19.832</td><td>-1.0</td><td>12.1596</td><td>15.5321</td><td>15.9734</td><td>3.60828</td><td>2.0257</td><td>-1.0</td><td>-1.0</td><td>6500.0</td><td>8.25</td><td>-1.0</td><td>--</td><td>--</td><td>--</td><td>--</td><td>--</td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<Table masked=True length=240902>\n",
+       "     TARGETID       MOCKID  CONTAM_TARGET ... ZWARN SPECTYPE DESI_TARGET\n",
+       "      int64         int64       int64     ... int64   str6      int64   \n",
+       "------------------ -------- ------------- ... ----- -------- -----------\n",
+       "288230398217945088 15594312             0 ...    --       --          --\n",
+       "288230398217945089 19713506             0 ...    --       --          --\n",
+       "288230398217945090 17928726             0 ...    --       --          --\n",
+       "288230398217945091 19762079             0 ...    --       --          --\n",
+       "288230398217945092 13979089             0 ...    --       --          --\n",
+       "288230398217945093 16459200             0 ...    --       --          --\n",
+       "288230398217945094 18522434             0 ...    --       --          --\n",
+       "288230398217945095 17843316             0 ...    --       --          --\n",
+       "288230398217945096 16440187             0 ...    --       --          --\n",
+       "288230398217945097 12968431             0 ...    --       --          --\n",
+       "               ...      ...           ... ...   ...      ...         ...\n",
+       "288230399866311538  1298455             0 ...    --       --          --\n",
+       "288230399866311539  1230927             0 ...    --       --          --\n",
+       "288230399866311540  1205543             0 ...    --       --          --\n",
+       "288230399866311541    33687             0 ...    --       --          --\n",
+       "288230399866311542   389682             0 ...    --       --          --\n",
+       "288230399866311543    86008             0 ...    --       --          --\n",
+       "288230399866311544   389524             0 ...    --       --          --\n",
+       "288230399866311545   389964             0 ...    --       --          --\n",
+       "288230399866311546    86073             0 ...    --       --          --\n",
+       "288230399866311547    86072             0 ...    --       --          --"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simz_tab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "&lt;MaskedColumn name=&apos;ZWARN&apos; dtype=&apos;int64&apos; length=7&gt;\n",
+       "<table>\n",
+       "<tr><td>0</td></tr>\n",
+       "<tr><td>4</td></tr>\n",
+       "<tr><td>32</td></tr>\n",
+       "<tr><td>36</td></tr>\n",
+       "<tr><td>1024</td></tr>\n",
+       "<tr><td>1028</td></tr>\n",
+       "<tr><td>--</td></tr>\n",
+       "</table>"
+      ],
+      "text/plain": [
+       "<MaskedColumn name='ZWARN' dtype='int64' length=7>\n",
+       "   0\n",
+       "   4\n",
+       "  32\n",
+       "  36\n",
+       "1024\n",
+       "1028\n",
+       "  --"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "np.unique(simz_tab['ZWARN'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(<MaskedColumn name='SPECTYPE' dtype='str6' length=3>\n",
+       " GALAXY\n",
+       " QSO   \n",
+       " STAR  , <MaskedColumn name='TRUESPECTYPE' dtype='str10' length=4>\n",
+       " GALAXY    \n",
+       " QSO       \n",
+       " STAR      \n",
+       " WD        )"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "measured_z = simz_tab['ZWARN'].mask == False\n",
+    "np.unique(simz_tab[measured_z]['SPECTYPE']), np.unique(simz_tab[measured_z]['TRUESPECTYPE'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Confuse me"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Cut the table\n",
+    "cut_simz = simz_tab[measured_z]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Strip those columns\n",
+    "strip_ttypes = np.char.rstrip(cut_simz['TRUESPECTYPE'])\n",
+    "strip_stypes = np.char.rstrip(cut_simz['SPECTYPE'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['GALAXY', 'QSO', 'STAR', 'WD'], \n",
+       "      dtype='<U10')"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# All TRUE types\n",
+    "ttypes = np.unique(strip_ttypes)\n",
+    "ttypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['GALAXY', 'QSO', 'STAR'], \n",
+       "      dtype='<U6')"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# All SPEC types\n",
+    "stypes = np.unique(strip_stypes)\n",
+    "stypes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Init\n",
+    "results = {}\n",
+    "for ttype in ttypes:\n",
+    "    results[ttype] = {}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for ttype in ttypes:\n",
+    "    itrue = strip_ttypes == ttype\n",
+    "    # Init correct answer in case there are none\n",
+    "    results[ttype][ttype] = 0\n",
+    "    #import pdb; pdb.set_trace()\n",
+    "    for stype in stypes:\n",
+    "        results[ttype][stype] = np.sum(strip_stypes[itrue] == stype)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'GALAXY': {'GALAXY': 34736, 'QSO': 2, 'STAR': 0},\n",
+       " 'QSO': {'GALAXY': 17, 'QSO': 3388, 'STAR': 0},\n",
+       " 'STAR': {'GALAXY': 521, 'QSO': 0, 'STAR': 2271},\n",
+       " 'WD': {'GALAXY': 7, 'QSO': 0, 'STAR': 71, 'WD': 0}}"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Build the matrix"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "confuse = np.zeros((ttypes.size, ttypes.size))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[  3.47360000e+04,   2.00000000e+00,   0.00000000e+00,\n",
+       "          0.00000000e+00],\n",
+       "       [  1.70000000e+01,   3.38800000e+03,   0.00000000e+00,\n",
+       "          0.00000000e+00],\n",
+       "       [  5.21000000e+02,   0.00000000e+00,   2.27100000e+03,\n",
+       "          0.00000000e+00],\n",
+       "       [  7.00000000e+00,   0.00000000e+00,   7.10000000e+01,\n",
+       "          0.00000000e+00]])"
+      ]
+     },
+     "execution_count": 54,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "for ii,ttype in enumerate(ttypes):\n",
+    "    for jj,ottype in enumerate(ttypes):\n",
+    "        if ottype in results[ttype].keys():\n",
+    "            confuse[ii,jj] = results[ttype][ottype]\n",
+    "confuse"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Normalize"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[  9.99942426e-01,   5.75738384e-05,   0.00000000e+00,\n",
+       "          0.00000000e+00],\n",
+       "       [  4.99265786e-03,   9.95007342e-01,   0.00000000e+00,\n",
+       "          0.00000000e+00],\n",
+       "       [  1.86604585e-01,   0.00000000e+00,   8.13395415e-01,\n",
+       "          0.00000000e+00],\n",
+       "       [  8.97435897e-02,   0.00000000e+00,   9.10256410e-01,\n",
+       "          0.00000000e+00]])"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "for kk in range(confuse.shape[0]):\n",
+    "    confuse[kk,:] /= np.sum(confuse[kk,:])\n",
+    "confuse"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "/* Put everything inside the global mpl namespace */\n",
+       "window.mpl = {};\n",
+       "\n",
+       "\n",
+       "mpl.get_websocket_type = function() {\n",
+       "    if (typeof(WebSocket) !== 'undefined') {\n",
+       "        return WebSocket;\n",
+       "    } else if (typeof(MozWebSocket) !== 'undefined') {\n",
+       "        return MozWebSocket;\n",
+       "    } else {\n",
+       "        alert('Your browser does not have WebSocket support.' +\n",
+       "              'Please try Chrome, Safari or Firefox ≥ 6. ' +\n",
+       "              'Firefox 4 and 5 are also supported but you ' +\n",
+       "              'have to enable WebSockets in about:config.');\n",
+       "    };\n",
+       "}\n",
+       "\n",
+       "mpl.figure = function(figure_id, websocket, ondownload, parent_element) {\n",
+       "    this.id = figure_id;\n",
+       "\n",
+       "    this.ws = websocket;\n",
+       "\n",
+       "    this.supports_binary = (this.ws.binaryType != undefined);\n",
+       "\n",
+       "    if (!this.supports_binary) {\n",
+       "        var warnings = document.getElementById(\"mpl-warnings\");\n",
+       "        if (warnings) {\n",
+       "            warnings.style.display = 'block';\n",
+       "            warnings.textContent = (\n",
+       "                \"This browser does not support binary websocket messages. \" +\n",
+       "                    \"Performance may be slow.\");\n",
+       "        }\n",
+       "    }\n",
+       "\n",
+       "    this.imageObj = new Image();\n",
+       "\n",
+       "    this.context = undefined;\n",
+       "    this.message = undefined;\n",
+       "    this.canvas = undefined;\n",
+       "    this.rubberband_canvas = undefined;\n",
+       "    this.rubberband_context = undefined;\n",
+       "    this.format_dropdown = undefined;\n",
+       "\n",
+       "    this.image_mode = 'full';\n",
+       "\n",
+       "    this.root = $('<div/>');\n",
+       "    this._root_extra_style(this.root)\n",
+       "    this.root.attr('style', 'display: inline-block');\n",
+       "\n",
+       "    $(parent_element).append(this.root);\n",
+       "\n",
+       "    this._init_header(this);\n",
+       "    this._init_canvas(this);\n",
+       "    this._init_toolbar(this);\n",
+       "\n",
+       "    var fig = this;\n",
+       "\n",
+       "    this.waiting = false;\n",
+       "\n",
+       "    this.ws.onopen =  function () {\n",
+       "            fig.send_message(\"supports_binary\", {value: fig.supports_binary});\n",
+       "            fig.send_message(\"send_image_mode\", {});\n",
+       "            if (mpl.ratio != 1) {\n",
+       "                fig.send_message(\"set_dpi_ratio\", {'dpi_ratio': mpl.ratio});\n",
+       "            }\n",
+       "            fig.send_message(\"refresh\", {});\n",
+       "        }\n",
+       "\n",
+       "    this.imageObj.onload = function() {\n",
+       "            if (fig.image_mode == 'full') {\n",
+       "                // Full images could contain transparency (where diff images\n",
+       "                // almost always do), so we need to clear the canvas so that\n",
+       "                // there is no ghosting.\n",
+       "                fig.context.clearRect(0, 0, fig.canvas.width, fig.canvas.height);\n",
+       "            }\n",
+       "            fig.context.drawImage(fig.imageObj, 0, 0);\n",
+       "        };\n",
+       "\n",
+       "    this.imageObj.onunload = function() {\n",
+       "        this.ws.close();\n",
+       "    }\n",
+       "\n",
+       "    this.ws.onmessage = this._make_on_message_function(this);\n",
+       "\n",
+       "    this.ondownload = ondownload;\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype._init_header = function() {\n",
+       "    var titlebar = $(\n",
+       "        '<div class=\"ui-dialog-titlebar ui-widget-header ui-corner-all ' +\n",
+       "        'ui-helper-clearfix\"/>');\n",
+       "    var titletext = $(\n",
+       "        '<div class=\"ui-dialog-title\" style=\"width: 100%; ' +\n",
+       "        'text-align: center; padding: 3px;\"/>');\n",
+       "    titlebar.append(titletext)\n",
+       "    this.root.append(titlebar);\n",
+       "    this.header = titletext[0];\n",
+       "}\n",
+       "\n",
+       "\n",
+       "\n",
+       "mpl.figure.prototype._canvas_extra_style = function(canvas_div) {\n",
+       "\n",
+       "}\n",
+       "\n",
+       "\n",
+       "mpl.figure.prototype._root_extra_style = function(canvas_div) {\n",
+       "\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype._init_canvas = function() {\n",
+       "    var fig = this;\n",
+       "\n",
+       "    var canvas_div = $('<div/>');\n",
+       "\n",
+       "    canvas_div.attr('style', 'position: relative; clear: both; outline: 0');\n",
+       "\n",
+       "    function canvas_keyboard_event(event) {\n",
+       "        return fig.key_event(event, event['data']);\n",
+       "    }\n",
+       "\n",
+       "    canvas_div.keydown('key_press', canvas_keyboard_event);\n",
+       "    canvas_div.keyup('key_release', canvas_keyboard_event);\n",
+       "    this.canvas_div = canvas_div\n",
+       "    this._canvas_extra_style(canvas_div)\n",
+       "    this.root.append(canvas_div);\n",
+       "\n",
+       "    var canvas = $('<canvas/>');\n",
+       "    canvas.addClass('mpl-canvas');\n",
+       "    canvas.attr('style', \"left: 0; top: 0; z-index: 0; outline: 0\")\n",
+       "\n",
+       "    this.canvas = canvas[0];\n",
+       "    this.context = canvas[0].getContext(\"2d\");\n",
+       "\n",
+       "    var backingStore = this.context.backingStorePixelRatio ||\n",
+       "\tthis.context.webkitBackingStorePixelRatio ||\n",
+       "\tthis.context.mozBackingStorePixelRatio ||\n",
+       "\tthis.context.msBackingStorePixelRatio ||\n",
+       "\tthis.context.oBackingStorePixelRatio ||\n",
+       "\tthis.context.backingStorePixelRatio || 1;\n",
+       "\n",
+       "    mpl.ratio = (window.devicePixelRatio || 1) / backingStore;\n",
+       "\n",
+       "    var rubberband = $('<canvas/>');\n",
+       "    rubberband.attr('style', \"position: absolute; left: 0; top: 0; z-index: 1;\")\n",
+       "\n",
+       "    var pass_mouse_events = true;\n",
+       "\n",
+       "    canvas_div.resizable({\n",
+       "        start: function(event, ui) {\n",
+       "            pass_mouse_events = false;\n",
+       "        },\n",
+       "        resize: function(event, ui) {\n",
+       "            fig.request_resize(ui.size.width, ui.size.height);\n",
+       "        },\n",
+       "        stop: function(event, ui) {\n",
+       "            pass_mouse_events = true;\n",
+       "            fig.request_resize(ui.size.width, ui.size.height);\n",
+       "        },\n",
+       "    });\n",
+       "\n",
+       "    function mouse_event_fn(event) {\n",
+       "        if (pass_mouse_events)\n",
+       "            return fig.mouse_event(event, event['data']);\n",
+       "    }\n",
+       "\n",
+       "    rubberband.mousedown('button_press', mouse_event_fn);\n",
+       "    rubberband.mouseup('button_release', mouse_event_fn);\n",
+       "    // Throttle sequential mouse events to 1 every 20ms.\n",
+       "    rubberband.mousemove('motion_notify', mouse_event_fn);\n",
+       "\n",
+       "    rubberband.mouseenter('figure_enter', mouse_event_fn);\n",
+       "    rubberband.mouseleave('figure_leave', mouse_event_fn);\n",
+       "\n",
+       "    canvas_div.on(\"wheel\", function (event) {\n",
+       "        event = event.originalEvent;\n",
+       "        event['data'] = 'scroll'\n",
+       "        if (event.deltaY < 0) {\n",
+       "            event.step = 1;\n",
+       "        } else {\n",
+       "            event.step = -1;\n",
+       "        }\n",
+       "        mouse_event_fn(event);\n",
+       "    });\n",
+       "\n",
+       "    canvas_div.append(canvas);\n",
+       "    canvas_div.append(rubberband);\n",
+       "\n",
+       "    this.rubberband = rubberband;\n",
+       "    this.rubberband_canvas = rubberband[0];\n",
+       "    this.rubberband_context = rubberband[0].getContext(\"2d\");\n",
+       "    this.rubberband_context.strokeStyle = \"#000000\";\n",
+       "\n",
+       "    this._resize_canvas = function(width, height) {\n",
+       "        // Keep the size of the canvas, canvas container, and rubber band\n",
+       "        // canvas in synch.\n",
+       "        canvas_div.css('width', width)\n",
+       "        canvas_div.css('height', height)\n",
+       "\n",
+       "        canvas.attr('width', width * mpl.ratio);\n",
+       "        canvas.attr('height', height * mpl.ratio);\n",
+       "        canvas.attr('style', 'width: ' + width + 'px; height: ' + height + 'px;');\n",
+       "\n",
+       "        rubberband.attr('width', width);\n",
+       "        rubberband.attr('height', height);\n",
+       "    }\n",
+       "\n",
+       "    // Set the figure to an initial 600x600px, this will subsequently be updated\n",
+       "    // upon first draw.\n",
+       "    this._resize_canvas(600, 600);\n",
+       "\n",
+       "    // Disable right mouse context menu.\n",
+       "    $(this.rubberband_canvas).bind(\"contextmenu\",function(e){\n",
+       "        return false;\n",
+       "    });\n",
+       "\n",
+       "    function set_focus () {\n",
+       "        canvas.focus();\n",
+       "        canvas_div.focus();\n",
+       "    }\n",
+       "\n",
+       "    window.setTimeout(set_focus, 100);\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype._init_toolbar = function() {\n",
+       "    var fig = this;\n",
+       "\n",
+       "    var nav_element = $('<div/>')\n",
+       "    nav_element.attr('style', 'width: 100%');\n",
+       "    this.root.append(nav_element);\n",
+       "\n",
+       "    // Define a callback function for later on.\n",
+       "    function toolbar_event(event) {\n",
+       "        return fig.toolbar_button_onclick(event['data']);\n",
+       "    }\n",
+       "    function toolbar_mouse_event(event) {\n",
+       "        return fig.toolbar_button_onmouseover(event['data']);\n",
+       "    }\n",
+       "\n",
+       "    for(var toolbar_ind in mpl.toolbar_items) {\n",
+       "        var name = mpl.toolbar_items[toolbar_ind][0];\n",
+       "        var tooltip = mpl.toolbar_items[toolbar_ind][1];\n",
+       "        var image = mpl.toolbar_items[toolbar_ind][2];\n",
+       "        var method_name = mpl.toolbar_items[toolbar_ind][3];\n",
+       "\n",
+       "        if (!name) {\n",
+       "            // put a spacer in here.\n",
+       "            continue;\n",
+       "        }\n",
+       "        var button = $('<button/>');\n",
+       "        button.addClass('ui-button ui-widget ui-state-default ui-corner-all ' +\n",
+       "                        'ui-button-icon-only');\n",
+       "        button.attr('role', 'button');\n",
+       "        button.attr('aria-disabled', 'false');\n",
+       "        button.click(method_name, toolbar_event);\n",
+       "        button.mouseover(tooltip, toolbar_mouse_event);\n",
+       "\n",
+       "        var icon_img = $('<span/>');\n",
+       "        icon_img.addClass('ui-button-icon-primary ui-icon');\n",
+       "        icon_img.addClass(image);\n",
+       "        icon_img.addClass('ui-corner-all');\n",
+       "\n",
+       "        var tooltip_span = $('<span/>');\n",
+       "        tooltip_span.addClass('ui-button-text');\n",
+       "        tooltip_span.html(tooltip);\n",
+       "\n",
+       "        button.append(icon_img);\n",
+       "        button.append(tooltip_span);\n",
+       "\n",
+       "        nav_element.append(button);\n",
+       "    }\n",
+       "\n",
+       "    var fmt_picker_span = $('<span/>');\n",
+       "\n",
+       "    var fmt_picker = $('<select/>');\n",
+       "    fmt_picker.addClass('mpl-toolbar-option ui-widget ui-widget-content');\n",
+       "    fmt_picker_span.append(fmt_picker);\n",
+       "    nav_element.append(fmt_picker_span);\n",
+       "    this.format_dropdown = fmt_picker[0];\n",
+       "\n",
+       "    for (var ind in mpl.extensions) {\n",
+       "        var fmt = mpl.extensions[ind];\n",
+       "        var option = $(\n",
+       "            '<option/>', {selected: fmt === mpl.default_extension}).html(fmt);\n",
+       "        fmt_picker.append(option)\n",
+       "    }\n",
+       "\n",
+       "    // Add hover states to the ui-buttons\n",
+       "    $( \".ui-button\" ).hover(\n",
+       "        function() { $(this).addClass(\"ui-state-hover\");},\n",
+       "        function() { $(this).removeClass(\"ui-state-hover\");}\n",
+       "    );\n",
+       "\n",
+       "    var status_bar = $('<span class=\"mpl-message\"/>');\n",
+       "    nav_element.append(status_bar);\n",
+       "    this.message = status_bar[0];\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.request_resize = function(x_pixels, y_pixels) {\n",
+       "    // Request matplotlib to resize the figure. Matplotlib will then trigger a resize in the client,\n",
+       "    // which will in turn request a refresh of the image.\n",
+       "    this.send_message('resize', {'width': x_pixels, 'height': y_pixels});\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.send_message = function(type, properties) {\n",
+       "    properties['type'] = type;\n",
+       "    properties['figure_id'] = this.id;\n",
+       "    this.ws.send(JSON.stringify(properties));\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.send_draw_message = function() {\n",
+       "    if (!this.waiting) {\n",
+       "        this.waiting = true;\n",
+       "        this.ws.send(JSON.stringify({type: \"draw\", figure_id: this.id}));\n",
+       "    }\n",
+       "}\n",
+       "\n",
+       "\n",
+       "mpl.figure.prototype.handle_save = function(fig, msg) {\n",
+       "    var format_dropdown = fig.format_dropdown;\n",
+       "    var format = format_dropdown.options[format_dropdown.selectedIndex].value;\n",
+       "    fig.ondownload(fig, format);\n",
+       "}\n",
+       "\n",
+       "\n",
+       "mpl.figure.prototype.handle_resize = function(fig, msg) {\n",
+       "    var size = msg['size'];\n",
+       "    if (size[0] != fig.canvas.width || size[1] != fig.canvas.height) {\n",
+       "        fig._resize_canvas(size[0], size[1]);\n",
+       "        fig.send_message(\"refresh\", {});\n",
+       "    };\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.handle_rubberband = function(fig, msg) {\n",
+       "    var x0 = msg['x0'] / mpl.ratio;\n",
+       "    var y0 = (fig.canvas.height - msg['y0']) / mpl.ratio;\n",
+       "    var x1 = msg['x1'] / mpl.ratio;\n",
+       "    var y1 = (fig.canvas.height - msg['y1']) / mpl.ratio;\n",
+       "    x0 = Math.floor(x0) + 0.5;\n",
+       "    y0 = Math.floor(y0) + 0.5;\n",
+       "    x1 = Math.floor(x1) + 0.5;\n",
+       "    y1 = Math.floor(y1) + 0.5;\n",
+       "    var min_x = Math.min(x0, x1);\n",
+       "    var min_y = Math.min(y0, y1);\n",
+       "    var width = Math.abs(x1 - x0);\n",
+       "    var height = Math.abs(y1 - y0);\n",
+       "\n",
+       "    fig.rubberband_context.clearRect(\n",
+       "        0, 0, fig.canvas.width, fig.canvas.height);\n",
+       "\n",
+       "    fig.rubberband_context.strokeRect(min_x, min_y, width, height);\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.handle_figure_label = function(fig, msg) {\n",
+       "    // Updates the figure title.\n",
+       "    fig.header.textContent = msg['label'];\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.handle_cursor = function(fig, msg) {\n",
+       "    var cursor = msg['cursor'];\n",
+       "    switch(cursor)\n",
+       "    {\n",
+       "    case 0:\n",
+       "        cursor = 'pointer';\n",
+       "        break;\n",
+       "    case 1:\n",
+       "        cursor = 'default';\n",
+       "        break;\n",
+       "    case 2:\n",
+       "        cursor = 'crosshair';\n",
+       "        break;\n",
+       "    case 3:\n",
+       "        cursor = 'move';\n",
+       "        break;\n",
+       "    }\n",
+       "    fig.rubberband_canvas.style.cursor = cursor;\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.handle_message = function(fig, msg) {\n",
+       "    fig.message.textContent = msg['message'];\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.handle_draw = function(fig, msg) {\n",
+       "    // Request the server to send over a new figure.\n",
+       "    fig.send_draw_message();\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.handle_image_mode = function(fig, msg) {\n",
+       "    fig.image_mode = msg['mode'];\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.updated_canvas_event = function() {\n",
+       "    // Called whenever the canvas gets updated.\n",
+       "    this.send_message(\"ack\", {});\n",
+       "}\n",
+       "\n",
+       "// A function to construct a web socket function for onmessage handling.\n",
+       "// Called in the figure constructor.\n",
+       "mpl.figure.prototype._make_on_message_function = function(fig) {\n",
+       "    return function socket_on_message(evt) {\n",
+       "        if (evt.data instanceof Blob) {\n",
+       "            /* FIXME: We get \"Resource interpreted as Image but\n",
+       "             * transferred with MIME type text/plain:\" errors on\n",
+       "             * Chrome.  But how to set the MIME type?  It doesn't seem\n",
+       "             * to be part of the websocket stream */\n",
+       "            evt.data.type = \"image/png\";\n",
+       "\n",
+       "            /* Free the memory for the previous frames */\n",
+       "            if (fig.imageObj.src) {\n",
+       "                (window.URL || window.webkitURL).revokeObjectURL(\n",
+       "                    fig.imageObj.src);\n",
+       "            }\n",
+       "\n",
+       "            fig.imageObj.src = (window.URL || window.webkitURL).createObjectURL(\n",
+       "                evt.data);\n",
+       "            fig.updated_canvas_event();\n",
+       "            fig.waiting = false;\n",
+       "            return;\n",
+       "        }\n",
+       "        else if (typeof evt.data === 'string' && evt.data.slice(0, 21) == \"data:image/png;base64\") {\n",
+       "            fig.imageObj.src = evt.data;\n",
+       "            fig.updated_canvas_event();\n",
+       "            fig.waiting = false;\n",
+       "            return;\n",
+       "        }\n",
+       "\n",
+       "        var msg = JSON.parse(evt.data);\n",
+       "        var msg_type = msg['type'];\n",
+       "\n",
+       "        // Call the  \"handle_{type}\" callback, which takes\n",
+       "        // the figure and JSON message as its only arguments.\n",
+       "        try {\n",
+       "            var callback = fig[\"handle_\" + msg_type];\n",
+       "        } catch (e) {\n",
+       "            console.log(\"No handler for the '\" + msg_type + \"' message type: \", msg);\n",
+       "            return;\n",
+       "        }\n",
+       "\n",
+       "        if (callback) {\n",
+       "            try {\n",
+       "                // console.log(\"Handling '\" + msg_type + \"' message: \", msg);\n",
+       "                callback(fig, msg);\n",
+       "            } catch (e) {\n",
+       "                console.log(\"Exception inside the 'handler_\" + msg_type + \"' callback:\", e, e.stack, msg);\n",
+       "            }\n",
+       "        }\n",
+       "    };\n",
+       "}\n",
+       "\n",
+       "// from http://stackoverflow.com/questions/1114465/getting-mouse-location-in-canvas\n",
+       "mpl.findpos = function(e) {\n",
+       "    //this section is from http://www.quirksmode.org/js/events_properties.html\n",
+       "    var targ;\n",
+       "    if (!e)\n",
+       "        e = window.event;\n",
+       "    if (e.target)\n",
+       "        targ = e.target;\n",
+       "    else if (e.srcElement)\n",
+       "        targ = e.srcElement;\n",
+       "    if (targ.nodeType == 3) // defeat Safari bug\n",
+       "        targ = targ.parentNode;\n",
+       "\n",
+       "    // jQuery normalizes the pageX and pageY\n",
+       "    // pageX,Y are the mouse positions relative to the document\n",
+       "    // offset() returns the position of the element relative to the document\n",
+       "    var x = e.pageX - $(targ).offset().left;\n",
+       "    var y = e.pageY - $(targ).offset().top;\n",
+       "\n",
+       "    return {\"x\": x, \"y\": y};\n",
+       "};\n",
+       "\n",
+       "/*\n",
+       " * return a copy of an object with only non-object keys\n",
+       " * we need this to avoid circular references\n",
+       " * http://stackoverflow.com/a/24161582/3208463\n",
+       " */\n",
+       "function simpleKeys (original) {\n",
+       "  return Object.keys(original).reduce(function (obj, key) {\n",
+       "    if (typeof original[key] !== 'object')\n",
+       "        obj[key] = original[key]\n",
+       "    return obj;\n",
+       "  }, {});\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.mouse_event = function(event, name) {\n",
+       "    var canvas_pos = mpl.findpos(event)\n",
+       "\n",
+       "    if (name === 'button_press')\n",
+       "    {\n",
+       "        this.canvas.focus();\n",
+       "        this.canvas_div.focus();\n",
+       "    }\n",
+       "\n",
+       "    var x = canvas_pos.x * mpl.ratio;\n",
+       "    var y = canvas_pos.y * mpl.ratio;\n",
+       "\n",
+       "    this.send_message(name, {x: x, y: y, button: event.button,\n",
+       "                             step: event.step,\n",
+       "                             guiEvent: simpleKeys(event)});\n",
+       "\n",
+       "    /* This prevents the web browser from automatically changing to\n",
+       "     * the text insertion cursor when the button is pressed.  We want\n",
+       "     * to control all of the cursor setting manually through the\n",
+       "     * 'cursor' event from matplotlib */\n",
+       "    event.preventDefault();\n",
+       "    return false;\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype._key_event_extra = function(event, name) {\n",
+       "    // Handle any extra behaviour associated with a key event\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.key_event = function(event, name) {\n",
+       "\n",
+       "    // Prevent repeat events\n",
+       "    if (name == 'key_press')\n",
+       "    {\n",
+       "        if (event.which === this._key)\n",
+       "            return;\n",
+       "        else\n",
+       "            this._key = event.which;\n",
+       "    }\n",
+       "    if (name == 'key_release')\n",
+       "        this._key = null;\n",
+       "\n",
+       "    var value = '';\n",
+       "    if (event.ctrlKey && event.which != 17)\n",
+       "        value += \"ctrl+\";\n",
+       "    if (event.altKey && event.which != 18)\n",
+       "        value += \"alt+\";\n",
+       "    if (event.shiftKey && event.which != 16)\n",
+       "        value += \"shift+\";\n",
+       "\n",
+       "    value += 'k';\n",
+       "    value += event.which.toString();\n",
+       "\n",
+       "    this._key_event_extra(event, name);\n",
+       "\n",
+       "    this.send_message(name, {key: value,\n",
+       "                             guiEvent: simpleKeys(event)});\n",
+       "    return false;\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.toolbar_button_onclick = function(name) {\n",
+       "    if (name == 'download') {\n",
+       "        this.handle_save(this, null);\n",
+       "    } else {\n",
+       "        this.send_message(\"toolbar_button\", {name: name});\n",
+       "    }\n",
+       "};\n",
+       "\n",
+       "mpl.figure.prototype.toolbar_button_onmouseover = function(tooltip) {\n",
+       "    this.message.textContent = tooltip;\n",
+       "};\n",
+       "mpl.toolbar_items = [[\"Home\", \"Reset original view\", \"fa fa-home icon-home\", \"home\"], [\"Back\", \"Back to  previous view\", \"fa fa-arrow-left icon-arrow-left\", \"back\"], [\"Forward\", \"Forward to next view\", \"fa fa-arrow-right icon-arrow-right\", \"forward\"], [\"\", \"\", \"\", \"\"], [\"Pan\", \"Pan axes with left mouse, zoom with right\", \"fa fa-arrows icon-move\", \"pan\"], [\"Zoom\", \"Zoom to rectangle\", \"fa fa-square-o icon-check-empty\", \"zoom\"], [\"\", \"\", \"\", \"\"], [\"Download\", \"Download plot\", \"fa fa-floppy-o icon-save\", \"download\"]];\n",
+       "\n",
+       "mpl.extensions = [\"eps\", \"jpeg\", \"pdf\", \"png\", \"ps\", \"raw\", \"svg\", \"tif\"];\n",
+       "\n",
+       "mpl.default_extension = \"png\";var comm_websocket_adapter = function(comm) {\n",
+       "    // Create a \"websocket\"-like object which calls the given IPython comm\n",
+       "    // object with the appropriate methods. Currently this is a non binary\n",
+       "    // socket, so there is still some room for performance tuning.\n",
+       "    var ws = {};\n",
+       "\n",
+       "    ws.close = function() {\n",
+       "        comm.close()\n",
+       "    };\n",
+       "    ws.send = function(m) {\n",
+       "        //console.log('sending', m);\n",
+       "        comm.send(m);\n",
+       "    };\n",
+       "    // Register the callback with on_msg.\n",
+       "    comm.on_msg(function(msg) {\n",
+       "        //console.log('receiving', msg['content']['data'], msg);\n",
+       "        // Pass the mpl event to the overriden (by mpl) onmessage function.\n",
+       "        ws.onmessage(msg['content']['data'])\n",
+       "    });\n",
+       "    return ws;\n",
+       "}\n",
+       "\n",
+       "mpl.mpl_figure_comm = function(comm, msg) {\n",
+       "    // This is the function which gets called when the mpl process\n",
+       "    // starts-up an IPython Comm through the \"matplotlib\" channel.\n",
+       "\n",
+       "    var id = msg.content.data.id;\n",
+       "    // Get hold of the div created by the display call when the Comm\n",
+       "    // socket was opened in Python.\n",
+       "    var element = $(\"#\" + id);\n",
+       "    var ws_proxy = comm_websocket_adapter(comm)\n",
+       "\n",
+       "    function ondownload(figure, format) {\n",
+       "        window.open(figure.imageObj.src);\n",
+       "    }\n",
+       "\n",
+       "    var fig = new mpl.figure(id, ws_proxy,\n",
+       "                           ondownload,\n",
+       "                           element.get(0));\n",
+       "\n",
+       "    // Call onopen now - mpl needs it, as it is assuming we've passed it a real\n",
+       "    // web socket which is closed, not our websocket->open comm proxy.\n",
+       "    ws_proxy.onopen();\n",
+       "\n",
+       "    fig.parent_element = element.get(0);\n",
+       "    fig.cell_info = mpl.find_output_cell(\"<div id='\" + id + \"'></div>\");\n",
+       "    if (!fig.cell_info) {\n",
+       "        console.error(\"Failed to find cell for figure\", id, fig);\n",
+       "        return;\n",
+       "    }\n",
+       "\n",
+       "    var output_index = fig.cell_info[2]\n",
+       "    var cell = fig.cell_info[0];\n",
+       "\n",
+       "};\n",
+       "\n",
+       "mpl.figure.prototype.handle_close = function(fig, msg) {\n",
+       "    var width = fig.canvas.width/mpl.ratio\n",
+       "    fig.root.unbind('remove')\n",
+       "\n",
+       "    // Update the output cell to use the data from the current canvas.\n",
+       "    fig.push_to_output();\n",
+       "    var dataURL = fig.canvas.toDataURL();\n",
+       "    // Re-enable the keyboard manager in IPython - without this line, in FF,\n",
+       "    // the notebook keyboard shortcuts fail.\n",
+       "    IPython.keyboard_manager.enable()\n",
+       "    $(fig.parent_element).html('<img src=\"' + dataURL + '\" width=\"' + width + '\">');\n",
+       "    fig.close_ws(fig, msg);\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.close_ws = function(fig, msg){\n",
+       "    fig.send_message('closing', msg);\n",
+       "    // fig.ws.close()\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.push_to_output = function(remove_interactive) {\n",
+       "    // Turn the data on the canvas into data in the output cell.\n",
+       "    var width = this.canvas.width/mpl.ratio\n",
+       "    var dataURL = this.canvas.toDataURL();\n",
+       "    this.cell_info[1]['text/html'] = '<img src=\"' + dataURL + '\" width=\"' + width + '\">';\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.updated_canvas_event = function() {\n",
+       "    // Tell IPython that the notebook contents must change.\n",
+       "    IPython.notebook.set_dirty(true);\n",
+       "    this.send_message(\"ack\", {});\n",
+       "    var fig = this;\n",
+       "    // Wait a second, then push the new image to the DOM so\n",
+       "    // that it is saved nicely (might be nice to debounce this).\n",
+       "    setTimeout(function () { fig.push_to_output() }, 1000);\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype._init_toolbar = function() {\n",
+       "    var fig = this;\n",
+       "\n",
+       "    var nav_element = $('<div/>')\n",
+       "    nav_element.attr('style', 'width: 100%');\n",
+       "    this.root.append(nav_element);\n",
+       "\n",
+       "    // Define a callback function for later on.\n",
+       "    function toolbar_event(event) {\n",
+       "        return fig.toolbar_button_onclick(event['data']);\n",
+       "    }\n",
+       "    function toolbar_mouse_event(event) {\n",
+       "        return fig.toolbar_button_onmouseover(event['data']);\n",
+       "    }\n",
+       "\n",
+       "    for(var toolbar_ind in mpl.toolbar_items){\n",
+       "        var name = mpl.toolbar_items[toolbar_ind][0];\n",
+       "        var tooltip = mpl.toolbar_items[toolbar_ind][1];\n",
+       "        var image = mpl.toolbar_items[toolbar_ind][2];\n",
+       "        var method_name = mpl.toolbar_items[toolbar_ind][3];\n",
+       "\n",
+       "        if (!name) { continue; };\n",
+       "\n",
+       "        var button = $('<button class=\"btn btn-default\" href=\"#\" title=\"' + name + '\"><i class=\"fa ' + image + ' fa-lg\"></i></button>');\n",
+       "        button.click(method_name, toolbar_event);\n",
+       "        button.mouseover(tooltip, toolbar_mouse_event);\n",
+       "        nav_element.append(button);\n",
+       "    }\n",
+       "\n",
+       "    // Add the status bar.\n",
+       "    var status_bar = $('<span class=\"mpl-message\" style=\"text-align:right; float: right;\"/>');\n",
+       "    nav_element.append(status_bar);\n",
+       "    this.message = status_bar[0];\n",
+       "\n",
+       "    // Add the close button to the window.\n",
+       "    var buttongrp = $('<div class=\"btn-group inline pull-right\"></div>');\n",
+       "    var button = $('<button class=\"btn btn-mini btn-primary\" href=\"#\" title=\"Stop Interaction\"><i class=\"fa fa-power-off icon-remove icon-large\"></i></button>');\n",
+       "    button.click(function (evt) { fig.handle_close(fig, {}); } );\n",
+       "    button.mouseover('Stop Interaction', toolbar_mouse_event);\n",
+       "    buttongrp.append(button);\n",
+       "    var titlebar = this.root.find($('.ui-dialog-titlebar'));\n",
+       "    titlebar.prepend(buttongrp);\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype._root_extra_style = function(el){\n",
+       "    var fig = this\n",
+       "    el.on(\"remove\", function(){\n",
+       "\tfig.close_ws(fig, {});\n",
+       "    });\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype._canvas_extra_style = function(el){\n",
+       "    // this is important to make the div 'focusable\n",
+       "    el.attr('tabindex', 0)\n",
+       "    // reach out to IPython and tell the keyboard manager to turn it's self\n",
+       "    // off when our div gets focus\n",
+       "\n",
+       "    // location in version 3\n",
+       "    if (IPython.notebook.keyboard_manager) {\n",
+       "        IPython.notebook.keyboard_manager.register_events(el);\n",
+       "    }\n",
+       "    else {\n",
+       "        // location in version 2\n",
+       "        IPython.keyboard_manager.register_events(el);\n",
+       "    }\n",
+       "\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype._key_event_extra = function(event, name) {\n",
+       "    var manager = IPython.notebook.keyboard_manager;\n",
+       "    if (!manager)\n",
+       "        manager = IPython.keyboard_manager;\n",
+       "\n",
+       "    // Check for shift+enter\n",
+       "    if (event.shiftKey && event.which == 13) {\n",
+       "        this.canvas_div.blur();\n",
+       "        // select the cell after this one\n",
+       "        var index = IPython.notebook.find_cell_index(this.cell_info[0]);\n",
+       "        IPython.notebook.select(index + 1);\n",
+       "    }\n",
+       "}\n",
+       "\n",
+       "mpl.figure.prototype.handle_save = function(fig, msg) {\n",
+       "    fig.ondownload(fig, null);\n",
+       "}\n",
+       "\n",
+       "\n",
+       "mpl.find_output_cell = function(html_output) {\n",
+       "    // Return the cell and output element which can be found *uniquely* in the notebook.\n",
+       "    // Note - this is a bit hacky, but it is done because the \"notebook_saving.Notebook\"\n",
+       "    // IPython event is triggered only after the cells have been serialised, which for\n",
+       "    // our purposes (turning an active figure into a static one), is too late.\n",
+       "    var cells = IPython.notebook.get_cells();\n",
+       "    var ncells = cells.length;\n",
+       "    for (var i=0; i<ncells; i++) {\n",
+       "        var cell = cells[i];\n",
+       "        if (cell.cell_type === 'code'){\n",
+       "            for (var j=0; j<cell.output_area.outputs.length; j++) {\n",
+       "                var data = cell.output_area.outputs[j];\n",
+       "                if (data.data) {\n",
+       "                    // IPython >= 3 moved mimebundle to data attribute of output\n",
+       "                    data = data.data;\n",
+       "                }\n",
+       "                if (data['text/html'] == html_output) {\n",
+       "                    return [cell, data, j];\n",
+       "                }\n",
+       "            }\n",
+       "        }\n",
+       "    }\n",
+       "}\n",
+       "\n",
+       "// Register the function which deals with the matplotlib target/channel.\n",
+       "// The kernel may be null if the page has been refreshed.\n",
+       "if (IPython.notebook.kernel != null) {\n",
+       "    IPython.notebook.kernel.comm_manager.register_target('matplotlib', mpl.mpl_figure_comm);\n",
+       "}\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<img src=\"data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAhAAAAIQCAYAAADQAFeJAAAgAElEQVR4Xu3dCdylc/3/8bd9bIOyjJ2okCRMxmRrQck2ZY2IpJSUfR9bWSIJIWUnZYkkiYTBGAZJ9n0yzBjbGMas8nt877nuX8fdPXPO9fl8vvd9Xfd5ncfD4///zZzv9z7n+b1yv3yv61xnNvFAAAEEEEAAAQRKCsxW8vk8HQEEEEAAAQQQEAHBQYAAAggggAACpQUIiNJkDEAAAQQQQAABAoJjAAEEEEAAAQRKCxAQpckYgAACCCCAAAIEBMcAAggggAACCJQWICBKkzEAAQQQQAABBAgIjgEEEEAAAQQQKC1AQJQmYwACCCCAAAIIEBAcAwgggAACCCBQWoCAKE3GAAQQQAABBBAgIDgGEEAAAQQQQKC0AAFRmowBCCCAAAIIIEBAcAwggAACCCCAQGkBAqI0GQMQQAABBBBAgIDgGEAAAQQQQACB0gIERGkyBiCAAAIIIIAAAcExgAACCCCAAAKlBQiI0mQMQAABBBBAAAECgmMAAQQQQAABBEoLEBClyRiAAAIIIIAAAgQExwACCCCAAAIIlBYgIEqTMQABBBBAAAEECAiOAQQQQAABBBAoLUBAlCZjAAIIIIAAAggQEBwDCCCAAAIIIFBagIAoTcYABBBAAAEEECAgOAYQQAABBBBAoLQAAVGajAEIIIAAAgggQEBwDCCAAAIIIIBAaQECojQZAxBAAAEEEECAgOAYQAABBBBAAIHSAgREaTIGIIAAAggggAABwTGAAAIIIIAAAqUFCIjSZAxAAAEEEEAAAQKCYwABBBBAAAEESgsQEKXJGIAAAggggAACBATHAAIIIIAAAgiUFiAgSpMxAAEEEEAAAQQICI4BBBBAAAEEECgtQECUJmMAAggggAACCBAQHAMIIIAAAgggUFqAgChNxgAEEEAAAQQQICA4BhBAAAEEEECgtAABUZqMAQgggAACCCBAQHAMIIAAAggggEBpAQKiNBkDEEAAAQQQQICA4BhAAAEEEEAAgdICBERpMgYggAACCCCAAAHBMYAAAggggAACpQUIiNJkDEAAAQQQQAABAoJjAAEEEEAAAQRKCxAQpckYgAACCCCAAAIEBMcAAggggAACCJQWICBKkzEAAQQQQAABBAgIjgEEEEAAAQQQKC1AQJQmYwACCCCAAAIIEBAcAwgggAACCCBQWoCAKE3GAAQQQAABBBAgIDgGEEAAAQQQQKC0AAFRmowBCCCAAAIIIEBAcAwggAACCCCAQGkBAqI0GQMQQAABBBBAgIDgGEAAAQQQQACB0gIERGkyBiCAAAIIIIAAAcExgAACCCCAAAKlBQiI0mQMQAABBBBAAAECgmMAAQQQQAABBEoLEBClyRiAAAIIIIAAAgQExwACCCCAQB0EFpa0QOALfUfS+MD52m4qAqLtlpw3jAACCNROYOEPLTL7m2+8+Z/IF/6GpJWICDspAWG3YyQCCCCAQM8ILCPpxRF/WVZLLj6H+yeOGfeeBn35xTTPspJGuyds0wkIiDZdeN42AgggUCOBjoB4/oHltcxSc7pf9uiXp2vFtUcREE5JAsIJyHAEEEAAgewCBER24vI/gIAob8YIBBBAAIGeFegIiGfuXzZsB2LldTiF4V1CAsIryHgEEEAAgdwCBERuYcP8BIQBjSEIIIAAAj0q0BEQT92/TNgOxMfW6bh2kosoHctIQDjwGIoAAggg0CMCHQHx5P1LaemAiyhfenm6Pr7OywSEc+kICCcgwxFAAAEEsgsQENmJy/8AAqK8GSMQQAABBHpWoCMgHhu5ZNgOxGoDx7AD4VxDAsIJyHAEEEAAgewCHQHxyMgBYQGx+sCxBIRz2QgIJyDDEUAAAQSyCxAQ2YnL/wACorwZIxBAAAEEelagIyAeHjlASy3lv5X1yy+/pzXYgXCvIAHhJmQCBBBAAIHMAgREZmDL9ASERY0xCCCAAAI9KdAREA+NXCJsB2LNga+k1899IByrSEA48BiKAAIIINAjAh0B8cB9i4cFxNqfGUdAOJeOgHACVnT4KpLOlDRY0tuSLpF0pKSpFX29VX1ZK0s6UNIgSatLeqL4f6v6eqv4uraXtKuktSQtJOlpSWdIulDS+1V8wRV9TZtLOkTSapL6S3pJ0nWSjpX0VkVfc+TLIiAiNYPmIiCCICs0zSKSHi3+RX2CpKUlnSbpMkn7VOh11uGlbC3pLEn3SvqYpNkJiNLLdo+kF4pfdq9K2kTSwZKOK375lZ6wTQfsImmN4lh8vTgOj5H0oKRN28CkIyBGBu5ADGQHwn3YEBBuwspNcJikIyQtJ+mN4tXtJens4s867t/KoyWBFAz/KZ55kaR1CIiW3BqftKik17qMOk/SDpJS7Hb6lp6YAfq2pGSZ/iOhr//vuiMg7r1vMS0Z8CmMMS+/p3U/k3qWayA8/zsiIDx61Rw7rAiHbRpe3sLFn+0hKf0i5FFegIAobzazEXsXQZu24tMpNh42ga9KukbSisUuj22WeowiICq4TgREBRfF+ZLSlUEXSDq0yzzpnOml3fy588e1zXACIm6pL5e0kaT0S4FHOYF0E4S5imsh0v/OR0lKp9r6+qMjIIanHYgl/feBGDPmPQ1mB8J9zBAQbsLKTTBN0lGSTuryyh6RNFxSOp3Bo7wAAVHerLsR60u6Q9IBkk6PmbKtZknfQZ1OWaTHTZK2lTSxDQQIiAouMgFRwUVxviQCwgk4k+EEhN81/RJIF6Q+Xlz4x/UP5U3ThZTzS/pE8cmq54oLU98rP1WtRnQExF2BOxDrswPhPgAICDdh5SZIpzDOl5Qupmx8cArDt1QEhM8vXYdzZ/HRzQ3a5KOHPrHmoz8l6SFJ20m6uvnTa/2MjoAYdt/iGhBwCmPsmPe0IZ/CcB8QBISbsHITpIso08e8hjS8svT5+zclcRGlfbkICLvdvJJuKT4FtF5xDwP7bIzsFEj//p4iaWg3pyz7mhIBUcEVJSAquCjOl5R2Hg4vPp40vphrT0nn8jFOlywBYeObU9K1xU3N0s7DY7ZpGNWNQLrBWbrPRvpI7JV9XKgjIG6/N24HYuN1uROl95ghILyC1RvfeSOppyQ13kgqXfnOjaTKrdd8ktIdANPj+5JWkrR/8X+nCwE7PkjOY5YC6T4F6X4F6aLJdBFv4+MfxX9BQ9hc4A+S7pf0sKRJktLpi4Mkpd+CA9vgLrMdAXHrvUuEncL4wrp8F0bzw27WzyAgvILVHL9qN7eyTjeX4lbW5dZrBUnPz2TI5yTdXm66tnx2ugvl8jN55+1w/4KoRU8fy047DSli0w3OkmuKilMlTYj6IRWeh4Co4OIQEBVcFF4SAggggMAHBDoC4uZ7B4TtQGy67tj0A/g2TseBRkA48BiKAAIIINAjAgREjzCX+yEERDkvno0AAggg0PMCHQHx1xEDtMSS6bpc3+OVMdO12SB2IHyKEgHhFWQ8AggggEBugY6AuHHEkmEBsfmgMZzCcK4aAeEEZDgCCCCAQHYBAiI7cfkfQECUN2MEAggggEDPCnQExJ9GLB22A7HloHRzXi6i9CwjAeHRYywCCCCAQE8IdATE9fcso8UDroEYN2a6tlovfS8ZAeFZPALCo8dYBBBAAIGeECAgekK55M8gIEqC1ezp/Ys7J57WJjebybU8OMbI4oijVaAjIK69Z9mwHYgh673IDoR1NYpxBIQTsOLDO/5Hxzade5VwdBN2TIAjjlYBAsIql3EcAZERtwJT8y/smEXAEccYgZhZ2vF47HjPVw9fPmwHYtvBo9iBcB6PBIQTsOLD2/FfNDmWBMcYVRxxtAp0HDtXDl9Biy85l3WO/x83bsw0bT84fZ0IF1F6MAkIu948kj5ZfCPje/Zpso4cIGlk8W19Hbdd42ESwNHE9j+DcGwfxzkkLSbpX0HfuEpAxBw7obMQEHbOdYpfzvYZGIkAAgj0bYH0VePpa8i9j46A+N3wFbVYwA7Eq2OmacfBHV+0y5dpOVaGgLDjpa8ofmHEjctoySX892a3v4z6j9x57dXq/yZ4Bwgg8P8CUzRJI3Vb+r9XkNRxsYHz0REQl9+9UlhA7PzZZwkI56IQEHbAjgN61AMraJmlCAg7o7TZUmt6hjMWAQQqJjD5/Xd1l26M/AVNQFRsjdPLISDsi0JA2O0+MJKACIJkGgQqIpArIC69e+WwHYhvfPaZyMCpiHzPvgwCwu5NQNjtCIggO6ZBoIoCBEQVVyX+NREQdlMCwm5HQATZMQ0CVRTIFRAX3/0xLRpwEeVrY6Zpt88+xQ6E8+AhIOyABITdjoAIsmMaBKookCsgLrhrlbCA2GP9JwgI58FDQNgBCQi7HQERZMc0CFRRgICo4qrEvyYCwm5KQNjtCIggO6ZBoIoCuQLiN3etqkWXnNv9ll8bM1V7rv84OxBOSQLCDkhA2O0IiCA7pkGgigK5AuK8O1fThwMC4vUxU7XXBo8REM6Dh4CwAxIQdjsCIsiOaRCoogABUcVViX9NBITdlICw2xEQQXZMg0AVBXIFxDl3rh62A7H3Bo+wA+E8eAgIOyABYbcjIILsmAaBKgoQEFVclfjXREDYTQkIux0BEWTHNAhUUSBXQPxy2BphOxDf3/BhdiCcBw8BYQckIOx2BESQHdMgUEWBXAFxxrA1wwJi3w0fIiCcBw8BYQckIOx2BESQHdMgUEUBAqKKqxL/mggIuykBYbcjIILsmAaBKgrkCojTh62pDw2Yx/2W3xg7RT9iB8LtSEDYCQkIux0BEWTHNAhUUSBXQJw2bK2wgNh/wwc5heE8eAgIOyABYbcjIILsmAaBKgoQEFVclfjXREDYTQkIux0BEWTHNAhUUSBXQJxyxzphOxAHbXQ/OxDOg4eAsAMSEHY7AiLIjmkQqKIAAVHFVYl/TQSE3ZSAsNsREEF2TINAFQVyBcTJdwwM24E4ZKOR7EA4Dx4Cwg5IQNjtCIggO6ZBoIoCuQLixNvX1SIBn8J4c+wUHbbxvQSE8+AhIOyABITdjoAIsmMaBKooQEBUcVXiXxMBYTclIOx2BESQHdMgUEWBXAHx49sHaZEB/dxv+c2xk3XkxiPYgXBKEhB2QALCbkdABNkxDQJVFMgVEMfdtl5YQAz93D0EhPPgISDsgASE3Y6ACLJjGgSqKEBAVHFV4l8TAWE3JSDsdgREkB3TIFBFgVwBccxtn9XCAacwxo+drGM+dzc7EM6Dh4CwAxIQdjsCIsiOaRCoogABUcVViX9NBITdlICw2xEQQXZMg0AVBXIFxNC/bxC2A3Hc5+9kB8J58BAQdkACwm5HQATZMQ0CVRTIFRBH/H3DsID4yeeHERDOg4eAsAMSEHY7AiLIjmkQqKIAAVHFVYl/TQSE3ZSAsNsREEF2TINAFQVyBcRht24ctgNx4hduZwfCefAQEHZAAsJuR0AE2TENAlUUyBUQh9y6sRYaMK/7Lb81dpJOJiDcjgSEnZCAsNsREEF2TINAFQUIiCquSvxrateAWEXSmZIGS3pb0iWSjpQ0tQQxAVECa1ZP3WypNYNmYhoEEKiCQK6AOOhvnw/bgTjli3+3nMKw/u6YT9JRknaQNEDSaEkXSfqppOlVWDPLa2jHgFhE0qOSnpZ0gqSlJZ0m6TJJ+5RAJCBKYBEQQVhMg0ANBPpoQHh+d1wg6WuSDpf0mKT1JB0n6WRJR9RgSbt9ie0YEIcVC7acpDcKlb0knS0p/dnLLS4mAdEiVLOnsQPRTIi/R6BeArkCYv9bvhi2A3HaJn8ruwNh/d0xe7HTfYqkYxpW8mJJ60taqV6r+99X244BkT78m8Jhm4ZFW7j4sz2KbaVW1pOAaEWphecQEC0g8RQEaiSQKyD2u2UT9Q+4iHLC2En6+Sa3lA0I6++OOSS9K+lQST9vWMYzJG0h6SM1WtoPvNR2DIhxktJ2UlrMxsdLki7t5s9ntrYERNBRT0AEQTINAhUR6KMB4fnd8StJX5S0o6THJQ2SdJWk44tT6BVZuXIvox0DYlpxMctJXagekTRcUjqd0d2jv6T0T+cjXQgzctQDK2iZpeYsp86zPyBAQHBAINC3BHIFxL43bxa2A3HGpn9N6AMljW3QnyAp/dPdw/q7I82VdiHOlbRnw8QnFtdE1HbxCYj/Ll2zgEjnro7uutIEhP/YJyD8hsyAQJUEcgXEPjd/Sf2X8N8HYsIrk3TWpjd1R3Zsl+sUGp/jCYh0/cPOxX+8pgv40w5E+n2Sfq+kv6vlox0DIm1DnS8pXRDT+Gh2CoMdiEyHOAGRCZZpEeglgRoFRJkdCOvvjtUl/UvSVpL+1LAk6dMX6aOdixUXWfbSatl/bDsGRLoQ5nVJQxrYFpL0piQuorQfS+aRBISZjoEIVFIgV0DsffOX1X+JdEsF32PCK+/qnE3/kiZZtrgnQysTWn93bC/p95KWl/Tvhh+0uaQ/S1qtuC6ilddQqee0Y0CknYf0Wdx04IwvViOdl0rnp/gYZy8cngREL6DzIxHIKJArIL771821YEBAvP3Kuzp3sxvLBoT1d8e6kkYUn/z7YwN72n1Ip0wWKD6lkXFF8kzdjgHReTOQp7rcSOpybiSV5yBrNisB0UyIv0egXgJ9NCBa/d2RTpHvJqnz6vp0AWUKiPQfrUMlPSMpRUUKiN92ubCyVgvdjgGRFmjVbm5lnc5HcSvrXjh8CYheQOdHIpBRIFdA7PXXLcJ2IM7b7IayOxCt/u5It6hOAdH4+zV9ai99ZHMTSYtLelHSFcWdKCdlXIqsU7drQESgch+ICEVJBEQQJNMgUBGBPhwQFRGuxssgIOzrQEDY7T4wkoAIgmQaBCoikCsgvnXTlmE7EOd/qeMDEWUuoqyIbnVeBgFhXwsCwm5HQATZMQ0CVRTIFRC7/2WrsIC48MvXExDOg4eAsAMSEHY7AiLIjmkQqKIAAVHFVYl/TQSE3ZSAsNsREEF2TINAFQVyBcQ3b9xGCwR8jPOdV97VRZtfxw6E8+AhIOyABITdjoAIsmMaBKookCsgvnHjkLCAuHTzawkI58FDQNgBCQi7HQERZMc0CFRRgICo4qrEvyYCwm5KQNjtCIggO6ZBoIoCuQJi5z+nHYj53W/5nVcm6vKvsAPhhSQg7IIEhN2OgAiyYxoEqihAQFRxVeJfEwFhNyUg7HYERJAd0yBQRYFcAbHTDV8L24G4YotrEh33gXAcQASEHY+AsNsREEF2TINAFQVyBcSON2yr+QNOYUx8ZaJ+t8XVBITz4CEg7IAEhN2OgAiyYxoEqihAQFRxVeJfEwFhNyUg7HYERJAd0yBQRYFcAbHdn7YL24G4asur2IFwHjwEhB2QgLDbERBBdkyDQBUFcgXE167fISwgrtnq9wSE8+AhIOyABITdjoAIsmMaBKooQEBUcVXiXxMBYTclIOx2BESQHdMgUEWBXAEx5PodNf/i/vtATBw3Uddu9Tt2IJwHDwFhByQg7HYERJAd0yBQRQECooqrEv+aCAi7KQFhtyMgguyYBoEqCuQKiG2u30nzBexAvDtuoq7b6gp2IJwHDwFhByQg7HYERJAd0yBQRYFcAbHVH1NALOB+y++Oe0fXb01AeCEJCLsgAWG3IyCC7JgGgSoKEBBVXJX410RA2E0JCLsdARFkxzQIVFEgV0Bscd3OYTsQN2xzOacwnAcPAWEHJCDsdgREkB3TIFBFgVwBsfm1u4QFxI1DLiMgnAcPAWEHJCDsdgREkB3TIFBFAQKiiqsS/5oICLspAWG3IyCC7JgGgSoK5AqIL137jbAdiJuGXMoOhPPgISDsgASE3Y6ACLJjGgSqKEBAVHFV4l8TAWE3JSDsdgREkB3TIFBFgVwBsdkfdtW8AR/jnDTuHf31q5ewA+E8eAgIOyABYbcjIILsmAaBKgrkCohNrtktLCBu+drFBITz4CEg7IAEhN2OgAiyYxoEqihAQFRxVeJfEwFhNyUg7HYERJAd0yBQRYFcAfGFq78ZtgNx67YXsQPhPHgICDsgAWG3IyCC7JgGgSoK5AqIz121e1hA3LbdhQSE8+AhIOyABITdjoAIsmMaBKooQEBUcVXiXxMBYTclIOx2BESQHdMgUEWBXAGx8VW7q9/iC7rf8uRxb+t2diDcjgSEnZCAsNsREEF2TINAFQUIiCquSvxrIiDspgSE3Y6ACLJjGgSqKJArIDa8co+wHYhh21+Q6JaVNLqKhnV4TQSEfZUICLsdARFkxzQIVFEgV0Csf+W31G+xgFMYr76tu7Y/n4BwHjwEhB2wIyDWn+0r6jfbfPZZGKkbRz+AQoDA5kuvFTALUyDgFyAg/IZ1mIGAsK8SAWG3+8BIAiIGkoCIcWQWv0CugBj8+z3DdiCG7/AbdiCcS01A2AEJCLsdARFk1zgNAZEBlSlNArkCYtDvvh0WECN2/DUBYVrd/w4iIOyABITdjoAIsiMgMkAypVuAgHAT1mICAsK+TASE3Y6ACLIjIDJAMqVbIFtAXLGX5gm4iHLKq29rxE7nsQPhXGkCwg5IQNjtCIggOwIiAyRTugUICDdhLSYgIOzLREDY7QiIIDsCIgMkU7oFcgXEZ674TtgOxH07/YodCOdKExB2QALCbkdABNkREBkgmdItkCsg1vntd8MC4v6vn0tAOFeagLADEhB2OwIiyI6AyADJlG4BAsJNWIsJCAj7MhEQdjsCIsiOgMgAyZRugVwBsfble4ftQDyw8znsQDhXmoCwAxIQdjsCIsiOgMgAyZRugVwB8enLUkD0d7++Ka9O0D92ISC8kASEXZCAsNsREEF2BEQGSKZ0CxAQbsJaTEBA2JeJgLDbERBBdgREBkimdAvkCog1L/1e2A7EQ984m1MYzpUmIOyABITdjoAIsiMgMkAypVuAgHAT1mICAsK+TASE3Y6ACLIjIDJAMqVbIFdAfOqS72vugGsgpr46Qf/c9ZfsQDhXmoCwAxIQdjsCIsiOgMgAyZRugVwBsUYKiEX9F1FOfW2CHiYg3OtMQNgJCQi7HQERZEdAZIBkSrcAAeEmrMUEBIR9mQgIux0BEWRHQGSAZEq3QK6AWP2SfcJ2IB7Z9SxOYThXmoCwAxIQdjsCIsiOgMgAyZRugVwB8YmLfxAWEI/udiYB4VxpAsIOSEDY7QiIIDsCIgMkU7oFCAg3YS0mICDsy0RA2O0IiCA7AiIDJFO6BXIFxKoX7Ru2A/H4N89gB8K50gSEHZCAsNsREEF2BEQGSKZ0CxAQbsJaTEBA2JeJgLDbERBBdgREBkimdAvkCohVLozbgXhid3YgvAtNQNgFCQi7HQERZEdAZIBkSrdAtoC44IeaK+A+ENNem6An9vgFpzCcK01A2AEJCLsdARFkR0BkgGRKtwAB4SasxQQEhH2ZCAi7HQERZEdAZIBkSrdAroD4+Pk/CtuBePJbp7MD4VxpAsIOSEDY7QiIIDsCIgMkU7oFcgXER3+zX1hAPL3nzwkI50oTEHZAAsJuR0AE2REQGSCZ0i1AQLgJazEBAWFfJgLCbkdABNkREBkgmdItkCsgVv513A7EM99mB8K70ASEXZCAsNsREEF2BEQGSKZ0CxAQbsJaTEBA2JeJgLDbERBBdgREBkimdAvkCoiVzks7EAu5X9+0197Ss3uxA+GFJCDsggSE3Y6ACLIjIDJAMqVbIFdAfOS8/TXXhwMC4vW39Nxep6X3uayk0e433KYTEBD2hScg7HYERJAdAZEBkindAgSEm7AWExAQ9mUiIOx2BESQHQGRAZIp3QK5AmLFwB2I59mBcK8zAWEnJCDsdgREkB0BkQGSKd0CuQJihV8dEHYK44Xv/IxTGM6VbseAWFnSgZIGSVpd0hPF/1uWkoAoKzaT5984+oGgmdp7ms2XXqu9AXj3lRHowwGxiqQzJQ2W9LakSyQdKWlqC/gLSzpO0raSPiTpJUlnS+oomTo+2jEgtpZ0lqR7JX1M0uwERO8eugREjD8BEePILH6BbAFxbuAOxHdL70AsIulRSU9LOkHS0pLSlZiXSdqnidr8ku6WNF3SKZJeKX7/9Jd0ql+8d2Zox4BIwfCfgvsiSesQEL1z8HX+VAIixp+AiHFkFr9AHw2IwyQdIWk5SW8USnsVuwjpz16ehdzxkr4uaQ1JE/3C1ZihHQOiUZ6AqMBxSEDELAIBEePILH6BbAFxzoGaM+BjnNNff0sv7N3xH/5lPsY5rAiHbRqE0mmJFBN7SEq/T2b2GFPsfP/Er1udGQgIdiB6/WgkIGKWgICIcWQWv0CugFj+7LiAGPW90gExTtIFkg7tIpSuZbi0mz/vfNoKkp6X9F1JX5G0WbELcY2k/SS94xfvnRkIiNYDIp2rSv90PgZIGrn+bF9Rv9nm653V6yM/lYCIWUgCIsaRWfwCNQqIgZLGNrzjCZLSP909pkk6StJJXf7yEUnDJaXTGd090gX79xSh8IfiwsuPFvP8RdJOfvHemYGAaD0gjpF0dNdlIiD8By4B4TdMMxAQMY7M4hfIFRDL/fKgsFMY//5+upbxfx7HSkr/ro8MiPSJjXQB5YOS1m6YeE9Jv5a0kqTn/Oo9PwMB0XpAsAOR6fgkIGJgCYgYR2bxC2QLiLMOjguIfX6a3miZHYh0CuN8SeliysZHs1MYq0p6rPi4ZrqFQOdjxSIctpL0J796z89AQLQeEF1Xh/tABB2vBEQMJAER48gsfoEaBUTZiyhflzSkQSh9McebTS6inLs4LZJuH9BdQGwv6Sq/es/PQEAQED1/1HX5iQREzBIQEDGOzOIXyBUQy54ZtwPx4g86diDKBETaeTi8GDO+UEqnIc4tPto5q49xXl+M+3SDbrpm4leS0s0Nn/Wr9/wM7RgQ6YrHzQvq7xfnn/Yv/u87JL3a4jKwA9EiVLOnERDNhFr7ewKiNSeelV+gjwZE542knupyI6nLu9xIKp3m2E3SnA3S6dqHdKHl1ZIulpQuojyxOHWxc/4VyYlwXqcAACAASURBVPMT2jEgOj9S053o5yTd3iI1AdEiVLOnERDNhFr7ewKiNSeelV8gW0CcEbgDsW/pHYgEl65n6Hor63RzqcZbWaf7QaSA6Pr79QvFJy8+WZz2SOGRxk7JvyJ5fkI7BkSUJAERJElAxEASEDGOzOIXyBUQy/zikLCLKEf/8OT0RsucwvDD9LEZCAj7ghIQdrsPjCQgYiAJiBhHZvELEBB+wzrMUOWAGFoSMH3LWU8+CIggbQIiBpKAiHFkFr9A1oD4UPrgg+8x/Y23xA6EzzCNrnJApI/GND7SR2HmLf5gsqR+xf9/UnEOKX09ak8+CIggbQIiBpKAiHFkFr9AroBY+vRDNWdQQLz0o44bSnIKw7HcVQ6IxreVvjHzSknpG83SVazpe9gXlLRd8V3sO6TbSjscLEMJCItaN2MIiBhIAiLGkVn8AgSE37AOM9QlIEYUH305pxvU9FHMdMXrZ3oYnIAIAicgYiAJiBhHZvELZAuInwfuQOzHDoR3pesSEOk0Rbr7103dvOEvSUpfUNLT32hFQHiPvmI8AREDSUDEODKLX4CA8BvWYYa6BMTjkp4sIuL9Btj0+v9Y3JQjfT63Jx8ERJA2AREDSUDEODKLXyBfQBwWdw3Efuk+TlwD4VntugTE1sW1D6OKO3elLzVZXNKWkpaXtG0REh6LsmMJiLJiM3k+AREDSUDEODKLXyBbQJwWGBD7ExDela5LQKT3uaakQ4trHZaUNEbSfcWdvR7yQhjGExAGtO6GEBAxkAREjCOz+AUICL9hHWaoU0BUzZOACFoRAiIGkoCIcWQWv0C2gPhZ4A7EAexAeFe6jgGRPreb/vmnpIleAMd4AsKB1ziUgIiBJCBiHJnFL5AtIE5NAbGw+wVOf2O8XjqQgPBC1ikg0lefHi0pnb5IF1IOlPSgpGuLL8D6hRej5HgCoiTYzJ5OQMRAEhAxjsziFyAg/IZ1mKEuAfEjSembT06TdKukmyWlm0ulgPhhcUOp9XsYnIAIAicgYiAJiBhHZvEL5AqIpU6J24F4+SB2ILwrXZeAeFbShZJ+LGkOSdMaAiLdB+JSSYt5MUqOJyBKgrEDEQQ2k2kIiLy+zN66AAHRulWdn1mXgEjffbG5pL93ExDpO9ZvaPiejJ5aDwIiSJodiBhIAiLGkVn8AtkC4qeBOxAHswPhXem6BES6iVTagUj3Hu26A3G4pPRdGJ/yYpQcT0CUBGMHIgiMHYi8kMzuFsgWECcfHnYR5cuHnJDeJ1+m5VjtugTEgZKOKa53SLetfl3SepIWlXSZpCMkne1wsAwlICxq3YxhByIGkh2IGEdm8QsQEH7DOsxQl4BIlmdISl+clT6BMbuk/xTAKRz27QVsAiIInYCIgSQgYhyZxS+QKyCWTjsQiwR8jPPN8XqJHQj3QtcpINKb/YikLxY7D28Un8h42q1gm4CAsLn9zygCIgaSgIhxZBa/QLaAOCkwIA7lFIZ3pesSEBsWH9l8p5s3PL+ktSUN82KUHE9AlASb2dMJiBhIAiLGkVn8AgSE37AOM9QlIN4rrnlI333R9ZHiIf15uriyJx8ERJA2AREDSUDEODKLXyBbQJx4RNwpjMN+kt4oF1E6lrsuAZGudxhUhELXt5t2J26UtIDDwTKUgLCodTOGgIiBJCBiHJnFL0BA+A3rMEOVAyIFw+AC8dTiIsp/d0HtJyl91Xe6qDLd2ronHwREkDYBEQNJQMQ4MotfIFtAnBC4A3E4OxDela5yQKTvvUj/pEf65EV3rzXdkfJxSd+TNNyLUXI8AVESbGZPJyBiIAmIGEdm8QtkC4ifBAbEEQSEd6WrHBCN7y2dwkj3fbjX+4YDxxMQQZgERAwkARHjyCx+AQLCb1iHGeoSEFW0JCCCVoWAiIEkIGIcmcUvkC0gfhy4A3EkOxDela5LQKRbVS8n6ZRu3nC6S+UoSVd5MUqOJyBKgnEKIwhsJtMQEHl9mb11gWwBcfyRcZ/COCp9NyOfwmh9Vf/3mXUJiIckXVBcSNn1XaS7U+5R3AvCY1F2LAFRVmwmz2cHIgaSgIhxZBa/AAHhN6zDDHUJiImStiy+jbOr6+ckXS9pwR4GJyCCwAmIGEgCIsaRWfwCuQJimePidiBGD2UHwrvSdQmI9OVZ+0i6ops3/HVJv5S0iBej5HgCoiQYpzCCwDiFkReS2d0CBISbsBYT1CUg0jdwrlTcFyLtRnQ+0m2s75b0vKQhPSxOQASBswMRA8kORIwjs/gFsgXEsYE7EEezA+Fd6boExCqS7pE0RdLVkl6WtJSkbSXNXYTFE16MkuMJiJJg7EAEgbEDkReS2d0CBISbsBYT1CUgEubKko6V9HlJH5aUTmv8rfizZ3pBm4AIQmcHIgaSHYgYR2bxCxAQfsM6zFCngKiaJwERtCIERAwkARHjyCx+gVwBsWw6hbHwwu4XOH38eL3IKQy3IwFhJ+wIiMHrHqx+8yxkn4WRmv3Of6AQILDRw5MCZmGKO9aYFwSnQLaAOOaouIA45vj0Lvk2TsdaVzkg0kczD5D0dPExzVm9zfRdGelLtXryQUAEaRMQMZAERIwjAeF3JCD8hnWYocoBcZukvSWliyNvL75Qa1am6X4QPfkgIIK0CYgYSAIixpGA8DtmC4ijA3cgjmUHwrvSVQ4I73vLPZ6ACBImIGIgCYgYRwLC70hA+A3rMAMBYV8lAsJu94GRBEQMJAER40hA+B2zBcTQwB2I49iB8K50lQNiaMk3d1zJ53ufTkB4BYvxBEQMJAER40hA+B1zBcRyR8UFxL+PJyC8K13lgHizy5tLN4zqvDx6sqR+xd+nS8/TDaY+5MUoOZ6AKAk2s6cTEDGQBESMIwHhdyQg/IZ1mKHKAdHot46kKyWlZEx3ony7+PKs7SQdKSl93ffIHgYnIILACYgYSAIixpGA8DtmC4gjA3cgfswOhHel6xIQIyRdLOmcbt5w+jrv3SR9xotRcjwBURKMHYggsJlMQ0DE+BIQfsdsAXFEYED8hIDwrnRdAiKdpkhflnVTN2/4S5LSl23N58UoOZ6AKAlGQASBERBZIQkIPy8B4Teswwx1CYjHJT1ZRES6aVTnI73+P0r6qKRVexicgAgC5xRGDCQ7EDGOBITfMVdALH943A7EqBPYgfCudF0CIt1lMl37MErSnySNk7S4pC0lLV98K2cKiZ58EBBB2gREDCQBEeNIQPgdCQi/YR1mqEtAJMs1JR1aXOuwpKQxku6TdJKkh3oBm4AIQicgYiAJiBhHAsLvmC0gDhsa9l0Yo07s+OQ/34XhWO46BYTjbWYZSkAEsRIQMZAERIwjAeF3zBoQCwV8G+db40VA+Ne5jgGRijH9809JE/0E5hkICDPdBwcSEDGQBESMIwHhdyQg/IZ1mKFOAbGXpKMlpdMX6ULKgZIelHRt8WVbv+hhcAIiCJyAiIEkIGIcCQi/Y66AWOHQoZozaAfihZM4heFd6boExI8knSzpNEm3SrpZUrq5VAqIH0pKN5Ra34tRcjwBURJsZk8nIGIgCYgYRwLC75gtIA4JDIiTCQjvStclIJ6VdKGkH0uaQ9K0hoBI94G4VNJiXoyS4wmIkmAERBDYTKYhIGJ8CQi/IwHhN6zDDHUJiPTdF5tL+ns3AfEFSTc0fE9GT7kTEEHS7EDEQBIQMY4EhN8xW0AcPFRzBZzCmPbWeL3wU3YgvCtdl4BIN5FKOxDpI5tddyAOL74L41NejJLjCYiSYOxABIGxA5EVkoDw8xIQfsM6zFCXgDhQ0jHF9Q7pttWvS1pP0qKSLpN0hKSzexicgAgCZwciBpIdiBhHAsLvmC0gDgrcgTiFHQjvStclINL7PENS+uKs9AmM2SX9p3jzKRz29UIYxhMQBrTuhhAQMZAERIwjAeF3zBYQBwYGxKkEhHel6xQQ6b1+RNIXi52HN4pPZDztRTCOJyCMcF2HERAxkAREjCMB4XckIPyGdZihDgHRT9JPi09ajKwQKgERtBgERAwkARHjSED4HXMFxIoHxO1APP8zdiC8K12HgEjv8R1JX5F0h/cNB44nIIIwCYgYSAIixpGA8DsSEH7DOsxQl4BIN45KN5BKN5OqyoOACFoJAiIGkoCIcSQg/I4EhN+wDjPUJSAGSbpc0jmSbpT0SnExZaNxuiaiJx8ERJA2AREDSUDEOBIQfsdsAbF/4CmM0ziF4V3pugRE5ycu0vtNn8Lo7pHuD9GTDwIiSJuAiIEkIGIcCQi/IwHhN6zDDHUJiN1awLy4hedEPoWACNIkIGIgCYgYRwLC75grID6yX9wOxHM/ZwfCu9JVD4jVJH2n+Pjmy5KulnSL900HjScggiAJiBhIAiLGkYDwO2YNiP4Lu1/gtAnjRUC4GVXlgEjfrvk3SXNJek3Sh4obSKWbSZ3rf+vuGQgIN+GMCQiIGEgCIsaRgPA7EhB+wzrMUOWASJ+6SNGwlaQXJfUvvg9jo+JGUr3tS0AErQABEQNJQMQ4EhB+x2wB8aOhmitqB+J0TmF4V7rKATFO0nclpe++6HysIOk5ScsXUeF9/57xBIRHr2EsAREDSUDEOBIQfsdcAbHSD+MC4tlfEBDela5yQKRPXqSPb97X8CY7v4lzbUn/8L5553gCwgnYOZyAiIEkIGIcCQi/IwHhN6zDDFUPiHUlNd6+moCow1FV8jUSECXBZvJ0AiLGkYDwO2YLiH0DdyDOYAfCu9JVD4h3G751s/O9LiCp65+ne0Ms1CLG9pJ2lbRWMSZ9GVf6ps8LZ3GPie6mZgeiRfBmTyMgmgm19vcERGtOzZ5FQDQTav73fTggVpF0pqTBkt6WdImkIyVNba7y/8/YRtK1kh6VtHqJcZV7apUD4uiSWse2+Px7JL0g6TpJr0raRNLBklKOtjpH+lEERIvgzZ5GQDQTau3vCYjWnJo9i4BoJtT873MFxMo/iNuBeObM0jsQixS/9NN/dJ4gaWlJp0m6TNI+zVU6njGvpMeK/zd9upCAaBGuKk9btPhYaOPrOU/SDpLSAdJ418tZvWYCImhFCYgYSAIixpGA8DtmC4h9AgPirNIBcZikIyQtJ6nzqxP2knR28WfpXkXNHumHpk8SPi9pHQKiGVc9/n7v4iBIHxVN21KtPAiIVpRaeA4B0QJSC08hIFpAauEpBEQLSE2e0kcDYlgRDukUROcj3dUqxcQeki5qwrKSpIeL0x/7ERD+46wqM6Qv6kpVmKKg1QcB0apUk+cREDGQBESMIwHhd8wWEN8P3IH4ZekdiHRrgQskHdpF6CVJl3bz510hbyhuP5D+gzXFBjsQ/kOt12dId7y8Q9IBkk6fxatJuxPpn87HgPQJkcHrHqx+87R6/Wavv9dKvgACImZZCIgYRwLC75grID76vbiAePrsjoAYKGlswzueICn9091jmqSjJJ3U5S8fkTRcUjqdMbPHlpLS9zV9rDiFTkD4D7NenyHtItwr6XFJmza5/uEYSf9zYScB4V9DAsJvmGYgIGIcCQi/Y40CouubTRfSp3/XRwZEv+Liy/QfqOkTHOlBQPgPs16dIZ27urP46OYGkt5q8mrYgci0XAREDCwBEeNIQPgdswXE3oE7EOeU3oFIpzDOl5Qupmx8NDuFkU55fEvSepKmFwPThZdrFtdDpNsSlPkYqH+Bgmao8sc4g95it9Okj9Kkb/VMV9OmRU0HQNkH10CUFZvJ8wmIGEgCIsaRgPA71igglpU0usV3nC6ifF3SkIbnp/PXbza5iDLtNuw2i5+RromowhdEtsjw36e1Y0DMWdzEI90IJO08pM/kWh4EhEWtmzEERAwkARHjSED4HbMGxIIBX+f99ng9PWMHokxApJ2Hw4sx4wulPYtf/uk/Rmf2Mc5086l0zVzjI+1KfFzS7pKemsVY/2JknKEdAyLd8+HbxUWT6cKXxkf6fo0pLXoTEC1CNXsaAdFMqLW/JyBac2r2LAKimVDzv88VEB/77lDNFRQQT51bOiA6bySVfuE33kgqfYqv8UZS6TRH2nFI/7E6swfXQDQ/jCr5jHQXyvRtnt09VizuUtnKCycgWlFq4TkERAtILTyFgGgBqYWnEBAtIDV5Sh8NiPSuV+3mVtbp5lKN1zB0nrKY1X+gExD+w6zWMxAQQctHQMRAEhAxjgSE3zFbQHwncAfiV6V3IPwwfWyGdjyFEbWEBESQJAERA0lAxDgSEH7HXAHx8b3iAuLJ8wgI70oTEHZBAsJu94GRBEQMJAER40hA+B0JCL9hHWYgIOyrREDY7QiIILvGaQiIGFQCwu+YLSC+HbgD8Wt2ILwrTUDYBQkIux0BEWRHQMRDEhB+UwLCb1iHGQgI+yoREHY7AiLIjoCIhyQg/KbZAmLPwB2I37AD4V1pAsIuSEDY7QiIIDsCIh6SgPCb5gqIVQID4gkCwr3QBISdkICw2xEQQXYERDwkAeE3JSD8hnWYgYCwrxIBYbcjIILsCIh4SALCb5otIL4VdwrjifM5heFdaQLCLkhA2O0IiCA7AiIekoDwm2YLiD2Gau6AW1lPfXu8nriAgPCuNAFhFyQg7HYERJAdAREPSUD4TQkIv2EdZiAg7KtEQNjtCIggOwIiHpKA8JtmC4jdA3cgLmQHwrvSBIRdkICw2xEQQXYERDwkAeE3JSD8hnWYgYCwrxIBYbcjIILsCIh4SALCb5o1IBZY2P0Cp74zXk+wA+F2JCDshASE3Y6ACLIjIOIhCQi/aa6AWPWbQzV3UEA8fhGnMLwrTUDYBQkIux0BEWRHQMRDEhB+UwLCb1iHGQgI+yoREHY7AiLIjoCIhyQg/KbZAmK3wB2Ii9mB8K40AWEXJCDsdgREkB0BEQ9JQPhNcwXEarvGBcRjlxAQ3pUmIOyCBITdjoAIsiMg4iEJCL8pAeE3rMMMBIR9lQgIux0BEWRHQMRDEhB+02wB8Y3AHYhL2YHwrjQBYRckIOx2BESQHQERD0lA+E0JCL9hHWYgIOyrREDY7QiIIDsCIh6SgPCb5gqIT+wStwPx6GXsQHhXmoCwCxIQdjsCIsiOgIiHJCD8ptkCYufAgLicgPCuNAFhFyQg7HYERJAdAREPSUD4TQkIv2EdZiAg7KtEQNjtCIggOwIiHpKA8JtmC4ivB+5A/JYdCO9KExB2QQLCbkdABNkREPGQBITfNFdArL5TXEA8cgUB4V1pAsIuSEDY7QiIIDsCIh6SgPCbEhB+wzrMQEDYV4mAsNsREEF2BEQ8JAHhN80aEPMHfBvnxPFiB8K/zgSE3ZCAsNsREEF2BEQ8JAHhNyUg/IZ1mIGAsK8SAWG3IyCC7AiIeEgCwm+aKyA+ueNRmjtoB+Jfvzs+vdFlJY32v+P2nIGAsK87AWG3IyCC7AiIeEgCwm+aLSB2CAyI3xMQ3pUmIOyCBITdjoAIsiMg4iEJCL8pAeE3rMMMBIR9lQgIux0BEWRHQMRDEhB+01wBscb2cTsQD1/JDoR3pQkIuyABYbcjIILsCIh4SALCb5otILYLDIirCAjvShMQdkECwm5HQATZERDxkASE35SA8BvWYQYCwr5KHQGx8TJ7qt+cC9pnYaSmj3oRhQCBY597IGAWpjj6I2uD4BTIFRCf2jZuB+KfV7MD4VxmERB2QQLCbveBkQREDCQBEeNIQPgdswXE1wID4hoCwrvSBIRdkICw2xEQQXaN0xAQMagEhN+RgPAb1mEGAsK+SgSE3Y6ACLIjIOIhCQi/aa6AWPOrcTsQD/2BHQjvShMQdkECwm5HQATZERDxkASE35SA8BvWYQYCwr5KBITdjoAIsiMg4iEJCL9ptoAYErgDcS07EN6VJiDsggSE3Y6ACLIjIOIhCQi/ac6AmGc+/7dxTnl3vB4iINwLTUDYCQkIux0BEWRHQMRDEhB+UwLCb1iHGQgI+yoREHY7AiLIjoCIhyQg/KbZAmKbIxW2A3Hdj9Mb5ds4HctNQNjxCAi7HQERZEdAxEMSEH7TXAHx6a3jAuIffyQgvCtNQNgFCQi7HQERZEdAxEMSEH5TAsJvWIcZCAj7KhEQdjsCIsiOgIiHJCD8ptkCYqvAHYjr2YHwrjQBYRckIOx2BESQHQERD0lA+E0JCL9hHWYgIOyrREDY7QiIIDsCIh6SgPCb5gqItbaI24F48AZ2ILwrTUDYBQkIux0BEWRHQMRDEhB+02wB8ZXAgPgzAeFdaQLCLkhA2O0IiCA7AiIekoDwmxIQfsM6zEBA2FeJgLDbERBBdgREPCQB4TfNFRBrbx63A/HAjexAeFeagLALEhB2OwIiyI6AiIckIPym2QLiy0eE3Ujqgb/8JL1RbiTlWG4Cwo5HQNjtCIggOwIiHpKA8JsSEH7DOsxAQNhXiYCw2xEQQXYERDwkAeE3zRUQ63wpbgfi/pvYgfCuNAFhFyQg7HYERJAdAREPSUD4TQkIv2EdZiAg7KtEQNjtCIggOwIiHpKA8JtmDYh5A77Oe9J4sQPhX2cCwm5IQNjtCIggOwIiHpKA8JvmCoiBmx2heYICYuRfOYXhXWkCwi5IQNjtCIggOwIiHpKA8JsSEH7DOsxAQNhXiYCw2xEQQXYERDwkAeE3zRYQmx4etwNx8wnpjfIxTsdyExB2PALCbkdABNkREPGQBITfNFdAfGaTuIC47xYCwrvSBIRdkICw2xEQQXYERDwkAeE3JSD8hnWYgYCwrxIBYbcjIILsCIh4SALCb5otIL4YuAPxN3YgvCtNQNgFCQi7HQERZEdAxEMSEH5TAsJvWIcZCAj7KhEQdjsCIsiOgIiHJCD8prkCYt0vxO1A3HsrOxDelSYg7IIEhN2OgAiyIyDiIQkIv2m2gPjcYWGfwrj3thPTG+VTGI7lJiDseASE3Y6ACLIjIOIhCQi/KQHhN6zDDASEfZUICLsdARFkR0DEQxIQftNsAbFx4A7E7exAeFeagLALEhB2OwIiyI6AiIckIPymuQJiUAqIfgHfhTF5vEYQEO6FJiDshASE3Y6ACLIjIOIhCQi/KQHhN6zDDO0YEJtLOkTSapL6S3pJ0nWSjpX0VolFIyBKYM3qqdNHvRg0U3tPc+xzD7Q3QNC7JyD8kNkCYqO0A7GQ+wVOmfyWRtxhOoWxiqQzJQ2W9LakSyQdKWnqLF5U+j1zoKSvSPqopEmS7pN0uKR/ud9ML07QjgGxi6Q1JN0r6XVJq0s6RtKDkjYtsRYERAksAiIIaxbTEBAxxgSE37GPBsQikh6V9LSk9BnQpSWdJukySfvMQi39jrlF0vmShknqVwTF2pLWkfS4X7x3ZmjHgOhO+tuSzisOiJdbXAoCokWoZk9jB6KZUGt/T0C05tTsWQREM6Hmf58tIDY8TP0CdiAmpx2IYaV3IA6TdISk5SS9USjsJens4s9m9rtjfknvS3q3QW4BSaMk/VbSD5qLVvMZBMSMdfmqpGskrSjphRaXioBoEarZ0wiIZkKt/T0B0ZpTs2cREM2Emv99toDYIDAg7iwdEGn3IIXDNg0C6YrO9Gd7SLqoucwHnpF2wUdL+lrJcZV5ejsHxByS5iquhbigqMGtS6wMAVECa1ZPJSBiIAmIGEcCwu/YRwNinKT0u+LQLkLpOrpLu/nzWUGm8Ejjfl5cQ+FH74UZ2jkgUvmlc1jpcZOkbSVNnMUapAth0j+djwGSRm68zJ7qN+eCvbB0fedHEhAxa0lAxDgSEH7HXAGx3vqHhp3CuOeuk9IbHShpbMM7niAp/dPdY5qkoyR1DGx4PCJpuKR0OqPVRzpl/nVJ6aLM9Luolo92Doh0IWU6N/WJogCfk7SJpPdmspLpQsuju/4dAeE/7gkIv2GagYCIcSQg/I7ZAmJwYEAM79oBHe87fRov/bs+Z0DsXuxkfFPSxX7t3puhnQOiUf1Tkh6StJ2kq2eyHOxAZDpOCYgYWAIixpGA8DvWKCDK7ECkUxjpkxTpYsrGR5lTGF+WdL2kdAHGUL90785AQMzwTw5TigXtNku7WSaugQg6dgmIGEgCIsaRgPA75gqIwesdEnYKY/g9J6c3WubLtNJFlOmj/0MahNJNKd5s8SLKQZJulXSFpD39yr0/AwExYw3Swt4jaQdJV7a4LAREi1DNnkZANBNq7e8JiNacmj2LgGgm1Pzv+2hApJ2HdPOnFB3jC4UUAuc2+Rhnemq6ceGdxbUSKUCmN1es/jPaMSD+IOl+SQ8XdwRLpy8OkpS2p9J21qzuKNa4ogRE0PFNQMRAEhAxjgSE3zFbQAwK3IEYUXoHovNGUk91uZHU5V1uJJVOc+wmac5CcnFJ6Tax6fftrl3uB5Eu2HzML947M7RjQKSP4KSdhpUkzV7c9yFFxamzuPq2u9UhIIKOWQIiBpKAiHEkIPyO+QLiYPWbx38r68lT3tLwET9Nb7TMKYz0/FW7uZV1urlU4394pvtBpIDo/P26saTbZqJ6h6T097V8tGNARC0UAREkSUDEQBIQMY4EhN+xDweEH6cPzUBA2BeTgLDbfWAkAREDSUDEOBIQfsdcAfHZdeN2IO6+17QD4cfpQzMQEPbFJCDsdgREkF3jNAREDCoB4XfMFhCfOSjsFMbd951iOYXhx+lDMxAQ9sUkIOx2BESQHQERD0lA+E0JCL9hHWYgIOyrREDY7QiIIDsCIh6SgPCb5gqI9deJ24G46352ILwrTUDYBQkIux0BEWRHQMRDEhB+UwLCb1iHGQgI+yoREHY7AiLIjoCIhyQg/KbZAmLtA8OugbjrgfTJ/dIf4/Tj9KEZCAj7YhIQdjsCIsiOgIiHJCD8ptkCYq3AgHiQgPCuNAFhFyQg7HYERJAdAREPSUD4TQkIv2EdZiAg7KtEQNjtCIggOwIiHpKA8JvmCogNPn1A2CmMO//xM05hOJeagLADEhB2OwIiyI6AiIckIPym2QJizf3jAuKh0wgI51ITEHZAAsJuR0AE2REQC01AogAADWtJREFU8ZAEhN+UgPAb1mEGAsK+SgSE3Y6ACLIjIOIhCQi/abaA+NT+6jd3wJdpTX1Ld/6THQjvShMQdkECwm5HQATZERDxkASE35SA8BvWYQYCwr5KBITdjoAIsiMg4iEJCL9proDYcI39wnYghj388/RGy36dtx+nD81AQNgXk4Cw2xEQQXYERDwkAeE3zRYQn0wB0d/9AidPnaBh/yIgvJAEhF2QgLDbERBBdgREPCQB4TclIPyGdZiBgLCvEgFhtyMgguwIiHhIAsJvmi0gVv9R3A7EI6dzCsO51ASEHZCAsNsREEF2BEQ8JAHhN80WEKsFBsRjBIR3pQkIuyABYbcjIILsCIh4SALCb0pA+A3rMAMBYV8lAsJuR0AE2REQ8ZAEhN80V0BstOoPw05h3PH4LziF4VxqAsIOSEDY7QiIIDsCIh6SgPCbEhB+wzrMQEDYV4mAsNsREEF2BEQ8JAHhN80WEKvsG7cD8cQZ7EA4l5qAsAMSEHY7AiLIjoCIhyQg/Kb5AuIH6jdXwH0gpk3QHU+cSUA4l5qAsAMSEHY7AiLIjoCIhyQg/KYEhN+wDjMQEPZVIiDsdgREkB0BEQ9JQPhNswXEx/eJ24F48ix2IJxLTUDYAQkIux0BEWRHQMRDEhB+02wB8dHAgHiagPCuNAFhFyQg7HYERJAdAREPSUD4TQkIv2EdZiAg7KtEQNjtCIggOwIiHpKA8JvmCoiNV/5+2CmM25/5JacwnEtNQNgBCQi7HQERZEdAxEMSEH5TAsJvWIcZCAj7KhEQdjsCIsiOgIiHJCD8ptkCYqXvxe1APHs2OxDOpSYg7IAEhN2OgAiyIyDiIQkIv2m2gFhx77iAeP4cAsK51ASEHZCAsNsREEF2BEQ8JAHhNyUg/IZ1mIGAsK8SAWG3IyCC7AiIeEgCwm+aLSBWSDsQC7pf4ORpb+v2F9iB8EISEHbB5SW9MGjATuo35/z2WRip6aNfRiFA4IDh/wqYhSl+NviTIDgFpmiSRuq2NMsKkkY5p0vDZ/wH2wrfVb85AwJiegqIczmF4VwYAsIOuI6kkfbhjEQAAQT6vMBASfcHvEsCIgAxegoCwi46j6T0nyqvSnrPPk3WkQOKyEn/Ix6b9Sf17clxjFlfHNvHcQ5Ji0lK22JTAt72jIBY/jtxOxCjfsUOhHNhCAgnYMWHd/yPTtKykkZX/LVW+eXhGLM6OOJoFSAgrHIZxxEQGXErMDX/wo5ZBBxxjBGImaUdj8cZAbHsXnE7EC+exw6E83gkIJyAFR/ejv+iybEkOMao4oijVSD0U2+T00WUo39DQFhXoxhHQDgBKz68v6T9JZ0maULFX2uVXx6OMauDI45WAQLCKpdxHAGREZepEWhR4P0Wnre7pItaeB5PQaAvCswIiKW/FXcK46Xz2YFwHikEhBOQ4QgECAzqMsc9ks6U9NuGP3+2+MRPwI9jCgRqJzAjIJbcIy4gxlxAQDgPAwLCCchwBDIIpB2JgySd2sLc80qa1MLzeAoCdRYgICq4egREBReFl9T2AjMLiC9J+oukzSTtLemLkv4qaZciIn4g6awGvUMlHSOpX8OffVjSCZK2lrRw8Tn9g6UZtw3kgUBFBWYExIDd43Ygxl7IDoRzsQkIJyDDEcgg0CwgXpJ0saS/S5om6b4WAyKFxL2S0sWMx0oaIyldWzFE0hqSnszwXpgSgQgBAiJCMXgOAiIYlOkQCBBoFhCnS9qv4eekMEinMZrtQKRdizT2E5KeKcanfwc8WOxE7Brw2pkCgRwC/w2IORZwzz/5vXd0OzsQbkcCwk3IBAiECzQLiE0k/c0QENdKWkLShl1e8YmStpC0avg7YUIEYgRmBMQS31S/qIB4peNDTdyl17E+BIQDj6EIZBJoFhDpdEPjV2+2ugNxp6T1Z/KaJ0ry/6ddJhCmbXsBAqKChwABUcFF4SW1vUCzgEhf4vZIg1L64qKpxSc30k3DOh8nS/phw0WUf5S0VHEBZlfk/xSnMtoeH4BKCswIiMV2jduBePUSdiCcS01AOAEZjkAGgbIBkV5C+rK09AmNbxevJ/1v+wFJqzUERLpG4jhJH5c0LsPrZkoEcgnMCIhFvxEXEK9dSkA4V4uAcAIyHIEMApaASBdH7iXpQEnPSfqmpPWKax46P8aZ7hkxQtJcxe3N04WUi0haS1L6mUMzvBemRCBCgICIUAyeg4AIBmU6BAIELAGxoKRfFhdDpo92nl2c1ji6y30g0r0f0kc400c3B0h6rdipSPePSPeU4IFAFQVmBMSHd4nbgXj9MnYgnCtNQDgBGY4AAgggkF2AgMhOXP4HEBDlzRiBAAIIINCzAjMCYpGd43Yg3rycHQjnGhIQTkCGI4AAAghkF+gIiI0W3iksIO4YfwUB4Vw2AsIJyHAEEEAAgewCBER24vI/gIAob8YIBBBAAIGeFZgREAvtpH6zz+/+yZP/M1F3vMUOhBeSgPAKMh4BBBBAILfAjIDov2NcQEz4HacwnKtGQDgBGY4AAgggkF2AgMhOXP4HEBDlzRiBAAIIINCzAjMCYoHt43Yg3rmSHQjnGhIQTkCGI4AAAghkFyAgshOX/wEERHkzRiCAAAII9KzAjICYf7u4HYiJV7ED4VxDAsIJyHAEEEAAgewCHQGx4bxfCwuIYZOuISCcy0ZAOAEZjgACCCCQXYCAyE5c/gcQEOXNGIEAAggg0LMCMwKi31fjdiAm/4EdCOcaEhBOQIYjgAACCGQXmBEQ8wxRv9kCbiT1/kQNm3ItAeFcNgLCCchwBBBAAIHsAgREduLyP4CAKG/GCAQQQACBnhWYERBzb6N+s83n/smT339Xw6Zexw6EU5KAcAIyHAEEEEAgu0BVAmIVSWdKGizpbUmXSDpS0tQWBL4l6RBJy0l6UtIRkm5oYVxln0JAVHZpeGEIIIAAAoVAR0BsMOfWYTsQd07/Y9kdiEUkPSrpaUknSFpa0mmSLpO0T5OV2lHSbyX9RNLfJe0gKQXFBpJG1HWVCYi6rhyvGwEEEGgfgRkBMceWcQHx3p/KBsRhxa5B2kF4o6DfS9LZxa7Cy7NYjrTj8ICkrzc8Z7ik8ZI2r+syEhB1XTleNwIIINA+AlUIiGFFOGzTwL5w8Wd7SLpoJsvxEUnPShoiqePCi+Kxr6RTJPWXNKWOS0lA1HHVeM0IIIBAewl0BMT6s20RtgNx1/sdlx8sK2l0i5TjJF0g6dAuz39J0qXd/Hnn09IOw58lrSrpiYaxm0i6uZs/b/Hl9P7TCIjeXwNeAQIIIIDArAU6AmKgPq951M9tNUWTNbLjUgQNlDS2YcIJktI/3T2mSTpK0kld/vIRSel0RDqd0d1j5+I6iSW7/Kx1JI2U9NlivPt99fQEBERPi/PzEEAAAQTKCqRTBek0wIfKDpzF8ydJmrfL3x8r6RgCojVlAqI1J56FAAIIINC7AikiFgh8Cen33/td5pvVDkQ6hXG+pHQxZeOj1VMY6SOg6WLKzgenMAIXk6kQQAABBBCoqkC6iPL14mLIzte4kKQ3JbVyEWW6+LLjs6PF4weSTpW0YIv3kaicCzsQlVsSXhACCCCAQAUF0s7D4cWFl+njl+mxp6RzW/wYZ7reYZeG93VXcb0FH+Os4GLzkhBAAAEEEIgS6LyR1FNdbiR1eZcbSaXTHLtJmrPhB+8kKT3veEm3FTeSSvGxoaR7ol5gT8/DDkRPi/PzEEAAAQTqKpA+itn1VtbpltSNt7JO94NIAdH192u682T6CGjnrazTbga3sq7rkcDrRgABBBBAAAGbADsQNjdGIYAAAggg0NYCBERbLz9vHgEEEEAAAZsAAWFzYxQCCCCAAAJtLUBAtPXy8+YRQAABBBCwCRAQNjdGIYAAAggg0NYCBERbLz9vHgEEEEAAAZsAAWFzYxQCCCCAAAJtLUBAtPXy8+YRQAABBBCwCRAQNjdGIYAAAggg0NYCBERbLz9vHgEEEEAAAZsAAWFzYxQCCCCAAAJtLUBAtPXy8+YRQAABBBCwCRAQNjdGIYAAAggg0NYCBERbLz9vHgEEEEAAAZsAAWFzYxQCCCCAAAJtLUBAtPXy8+YRQAABBBCwCRAQNjdGIYAAAggg0NYCBERbLz9vHgEEEEAAAZsAAWFzYxQCCCCAAAJtLUBAtPXy8+YRQAABBBCwCRAQNjdGIYAAAggg0NYCBERbLz9vHgEEEEAAAZsAAWFzYxQCCCCAAAJtLUBAtPXy8+YRQAABBBCwCRAQNjdGIYAAAggg0NYCBERbLz9vHgEEEEAAAZsAAWFzYxQCCCCAAAJtLUBAtPXy8+YRQAABBBCwCRAQNjdGIYAAAggg0NYCBERbLz9vHgEEEEAAAZsAAWFzYxQCCCCAAAJtLUBAtPXy8+YRQAABBBCwCRAQNjdGIYAAAggg0NYCBERbLz9vHgEEEEAAAZsAAWFzYxQCCCCAAAJtLUBAtPXy8+YRQAABBBCwCRAQNjdGIYAAAggg0NYCBERbLz9vHgEEEEAAAZsAAWFzYxQCCCCAAAJtLUBAtPXy8+YRQAABBBCwCRAQNjdGIYAAAggg0NYC/wef+GXiZVgZbwAAAABJRU5ErkJggg==\" width=\"479.9999895962804\">"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "#plt.clf()\n",
+    "plt.matshow(confuse)\n",
+    "plt.colorbar()\n",
+    "plt.xlabel('True')\n",
+    "plt.ylabel('Predicted')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -116,6 +116,61 @@ def calc_obj_stats(simz_tab, objtype):
     return stat_dict
 
 
+def spectype_confusion(simz_tab, zb_tab=None):
+    """ Generate a Confusion Matrix for spectral types
+    See the Confusion_matrix_spectypes Notebook in docs/nb for an example
+
+    Parameters
+    ----------
+    simz_tab : Table
+       Truth table;  may be input from truth.fits
+    zb_tab : Table (optional)
+       zcatalog/zbest table; may be input from zcatalog-mini.fits
+       If provided, used to match the simz_tab to the zbest quantities
+
+    Returns
+    -------
+    results : dict
+      Nested dict.
+      First key is the TRUESPECTYPE
+      Second key is the SPECTYPE
+      e.g.  results['QSO']['QSO'] reports the number of True QSO classified as QSO
+            results['QSO']['Galaxy'] reports the number of True QSO classified as Galaxy
+    """
+
+    # Process simz_tab as need be
+    if zb_tab is not None:
+        match_truth_z(simz_tab, zb_tab, mini_read=True)
+    # Cut down to those processed with the Redshift fitter
+    measured_z = simz_tab['ZWARN'].mask == False
+    cut_simz = simz_tab[measured_z]
+
+    # Strip those columns
+    strip_ttypes = np.char.rstrip(cut_simz['TRUESPECTYPE'])
+    strip_stypes = np.char.rstrip(cut_simz['SPECTYPE'])
+
+    # All TRUE, SPEC types
+    ttypes = np.unique(strip_ttypes)
+    stypes = np.unique(strip_stypes)
+
+    # Init
+    results = {}
+    for ttype in ttypes:
+        results[ttype] = {}
+
+    # Fill
+    for ttype in ttypes:
+        itrue = strip_ttypes == ttype
+        # Init correct answer in case there are none
+        results[ttype][ttype] = 0
+        # import pdb; pdb.set_trace()
+        for stype in stypes:
+            results[ttype][stype] = np.sum(strip_stypes[itrue] == stype)
+
+    # Return
+    return results
+
+
 def find_zbest_files(fibermap_data):
 
     from desimodel.footprint import radec2pix

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -123,19 +123,21 @@ def spectype_confusion(simz_tab, zb_tab=None):
     Parameters
     ----------
     simz_tab : Table
-       Truth table;  may be input from truth.fits
+      Truth table;  may be input from truth.fits
     zb_tab : Table (optional)
-       zcatalog/zbest table; may be input from zcatalog-mini.fits
-       If provided, used to match the simz_tab to the zbest quantities
+      zcatalog/zbest table; may be input from zcatalog-mini.fits
+      If provided, used to match the simz_tab to the zbest quantities
 
     Returns
     -------
+    simz_tab : astropy.Table
+      Merged table of simpsec data
     results : dict
       Nested dict.
       First key is the TRUESPECTYPE
       Second key is the SPECTYPE
       e.g.  results['QSO']['QSO'] reports the number of True QSO classified as QSO
-            results['QSO']['Galaxy'] reports the number of True QSO classified as Galaxy
+      results['QSO']['Galaxy'] reports the number of True QSO classified as Galaxy
     """
 
     # Process simz_tab as need be


### PR DESCRIPTION
Compares truth vs type recovered from RedRock.

Generates a dict holding the matrix.

See https://github.com/desihub/desisim/blob/confuse_me/doc/nb/Confusion_matrix_spectypes.ipynb
for usage.

Have tested on 18.3 mini-test with:

```
from astropy.table import Table
from desisim.spec_qa import redshifts as dsqa_z

simz_tab = Table.read('truth.fits')
zcat = Table.read('zcatalog-mini.fits')

results = dsqa_z.spectype_confusion(simz_tab, zb_tab=zcat)
```

Addresses Issue #348 