### PR TITLE
raw data now under NIGHT/EXPID/ not just NIGHT/

### DIFF
--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -52,7 +52,7 @@ def findfile(filetype, night, expid, camera=None, outdir=None, mkdir=True):
 
     #- outdir default = $DESI_SPECTRO_SIM/$PIXPROD/{night}/
     if outdir is None:
-        outdir = simdir(night)
+        outdir = simdir(night, expid)
 
     #- Definition of where files go
     location = dict(
@@ -1000,12 +1000,13 @@ def write_templates(outfile, flux, wave, meta):
 #-------------------------------------------------------------------------
 #- Utility functions
 
-def simdir(night='', mkdir=False):
+def simdir(night='', expid=0, mkdir=False):
     """
     Return $DESI_SPECTRO_SIM/$PIXPROD/{night}
     If mkdir is True, create directory if needed
     """
-    dirname = os.path.join(os.getenv('DESI_SPECTRO_SIM'), os.getenv('PIXPROD'), str(night))
+    dirname = os.path.join(os.getenv('DESI_SPECTRO_SIM'), os.getenv('PIXPROD'),
+         str(night), '{:08d}'.format(expid))
     if mkdir and not os.path.exists(dirname):
         os.makedirs(dirname)
 

--- a/py/desisim/scripts/pixsim.py
+++ b/py/desisim/scripts/pixsim.py
@@ -45,9 +45,9 @@ def expand_args(args):
         args.rawfile = os.path.join(os.path.dirname(args.simspec), rawfile)
 
     if args.simpixfile is None:
+        outdir = os.path.dirname(os.path.abspath(args.rawfile))
         args.simpixfile = io.findfile(
-            'simpix', night=args.night, expid=args.expid,
-            outdir=os.path.dirname(os.path.abspath(args.rawfile)))
+            'simpix', night=args.night, expid=args.expid, outdir=outdir)
 
 
 #-------------------------------------------------------------------------

--- a/py/desisim/test/test_io.py
+++ b/py/desisim/test/test_io.py
@@ -49,8 +49,11 @@ class TestIO(unittest.TestCase):
         x = io.simdir()
         self.assertTrue(x is not None)
         night = '20150101'
-        x = io.simdir(night)
-        self.assertTrue(x.endswith(night))
+        expid = 123
+        x = io.simdir(night, expid)
+        self.assertTrue(x.endswith(str(expid)))
+        x = io.simdir(int(night), expid)
+        self.assertTrue(x.endswith(str(expid)))
         x = io.simdir(night, mkdir=True)
         self.assertTrue(os.path.exists(x))
 

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -221,14 +221,16 @@ class TestPixsim(unittest.TestCase):
         obs.new_exposure('arc', night=night, expid=expid, nspec=nspec)
 
         #- derive night from simspec input while overriding expid
+        #- Include wavelengths covering z, but only ask for b and r
         simspecfile = io.findfile('simspec', night, expid)
-        altrawfile = desispec.io.findfile('raw', night, expid) + '.blat'
+        altexpid = expid+1
+        altrawfile = desispec.io.findfile('raw', night, altexpid) + '.blat'
         opts = [
             '--simspec', simspecfile,
-            '--expid', expid+1,
+            '--expid', altexpid,
             '--rawfile', altrawfile,
             '--cameras', 'b0,r0',
-            '--wavemin', 5000, '--wavemax', 7000.0,
+            '--wavemin', 5500, '--wavemax', 7000.0,
             '--ccd_npix_x', 2000,
             ]
         if ncpu is not None:
@@ -237,7 +239,8 @@ class TestPixsim(unittest.TestCase):
         log.debug('testing pixsim.main({})'.format(opts))
         pixsimargs = desisim.scripts.pixsim.parse(opts)
         desisim.scripts.pixsim.main(pixsimargs)
-        simpixfile = io.findfile('simpix', night, expid+1)
+        simpixfile = io.findfile('simpix', night, altexpid)
+
         self.assertTrue(os.path.exists(simpixfile))
         self.assertTrue(os.path.exists(altrawfile))
         fx = fits.open(altrawfile)


### PR DESCRIPTION
This is a companion PR to desihub/desispec#648, to write simulated raw data into per-exposure directories `$DESI_SPECTRO_SIM/$PIXPROD/{YEARMMDD}/{EXPID}/` instead of `$DESI_SPECTRO_SIM/$PIXPROD/{YEARMMDD}/{EXPID}/`.

To be merged after desihub/desispec#648
