### PR TITLE
fix newexp-mock and wrap-fastframe NIGHT/EXPID/ vs. NIGHT/ parsing

### DIFF
--- a/bin/wrap-fastframe
+++ b/bin/wrap-fastframe
@@ -54,7 +54,7 @@ else:
 
 #- Assemble full list of simspec files; group by flavor to help MPI balancing
 if rank == 0:
-    allfiles = sorted(glob.glob('{}/*/simspec*.fits'.format(desisim.io.simdir())))
+    allfiles = sorted(glob.glob('{}/*/*/simspec*.fits'.format(desisim.io.simdir())))
 
     #- Generate list of cameras
     cameras = list()
@@ -64,7 +64,7 @@ if rank == 0:
 
     simspecfiles = list()
     for filename in allfiles:
-        night = os.path.basename(os.path.split(filename)[0])
+        night = os.path.basename(os.path.dirname(os.path.dirname(filename)))
         if (args.start <= night) & (night < args.stop):
             flavor = fits.getval(filename, 'FLAVOR')
             expid = fits.getval(filename, 'EXPID')

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -20,6 +20,8 @@ desisim change log
 * Add rest-frame option to templates.SIMQSO (`PR #377`_).
 * Optionally change output wave vector in templates.SIMQSO when noresample=True
   or restframe=True (`PR #383`_).
+* Fix `newexp-mock` and `wrap-fastframe` file parsing for `NIGHT/EXPID/*.*`
+  vs. `NIGHT/*.*`.
 
 .. _`PR #321`: https://github.com/desihub/desisim/pull/321
 .. _`PR #349`: https://github.com/desihub/desisim/pull/349

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -1000,13 +1000,24 @@ def write_templates(outfile, flux, wave, meta):
 #-------------------------------------------------------------------------
 #- Utility functions
 
-def simdir(night='', expid=0, mkdir=False):
+def simdir(night=None, expid=None, mkdir=False):
     """
     Return $DESI_SPECTRO_SIM/$PIXPROD/{night}
     If mkdir is True, create directory if needed
     """
-    dirname = os.path.join(os.getenv('DESI_SPECTRO_SIM'), os.getenv('PIXPROD'),
-         str(night), '{:08d}'.format(expid))
+
+    if (night is None) and (expid is None):
+        dirname = os.path.join(
+            os.getenv('DESI_SPECTRO_SIM'), os.getenv('PIXPROD')
+            )
+    #- must provide night+expid, and catch old usage where mkdir was 2nd arg
+    elif (expid is None) or isinstance(expid, bool):
+        raise ValueError("Must provide int expid, not {}".format(expid))
+    else:
+        dirname = os.path.join(
+            os.getenv('DESI_SPECTRO_SIM'), os.getenv('PIXPROD'),
+            str(night), '{:08d}'.format(expid)
+            )
     if mkdir and not os.path.exists(dirname):
         os.makedirs(dirname)
 

--- a/py/desisim/scripts/newexp_mock.py
+++ b/py/desisim/scripts/newexp_mock.py
@@ -59,7 +59,7 @@ def main(args=None):
     fiberassign = astropy.table.Table.read(args.fiberassign, 'FIBERASSIGN')
 
     if args.outdir is None:
-        args.outdir = desisim.io.simdir(night=night, mkdir=True)
+        args.outdir = desisim.io.simdir(night=night, expid=args.expid, mkdir=True)
 
     if args.nspec is None:
         args.nspec = len(fiberassign)

--- a/py/desisim/test/test_io.py
+++ b/py/desisim/test/test_io.py
@@ -54,8 +54,10 @@ class TestIO(unittest.TestCase):
         self.assertTrue(x.endswith(str(expid)))
         x = io.simdir(int(night), expid)
         self.assertTrue(x.endswith(str(expid)))
-        x = io.simdir(night, mkdir=True)
-        self.assertTrue(os.path.exists(x))
+
+        #- If providing night, must also provide expid
+        with self.assertRaises(ValueError):
+            x = io.simdir(night, mkdir=True)
 
     def test_findfile(self):
         night = '20150102'


### PR DESCRIPTION
This PR fixes a few leftovers from the switch to raw data in `basedir/NIGHT/EXPID/` directories instead of all exposures in a single `basedir/NIGHT/` directory.  In particular:
  * `wrap-fastframe` looks for input files with the correct glob (one level deeper)
  * `wrap-fastframe` parses the night from the path correctly
  * `newexp-mock` passes `expid` to `desisim.io.simdir` to get correct output location
  * `desisim.io.simdir` no longer has a default `expid=0` which was previously leading to science exposures silently being written to the incorrect directory.

@weaverba137 these changes are required for the minitest notebook to work.  I have tested them by taking the minitest notebook up to these stages and failing, and then debugging the `newexp-mock` and `wrap-fastframe` commands separately using this branch.