### PR TITLE
add transmission of metals from LYA transmission

### DIFF
--- a/py/desisim/lya_spectra.py
+++ b/py/desisim/lya_spectra.py
@@ -163,16 +163,11 @@ def apply_metals_transmission(qso_wave,qso_flux,trans_wave,trans,metals) :
 
     output_flux = qso_flux.copy()
     for q in range(qso_flux.shape[0]) :
-
-        metTrans = np.ones(trans_wave.size)
-
         for m in metals:
             mtau = absorber_IGM[m]['COEF']*tau[q,:]
             mtrans_wave = (zPix[q,:]+1.)*absorber_IGM[m]['LRF']
-            mtau = np.interp(trans_wave,mtrans_wave,mtau,left=0.,right=0.)
-            metTrans *= np.exp(-mtau)
+            output_flux[q, :] *= np.interp(qso_wave,mtrans_wave,np.exp(-mtau),left=1.,right=1.)
 
-        output_flux[q, :] *= np.interp(qso_wave,trans_wave,metTrans,left=0,right=1)
     return output_flux
 
 def get_spectra(lyafile, nqso=None, wave=None, templateid=None, normfilter='sdss2010-g',

--- a/py/desisim/lya_spectra.py
+++ b/py/desisim/lya_spectra.py
@@ -11,6 +11,45 @@ import numpy as np
 from desisim.dla import insert_dlas
 from desiutil.log import get_logger
 
+absorber_IGM = {
+    'Halpha'      : { 'LRF':6562.8, 'COEF':None },
+    'Hbeta'       : { 'LRF':4862.68, 'COEF':None },
+    'MgI(2853)'   : { 'LRF':2852.96, 'COEF':None },
+    'MgII(2804)'  : { 'LRF':2803.5324, 'COEF':None },
+    'MgII(2796)'  : { 'LRF':2796.3511, 'COEF':None },
+    'FeII(2600)'  : { 'LRF':2600.1724835, 'COEF':None },
+    'FeII(2587)'  : { 'LRF':2586.6495659, 'COEF':None },
+    'MnII(2577)'  : { 'LRF':2576.877, 'COEF':None },
+    'FeII(2383)'  : { 'LRF':2382.7641781, 'COEF':None },
+    'FeII(2374)'  : { 'LRF':2374.4603294, 'COEF':None },
+    'FeII(2344)'  : { 'LRF':2344.2129601, 'COEF':None },
+    'AlIII(1863)' : { 'LRF':1862.79113, 'COEF':None },
+    'AlIII(1855)' : { 'LRF':1854.71829, 'COEF':None },
+    'AlII(1671)'  : { 'LRF':1670.7886, 'COEF':None },
+    'FeII(1608)'  : { 'LRF':1608.4511, 'COEF':None },
+    'CIV(1551)'   : { 'LRF':1550.77845, 'COEF':None },
+    'CIV(eff)'    : { 'LRF':1549.06, 'COEF':None },
+    'CIV(1548)'   : { 'LRF':1548.2049, 'COEF':None },
+    'SiII(1527)'  : { 'LRF':1526.70698, 'COEF':None },
+    'SiIV(1403)'  : { 'LRF':1402.77291, 'COEF':None },
+    'SiIV(1394)'  : { 'LRF':1393.76018, 'COEF':None },
+    'CII(1335)'   : { 'LRF':1334.5323, 'COEF':None },
+    'SiII(1304)'  : { 'LRF':1304.3702, 'COEF':None },
+    'OI(1302)'    : { 'LRF':1302.1685, 'COEF':None },
+    'SiII(1260)'  : { 'LRF':1260.4221, 'COEF':0.002 },
+    'NV(1243)'    : { 'LRF':1242.804, 'COEF':None },
+    'NV(1239)'    : { 'LRF':1238.821, 'COEF':None },
+    'LYA'         : { 'LRF':1215.67, 'COEF':1. },
+    'SiIII(1207)' : { 'LRF':1206.500, 'COEF':0.005 },
+    'NI(1200)'    : { 'LRF':1200., 'COEF':None },
+    'SiII(1193)'  : { 'LRF':1193.2897, 'COEF':0.002 },
+    'SiII(1190)'  : { 'LRF':1190.4158, 'COEF':0.002 },
+    'OI(1039)'    : { 'LRF':1039.230, 'COEF':None },
+    'OVI(1038)'   : { 'LRF':1037.613, 'COEF':None },
+    'OVI(1032)'   : { 'LRF':1031.912, 'COEF':None },
+    'LYB'         : { 'LRF':1025.72, 'COEF':None },
+}
+
 def read_lya_skewers(lyafile,indices=None,dla_=False) :
     '''
     Reads Lyman alpha transmission skewers (from CoLoRe, format v2.x.y)
@@ -96,7 +135,45 @@ def apply_lya_transmission(qso_wave,qso_flux,trans_wave,trans) :
     for q in range(qso_flux.shape[0]) :
         output_flux[q, :] *= np.interp(qso_wave,trans_wave,trans[q, :],left=0,right=1)
     return output_flux
+def apply_metals_transmission(qso_wave,qso_flux,trans_wave,trans,metals) :
+    '''
+    Apply metal transmission to input flux, interpolating if needed.
+    The input transmission should be only due to lya, if not has no meaning
 
+    Args:
+        qso_wave: 1D[nwave] array of QSO wavelengths
+        qso_flux: 2D[nqso, nwave] array of fluxes
+        trans_wave: 1D[ntranswave ] array of lya transmission wavelength samples
+        trans: 2D[nqso, ntranswave] transmissions [0-1]
+        metals: list of metal names to use
+
+    Returns:
+        output_flux[nqso, nwave]
+
+    '''
+    if qso_flux.shape[0] != trans.shape[0] :
+        raise(ValueError("not same number of qso {} {}".format(qso_flux.shape[0],trans.shape[0])))
+
+    zPix = trans_wave*np.ones(qso_flux.shape[0])[:,None]/absorber_IGM['LYA']['LRF']-1.
+
+    tau = np.zeros(zPix.shape)
+    w = trans>1.e-100
+    tau[w] = -np.log(trans[w])
+    tau[~w] = -np.log(1.e-100)
+
+    output_flux = qso_flux.copy()
+    for q in range(qso_flux.shape[0]) :
+
+        metTrans = np.ones(trans_wave.size)
+
+        for m in metals:
+            mtau = absorber_IGM[m]['COEF']*tau[q,:]
+            mtrans_wave = (zPix[q,:]+1.)*absorber_IGM[m]['LRF']
+            mtau = np.interp(trans_wave,mtrans_wave,mtau,left=0.,right=0.)
+            metTrans *= np.exp(-mtau)
+
+        output_flux[q, :] *= np.interp(qso_wave,trans_wave,metTrans,left=0,right=1)
+    return output_flux
 
 def get_spectra(lyafile, nqso=None, wave=None, templateid=None, normfilter='sdss2010-g',
                 seed=None, rand=None, qso=None, add_dlas=False, debug=False, nocolorcuts=False):

--- a/py/desisim/lya_spectra.py
+++ b/py/desisim/lya_spectra.py
@@ -171,12 +171,12 @@ def apply_metals_transmission(qso_wave,qso_flux,trans_wave,trans,metals) :
             lstMetals += m+', '
         for m in np.array(metals)[~np.in1d(metals,[mm for mm in absorber_IGM.keys()])]:
             nolstMetals += m+', '
-        raise Exception("Input metals {} are not in the list, available metals are {}".format(nolstMetals,lstMetals)) from e
+        raise Exception("Input metals {} are not in the list, available metals are {}".format(nolstMetals[:-2],lstMetals[:-2])) from e
     except TypeError as e:
         lstMetals = ''
         for m in [ m for m in metals if absorber_IGM[m]['COEF'] is None ]:
             lstMetals += m+', '
-        raise Exception("Input metals {} have no values for COEF".format(lstMetals)) from e
+        raise Exception("Input metals {} have no values for COEF".format(lstMetals[:-2])) from e
 
     output_flux = qso_flux.copy()
     for q in range(qso_flux.shape[0]):

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -15,7 +15,7 @@ from desispec.io.fibermap import read_fibermap
 from desisim.simexp import reference_conditions
 from desisim.templates import SIMQSO
 from desisim.scripts.quickspectra import sim_spectra
-from desisim.lya_spectra import read_lya_skewers , apply_lya_transmission
+from desisim.lya_spectra import read_lya_skewers , apply_lya_transmission, apply_metals_transmission
 from desisim.dla import dla_spec
 from desispec.interpolation import resample_flux
 from desimodel.io import load_pixweight

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -258,7 +258,9 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
     tmp_qso_flux = apply_lya_transmission(tmp_qso_wave,tmp_qso_flux,trans_wave,transmission)
 
     if args.metals is not None:
-        log.info("Apply metals")
+        lstMetals = ''
+        for m in args.metals: lstMetals += m+', '
+        log.info("Apply metals: {}".format(lstMetals))
         tmp_qso_flux = apply_metals_transmission(tmp_qso_wave,tmp_qso_flux,trans_wave,transmission,args.metals)
 
 

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -260,7 +260,7 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
     if args.metals is not None:
         lstMetals = ''
         for m in args.metals: lstMetals += m+', '
-        log.info("Apply metals: {}".format(lstMetals))
+        log.info("Apply metals: {}".format(lstMetals[:-2]))
         tmp_qso_flux = apply_metals_transmission(tmp_qso_wave,tmp_qso_flux,trans_wave,transmission,args.metals)
 
 

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -57,6 +57,7 @@ def parse(options=None):
     parser.add_argument('--target-selection', action = "store_true" ,help="apply QSO target selection cuts to the simulated quasars")
     parser.add_argument('--mags', action = "store_true" ,help="compute and write the QSO mags in the fibermap")
     parser.add_argument('--desi-footprint', action = "store_true" ,help="select QSOs in DESI footprint")
+    parser.add_argument('--metals', type=str, default=None, required=False, help = 'list of metal to get the transmission from', nargs='*')
 
     #- Optional arguments to include dla
 
@@ -256,6 +257,9 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
     log.info("Apply lya")
     tmp_qso_flux = apply_lya_transmission(tmp_qso_wave,tmp_qso_flux,trans_wave,transmission)
 
+    if args.metals is not None:
+        log.info("Apply metals")
+        tmp_qso_flux = apply_metals_transmission(tmp_qso_wave,tmp_qso_flux,trans_wave,transmission,args.metals)
 
 
     bbflux=None


### PR DESCRIPTION
Add transmission from metals given the transmission from Lya.
`--metals SiII(1260) SiIII(1207) SiII(1193) SiII(1190) `?
To get the parameter for SiII(1260) SiIII(1207) SiII(1193) SiII(1190) I compared to the data.
Do we want to get the parameter for all the other lines CIV..., do we want to make a deeper study of the values of the parameters?
Such a study could take more time.

Here is a comparison of the 1d-correlation for: data, "noiseless+Transmission+Lya" and "noiseless+Transmission+Lya+Metals"
![x1d](https://user-images.githubusercontent.com/3166436/41069372-d326b55c-69aa-11e8-95c5-bf8b8a803b5c.png)

The unique small issue is that if setting something like SiII(1260) (wavelength>1215.67), because of the wavelength difference between Lya and this line, a part of the transmission at small wavelength is exactly 1.
@ngbusca did you notice that when doing the mockExpander? What solution did you use.

Here is an example of the metal transmission, you can see that it is exactly 1 for small wavelength.
![spec_siii1260](https://user-images.githubusercontent.com/3166436/41069669-2e7decee-69ac-11e8-9290-52c719ab4c15.png)
