### PR TITLE
add restframe option to SIMQSO

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,6 @@ desisim change log
 0.28.0 (unreleased)
 -------------------
 
-* Add BALs to QSO spectra outside of desisim.templates (`PR #370`_).
 * Add BALs to templates.QSO class (`PR #321`_).
 * Enable redshift QA using input summary catalogs of truth and redshifts
   (`PR #349`_).
@@ -17,6 +16,8 @@ desisim change log
 * Update QA to use qaprod_dir
 * Fix newexp-mock wrapper when first expid != 0 (`PR #361`_).
 * newexp-mock options for production running (`PR #363`_).
+* Add BALs to QSO spectra outside of desisim.templates (`PR #370`_).
+* Add rest-frame option to templates.SIMQSO (`PR #377`_).
 
 .. _`PR #321`: https://github.com/desihub/desisim/pull/321
 .. _`PR #349`: https://github.com/desihub/desisim/pull/349
@@ -30,6 +31,7 @@ desisim change log
 .. _`PR #361`: https://github.com/desihub/desisim/pull/361
 .. _`PR #363`: https://github.com/desihub/desisim/pull/363
 .. _`PR #370`: https://github.com/desihub/desisim/pull/370
+.. _`PR #377`: https://github.com/desihub/desisim/pull/377
 
 0.27.0 (2018-03-29)
 -------------------


### PR DESCRIPTION
Simple PR to address request #324.  @londumas I haven't tested this extensively, so please make sure Lyman-alpha and other lines are where they should be!

Note that for issues of speed (i.e., not having to resample) and because of the way `desisim.templates` uniquely interfaces with `simqso` (i.e., uniquely, compared to the other templates which we build in-house) you have to specify the `restframe` option in the class constructor itself, e.g.,

```
from desisim.templates import SIMQSO
qso = SIMQSO(restframe=True)
flux, wave, meta = qso.make_templates(5, seed=1)
```

Finally note that the output (rest-frame) wavelength vector is hard-coded to 900-60000 A at a resolution of 8000, but this can be changed easily.