### PR TITLE
faster emission line sims for MKL>=2018.0.2

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -22,7 +22,7 @@ desisim change log
   or restframe=True (`PR #383`_).
 * Fix `newexp-mock` and `wrap-fastframe` file parsing for `NIGHT/EXPID/*.*`
   vs. `NIGHT/*.*`.
-* Speed up emission line simulation when using MKL >= 2018.0.2
+* Speed up emission line simulation when using MKL >= 2018.0.2 (`PR #390`_).
 
 .. _`PR #321`: https://github.com/desihub/desisim/pull/321
 .. _`PR #349`: https://github.com/desihub/desisim/pull/349
@@ -38,6 +38,7 @@ desisim change log
 .. _`PR #370`: https://github.com/desihub/desisim/pull/370
 .. _`PR #377`: https://github.com/desihub/desisim/pull/377
 .. _`PR #383`: https://github.com/desihub/desisim/pull/383
+.. _`PR #390`: https://github.com/desihub/desisim/pull/390
 
 0.27.0 (2018-03-29)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -22,6 +22,7 @@ desisim change log
   or restframe=True (`PR #383`_).
 * Fix `newexp-mock` and `wrap-fastframe` file parsing for `NIGHT/EXPID/*.*`
   vs. `NIGHT/*.*`.
+* Speed up emission line simulation when using MKL >= 2018.0.2
 
 .. _`PR #321`: https://github.com/desihub/desisim/pull/321
 .. _`PR #349`: https://github.com/desihub/desisim/pull/349

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -222,14 +222,16 @@ class EMSpectrum(object):
         # Finally build the emission-line spectrum
         log10sigma = linesigma/LIGHT/np.log(10) # line-width [log-10 Angstrom]
         emspec = np.zeros(len(self.log10wave))
+
         for ii in range(len(line)):
             amp = line['flux'][ii] / line['wave'][ii] / np.log(10) # line-amplitude [erg/s/cm2/A]
             thislinewave = np.log10(line['wave'][ii] * (1.0+zshift))
             line['amp'][ii] = amp / (np.sqrt(2.0 * np.pi) * log10sigma)  # [erg/s/A]
 
             # Construct the spectrum [erg/s/cm2/A, rest]
-            emspec += amp * np.exp(-0.5 * (self.log10wave-thislinewave)**2 / log10sigma**2) \
-                      / (np.sqrt(2.0 * np.pi) * log10sigma)
+            jj = np.abs(self.log10wave-thislinewave) < 5*log10sigma
+            emspec[jj] += amp * np.exp(-0.5 * (self.log10wave[jj]-thislinewave)**2 / log10sigma**2) \
+                          / (np.sqrt(2.0 * np.pi) * log10sigma)
 
         return emspec, 10**self.log10wave, line
 

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -229,7 +229,7 @@ class EMSpectrum(object):
             line['amp'][ii] = amp / (np.sqrt(2.0 * np.pi) * log10sigma)  # [erg/s/A]
 
             # Construct the spectrum [erg/s/cm2/A, rest]
-            jj = np.abs(self.log10wave-thislinewave) < 5*log10sigma
+            jj = np.abs(self.log10wave-thislinewave) < 6*log10sigma
             emspec[jj] += amp * np.exp(-0.5 * (self.log10wave[jj]-thislinewave)**2 / log10sigma**2) \
                           / (np.sqrt(2.0 * np.pi) * log10sigma)
 


### PR DESCRIPTION
This PR fixes desihub/desitarget#323 where `select_mock_targets` became mysteriously slower for BGS and ELG using the latest desiconda.  I traced this to a single line in `desisim.templates.EMSpectrum`:
```python
emspec += amp * np.exp(-0.5 * (self.log10wave-thislinewave)**2 / log10sigma**2) \
            / (np.sqrt(2.0 * np.pi) * log10sigma)
```
The Gaussian is evaluated at all wavelengths `self.log10wave` instead of just a few sigma around `thislinewave`.  For earlier desiconda installations using the Intel Math Kernel Library (MKL) 2018.0.1, this wasn't a problem.  But newer desiconda installations use MKL 2018.0.2, which is 10x slower for this particular case of evaluating exponentials of large arrays of large negative numbers that will mostly result in 0.

I fixed this by pre-filtering the wavelengths to +/- 5 sigma around the line to add.  This restores the performance, and even makes it a bit faster than before.