### PR TITLE
Update to use fiberassign script in place of fiberassign_exec from c++ code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ env:
         - SPECSIM_VERSION=v0.12
         # - DESISPEC_VERSION=0.18.0
         - DESISPEC_VERSION=master
-        - DESITARGET_VERSION=0.19.0
+        - DESITARGET_VERSION=0.22.0
         - SIMQSO_VERSION=v1.2.1
         - DESI_LOGLEVEL=DEBUG
         - MAIN_CMD='python setup.py'

--- a/bin/quicksurvey
+++ b/bin/quicksurvey
@@ -10,16 +10,15 @@ parser = argparse.ArgumentParser(description="Quick and simplified simulation of
 
 parser.add_argument("--output_dir", "-O", help="Path to write the outputs", type=str, default="./")
 parser.add_argument("--targets_dir","-T",help="Path to the targets.fits file", type=str, required=True)
-parser.add_argument("--fiberassign_exec", "-f", help="Executable file for fiberassign", type=str, required=True)
+parser.add_argument("--fiberassign", "-f", help="Script for fiberassign", type=str, required=True)
 parser.add_argument("--template_fiberassign","-t",help="File containing template for fiberassign", type=str, required=True)
 parser.add_argument("--exposures","-E",help="exposures.fits file from surveysim", type=str, required=True)
 parser.add_argument("--fiberassign_dates","-D", help="file with list of dates to run fiberassign", type=str, required=True)
-
 args = parser.parse_args()
 
 setup = qs.SimSetup(output_path = args.output_dir, 
                     targets_path = args.targets_dir, 
-                    fiberassign_exec = args.fiberassign_exec, 
+                    fiberassign = args.fiberassign, 
                     template_fiberassign = args.template_fiberassign, 
                     exposures = args.exposures,
                     fiberassign_dates = args.fiberassign_dates

--- a/bin/quicksurvey
+++ b/bin/quicksurvey
@@ -11,7 +11,7 @@ parser = argparse.ArgumentParser(description="Quick and simplified simulation of
 parser.add_argument("--output_dir", "-O", help="Path to write the outputs", type=str, default="./")
 parser.add_argument("--targets_dir","-T",help="Path to the targets.fits file", type=str, required=True)
 parser.add_argument("--fiberassign", "-f", help="Script for fiberassign", type=str, required=True)
-parser.add_argument("--template_fiberassign","-t",help="File containing template for fiberassign", type=str, required=True)
+#parser.add_argument("--template_fiberassign","-t",help="File containing template for fiberassign", type=str, required=True)
 parser.add_argument("--exposures","-E",help="exposures.fits file from surveysim", type=str, required=True)
 parser.add_argument("--fiberassign_dates","-D", help="file with list of dates to run fiberassign", type=str, required=True)
 args = parser.parse_args()
@@ -19,7 +19,7 @@ args = parser.parse_args()
 setup = qs.SimSetup(output_path = args.output_dir, 
                     targets_path = args.targets_dir, 
                     fiberassign = args.fiberassign, 
-                    template_fiberassign = args.template_fiberassign, 
+                    #template_fiberassign = args.template_fiberassign, 
                     exposures = args.exposures,
                     fiberassign_dates = args.fiberassign_dates
                     )

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desisim change log
 0.29.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Update templates to DR7+ standard-star designation (FSTD-->STD) (`PR #400`_).
+
+.. _`PR #400`: https://github.com/desihub/desisim/pull/400
 
 0.29.0 (2018-07-26)
 -------------------

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -831,7 +831,7 @@ def read_basis_templates(objtype, subtype='', outwave=None, nspec=None,
 
     Args:
 
-        objtype (str): object type to read (e.g., ELG, LRG, QSO, STAR, FSTD, WD,
+        objtype (str): object type to read (e.g., ELG, LRG, QSO, STAR, STD, WD,
           MWS_STAR, BGS).
         subtype (str, optional): template subtype, currently only for white
             dwarfs.  The choices are DA and DB and the default is to read both
@@ -866,7 +866,7 @@ def read_basis_templates(objtype, subtype='', outwave=None, nspec=None,
         log = get_logger()
 
     ltype = objtype.lower()
-    if objtype == 'FSTD':
+    if objtype == 'STD':
         ltype = 'star'
     if objtype == 'MWS_STAR':
         ltype = 'star'

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -226,7 +226,7 @@ def specter_objtype(desitype):
     '''
     intype = np.atleast_1d(desitype)
     desi2specter = dict(
-        STAR='STAR', STD='STAR', STD_FSTAR='STAR', FSTD='STAR', MWS_STAR='STAR',
+        STAR='STAR', STD='STAR', MWS_STAR='STAR',
         LRG='LRG', ELG='ELG', QSO='QSO', QSO_BAD='STAR',
         BGS='LRG', # !!!
         SKY='SKY'

--- a/py/desisim/quickcat.py
+++ b/py/desisim/quickcat.py
@@ -599,10 +599,15 @@ def quickcat(tilefiles, targets, truth, zcat=None, obsconditions=None, perfect=F
         fibassign, header = fits.getdata(infile, 'FIBERASSIGN', header=True)
  
         # hack needed here rnc 7/26/18
-        # tile_id = header['TILEID']
-        fnew=infile.split('/')[-1]
-        tileidnew=fnew.split("_")[-1]
-        tileidnew=tileidnew[:-5]
+        if 'TILEID' in header:
+            tileidnew = header['TILEID']
+        else:
+            fnew=infile.split('/')[-1]
+            tileidnew=fnew.split("_")[-1]
+            tileidnew=int(tileidnew[:-5])
+            log.error('TILEID missing from {} header'.format(fnew))
+            log.error('{} -> TILEID {}'.format(infile, tileidnew))
+
         tileids.append(tileidnew)
 
         ii = (fibassign['TARGETID'] != -1)  #- targets with assignments

--- a/py/desisim/quickcat.py
+++ b/py/desisim/quickcat.py
@@ -595,13 +595,19 @@ def quickcat(tilefiles, targets, truth, zcat=None, obsconditions=None, perfect=F
     targets_in_tile = {}
     tileids = list()
     for infile in tilefiles:
-        fibassign, header = fits.getdata(infile, 'FIBER_ASSIGNMENTS', header=True)
-        tile_id = header['TILEID']
-        tileids.append(tile_id)
+        
+        fibassign, header = fits.getdata(infile, 'FIBERASSIGN', header=True)
+ 
+        # hack needed here rnc 7/26/18
+        # tile_id = header['TILEID']
+        fnew=infile.split('/')[-1]
+        tileidnew=fnew.split("_")[-1]
+        tileidnew=tileidnew[:-5]
+        tileids.append(tileidnew)
 
         ii = (fibassign['TARGETID'] != -1)  #- targets with assignments
         nobs.update(fibassign['TARGETID'][ii])
-        targets_in_tile[tile_id] = fibassign['TARGETID'][ii]
+        targets_in_tile[tileidnew] = fibassign['TARGETID'][ii]
 
     #- Trim obsconditions to just the tiles that were observed
     if obsconditions is not None:

--- a/py/desisim/quicksurvey.py
+++ b/py/desisim/quicksurvey.py
@@ -183,17 +183,18 @@ class SimSetup(object):
         np.savetxt(surveyfile, tiles, fmt='%d')
         print("{} tiles to be included in fiberassign".format(len(tiles)))
 
-
+    """
     def create_fiberassign_input(self):
-        """Creates input files for fiberassign from the provided template
+        Creates input files for fiberassign from the provided template
 
         Notes:
             The template filename is in self.template_fiberassign
-        """
+        
         params = ''.join(open(self.template_fiberassign).readlines())
         fx = open(os.path.join(self.tmp_output_path, 'fa_features.txt'), 'w')
         fx.write(params.format(inputdir = self.tmp_output_path, targetdir = self.targets_path))
         fx.close()
+    """
 
     def update_observed_tiles(self, epoch):
         """Creates the list of tilefiles to be gathered to buikd the redshift catalog.        

--- a/py/desisim/quicksurvey.py
+++ b/py/desisim/quicksurvey.py
@@ -41,7 +41,8 @@ class SimSetup(object):
         n_epochs (int): number of epochs to be simulated.
 
     """
-    def __init__(self, output_path, targets_path, fiberassign, template_fiberassign,
+    def __init__(self, output_path, targets_path, fiberassign, 
+#template_fiberassign,
                  exposures, fiberassign_dates):
         """Initializes all the paths, filenames and numbers describing DESI survey.
 
@@ -56,7 +57,7 @@ class SimSetup(object):
         self.output_path = output_path
         self.targets_path = targets_path
         self.fiberassign = fiberassign  
-        self.template_fiberassign = template_fiberassign
+        #self.template_fiberassign = template_fiberassign
 
         self.exposures = fitsio.read(exposures, upper=True)
 
@@ -248,7 +249,7 @@ class SimSetup(object):
 
         # setup the tileids for the current observation epoch
         self.create_surveyfile(epoch)
-        self.create_fiberassign_input()
+        #self.create_fiberassign_input()
 
         # launch fiberassign
         print("{} Launching fiberassign".format(asctime()))

--- a/py/desisim/quicksurvey.py
+++ b/py/desisim/quicksurvey.py
@@ -41,9 +41,7 @@ class SimSetup(object):
         n_epochs (int): number of epochs to be simulated.
 
     """
-    def __init__(self, output_path, targets_path, fiberassign, 
-#template_fiberassign,
-                 exposures, fiberassign_dates):
+    def __init__(self, output_path, targets_path, fiberassign, exposures, fiberassign_dates):
         """Initializes all the paths, filenames and numbers describing DESI survey.
 
         Args:
@@ -57,8 +55,6 @@ class SimSetup(object):
         self.output_path = output_path
         self.targets_path = targets_path
         self.fiberassign = fiberassign  
-        #self.template_fiberassign = template_fiberassign
-
         self.exposures = fitsio.read(exposures, upper=True)
 
         self.tmp_output_path = os.path.join(self.output_path, 'tmp/')
@@ -183,19 +179,6 @@ class SimSetup(object):
         np.savetxt(surveyfile, tiles, fmt='%d')
         print("{} tiles to be included in fiberassign".format(len(tiles)))
 
-    """
-    def create_fiberassign_input(self):
-        Creates input files for fiberassign from the provided template
-
-        Notes:
-            The template filename is in self.template_fiberassign
-        
-        params = ''.join(open(self.template_fiberassign).readlines())
-        fx = open(os.path.join(self.tmp_output_path, 'fa_features.txt'), 'w')
-        fx.write(params.format(inputdir = self.tmp_output_path, targetdir = self.targets_path))
-        fx.close()
-    """
-
     def update_observed_tiles(self, epoch):
         """Creates the list of tilefiles to be gathered to buikd the redshift catalog.        
 
@@ -250,7 +233,7 @@ class SimSetup(object):
 
         # setup the tileids for the current observation epoch
         self.create_surveyfile(epoch)
-        #self.create_fiberassign_input()
+
 
         # launch fiberassign
         print("{} Launching fiberassign".format(asctime()))

--- a/py/desisim/quicksurvey.py
+++ b/py/desisim/quicksurvey.py
@@ -36,26 +36,26 @@ class SimSetup(object):
         output_path (str): Path to write the outputs.x
         targets_path (str): Path where the files targets.fits can be found
         epochs_path (str): Path where the epoch files can be found.
-        fiberassign_exec (str): Name of the fiberassign executable
+        fiberassign (str): Name of the fiberassign script  
         template_fiberassign (str): Filename of the template input for fiberassign
         n_epochs (int): number of epochs to be simulated.
 
     """
-    def __init__(self, output_path, targets_path, fiberassign_exec, template_fiberassign,
+    def __init__(self, output_path, targets_path, fiberassign, template_fiberassign,
                  exposures, fiberassign_dates):
         """Initializes all the paths, filenames and numbers describing DESI survey.
 
         Args:
             output_path (str): Path to write the outputs.x
             targets_path (str): Path where the files targets.fits can be found
-            fiberassign_exec (str): Name of the fiberassign executable
+            fiberassign (str): Name of the fiberassign executable
             template_fiberassign (str): Filename of the template input for fiberassign
             exposures (stri): exposures.fits file summarazing surveysim results
             fiberassign_dates (str): ascii file with the dates to run fiberassign.
         """
         self.output_path = output_path
         self.targets_path = targets_path
-        self.fiberassign_exec = fiberassign_exec
+        self.fiberassign = fiberassign  
         self.template_fiberassign = template_fiberassign
 
         self.exposures = fitsio.read(exposures, upper=True)
@@ -204,8 +204,8 @@ class SimSetup(object):
             tilename = os.path.join(self.tmp_fiber_path, 'tile_%05d.fits'%(i))
             if os.path.isfile(tilename):
                 self.tilefiles.append(tilename)
-            else:
-                print('Suggested but does not exist {}'.format(tilename))
+            #else:
+              #  print('Suggested but does not exist {}'.format(tilename))
         print("{} {} tiles to gather in zcat".format(asctime(), len(self.tilefiles)))
 
         
@@ -253,7 +253,11 @@ class SimSetup(object):
         # launch fiberassign
         print("{} Launching fiberassign".format(asctime()))
         f = open('fiberassign.log','a')
-        p = subprocess.call([self.fiberassign_exec, os.path.join(self.tmp_output_path, 'fa_features.txt')], stdout=f)# stdout=subprocess.PIPE)
+        
+        p = subprocess.call([self.fiberassign, '--mtl',  os.path.join(self.tmp_output_path, 'mtl.fits'),'--stdstar',  os.path.join(self.targets_path, 'standards-dark.fits'),  '--sky',  os.path.join(self.targets_path, 'sky.fits'), '--surveytiles',  os.path.join(self.tmp_output_path, 'survey_list.txt'),
+ '--outdir',os.path.join(self.tmp_output_path, 'fiberassign')  , '--fibstatusfile',  '/global/cscratch1/sd/sjbailey/desi/code/desitest/mini/fiberstatus.ecsv'], stdout=f)
+
+
         print("{} Finished fiberassign".format(asctime()))
         f.close()
 

--- a/py/desisim/scripts/quickgen.py
+++ b/py/desisim/scripts/quickgen.py
@@ -277,8 +277,8 @@ def main(args):
                 bgs = desisim.templates.BGS(wave=wavelengths, add_SNeIa=args.add_SNeIa)
                 flux, tmpwave, meta1 = bgs.make_templates(nmodel=nobj, seed=args.seed, zrange=args.zrange_bgs,rmagrange=args.rmagrange_bgs,sne_rfluxratiorange=args.sne_rfluxratiorange)
             elif thisobj =='STD':
-                fstd = desisim.templates.FSTD(wave=wavelengths)
-                flux, tmpwave, meta1 = fstd.make_templates(nmodel=nobj, seed=args.seed)
+                std = desisim.templates.STD(wave=wavelengths)
+                flux, tmpwave, meta1 = std.make_templates(nmodel=nobj, seed=args.seed)
             elif thisobj == 'QSO_BAD': # use STAR template no color cuts
                 star = desisim.templates.STAR(wave=wavelengths)
                 flux, tmpwave, meta1 = star.make_templates(nmodel=nobj, seed=args.seed)

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -257,17 +257,17 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
         
         if trans_wave[0]>wanted_min_wave :
             log.info("Increase wavelength range from {}:{} to {}:{} to compute magnitudes".format(int(trans_wave[0]),int(trans_wave[-1]),int(wanted_min_wave),int(trans_wave[-1])))
-            # pad with zeros at short wavelength because we assume transmission = 0
-            # and we don't need any wavelength resolution here
+            # pad with ones at short wavelength, we assume F = 1 for z <~ 1.7
+            # we don't need any wavelength resolution here
             new_trans_wave = np.append([wanted_min_wave,trans_wave[0]-0.01],trans_wave)
-            new_transmission = np.zeros((transmission.shape[0],new_trans_wave.size))
+            new_transmission = np.ones((transmission.shape[0],new_trans_wave.size))
             new_transmission[:,2:] = transmission
             trans_wave   = new_trans_wave
             transmission = new_transmission
                     
         if trans_wave[-1]<wanted_max_wave :
             log.info("Increase wavelength range from {}:{} to {}:{} to compute magnitudes".format(int(trans_wave[0]),int(trans_wave[-1]),int(trans_wave[0]),int(wanted_max_wave)))
-            # pad with ones at long wavelength because we assume transmission = 1
+            # pad with ones at long wavelength because we assume F = 1
             coarse_dwave = 2. # we don't care about resolution, we just need a decent QSO spectrum, there is no IGM transmission in this range
             n = int((wanted_max_wave-trans_wave[-1])/coarse_dwave)+1
             new_trans_wave = np.append(trans_wave,np.linspace(trans_wave[-1]+coarse_dwave,trans_wave[-1]+coarse_dwave*(n+1),n))

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -500,8 +500,9 @@ def main(args=None):
     # seeds for each healpix are themselves random numbers
     seeds = np.random.randint(2**32, size=len(args.infile))
     if args.balprob:
-       bal=BAL()
-
+        bal=BAL()
+    else:
+        bal=None
     if args.nproc > 1 :
         func_args = [ {"ifilename":filename , \
                        "args":args, "model":model , \
@@ -509,14 +510,10 @@ def main(args=None):
                        "decam_and_wise_filters": decam_and_wise_filters , \
                        "footprint_healpix_weight": footprint_healpix_weight , \
                        "footprint_healpix_nside": footprint_healpix_nside , \
-                       "seed":seeds[i]
+                       "seed":seeds[i], "bal":bal \
                    } for i,filename in enumerate(args.infile) ]
         pool = multiprocessing.Pool(args.nproc)
         pool.map(_func, func_args)
     else :
         for i,ifilename in enumerate(args.infile) :
-            if args.balprob:
-               simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filters,footprint_healpix_weight,footprint_healpix_nside,seed=seeds[i],bal=bal)
-            else:
-                 simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filters,footprint_healpix_weight,footprint_healpix_nside,seed=seeds[i])
-        
+            simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filters,footprint_healpix_weight,footprint_healpix_nside,seed=seeds[i],bal=bal)

--- a/py/desisim/scripts/quickspectra.py
+++ b/py/desisim/scripts/quickspectra.py
@@ -79,7 +79,7 @@ def sim_spectra(wave, flux, program, spectra_filename, obsconditions=None,
     
     # add DESI_TARGET 
     tm = desitarget.targetmask.desi_mask
-    frame_fibermap['DESI_TARGET'][sourcetype=="star"]=tm.STD_FSTAR
+    frame_fibermap['DESI_TARGET'][sourcetype=="star"]=tm.STD
     frame_fibermap['DESI_TARGET'][sourcetype=="lrg"]=tm.LRG
     frame_fibermap['DESI_TARGET'][sourcetype=="elg"]=tm.ELG
     frame_fibermap['DESI_TARGET'][sourcetype=="qso"]=tm.QSO

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -326,7 +326,7 @@ def fibermeta2fibermap(fiberassign, meta):
 
     #- set OBJTYPE
     #- TODO: what about MWS science targets that are also standard stars?
-    stdmask = (desi_mask.STD_FSTAR | desi_mask.STD_WD | desi_mask.STD_BRIGHT)
+    stdmask = (desi_mask.STD | desi_mask.STD_WD | desi_mask.STD_BRIGHT)
     isSTD = (fiberassign['DESI_TARGET'] & stdmask) != 0
     isSKY = (fiberassign['DESI_TARGET'] & desi_mask.SKY) != 0
     isSCI = (~isSTD & ~isSKY)
@@ -653,7 +653,7 @@ def get_source_types(fibermap):
     source_type[(fibermap['DESI_TARGET'] & tm.LRG) != 0] = 'lrg'
     source_type[(fibermap['DESI_TARGET'] & tm.QSO) != 0] = 'qso'
     source_type[(fibermap['DESI_TARGET'] & tm.BGS_ANY) != 0] = 'bgs'
-    starmask = tm.STD_FSTAR | tm.STD_WD | tm.STD_BRIGHT | tm.MWS_ANY
+    starmask = tm.STD | tm.STD_WD | tm.STD_BRIGHT | tm.MWS_ANY
     source_type[(fibermap['DESI_TARGET'] & starmask) != 0] = 'star'
 
     #- Simulate unassigned fibers as sky

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -338,10 +338,10 @@ def get_targets(nspec, program, tileid=None, seed=None, specify_targets=dict(), 
             fibermap['DESI_TARGET'][ii] = desi_mask.QSO
 
         elif objtype == 'STD':
-            from desisim.templates import FSTD
-            fstd = FSTD(wave=wave)
-            simflux, wave1, meta1 = fstd.make_templates(nmodel=nobj, seed=seed, **obj_kwargs)
-            fibermap['DESI_TARGET'][ii] = desi_mask.STD_FSTAR
+            from desisim.templates import STD
+            std = STD(wave=wave)
+            simflux, wave1, meta1 = std.make_templates(nmodel=nobj, seed=seed, **obj_kwargs)
+            fibermap['DESI_TARGET'][ii] = desi_mask.STD
 
         elif objtype == 'MWS_STAR':
             from desisim.templates import MWS_STAR

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -1407,19 +1407,19 @@ class STAR(SUPERSTAR):
                                                        restframe=restframe, verbose=verbose)
         return outflux, wave, meta
 
-class FSTD(SUPERSTAR):
+class STD(SUPERSTAR):
     """Generate Monte Carlo spectra of (metal-poor, main sequence turnoff) standard
-    stars (FSTD).
+    stars (STD).
 
     """
     def __init__(self, minwave=3600.0, maxwave=10000.0, cdelt=0.2, wave=None,
                  normfilter='decam2014-r', colorcuts_function=None,
                  baseflux=None, basewave=None, basemeta=None):
-        """Initialize the FSTD class.  See the SUPERSTAR.__init__ method for
+        """Initialize the STD class.  See the SUPERSTAR.__init__ method for
         documentation on the arguments plus the inherited attributes.
 
         Note:
-          We assume that the FSTD templates will always be normalized in the
+          We assume that the STD templates will always be normalized in the
           DECam r-band filter.
 
         Args:
@@ -1430,9 +1430,9 @@ class FSTD(SUPERSTAR):
 
         """
         if colorcuts_function is None:
-            from desitarget.cuts import isFSTD_colors as colorcuts_function
+            from desitarget.cuts import isSTD_colors as colorcuts_function
 
-        super(FSTD, self).__init__(objtype='FSTD', minwave=minwave, maxwave=maxwave,
+        super(STD, self).__init__(objtype='STD', minwave=minwave, maxwave=maxwave,
                                    cdelt=cdelt, wave=wave, colorcuts_function=colorcuts_function,
                                    normfilter=normfilter, baseflux=baseflux, basewave=basewave,
                                    basemeta=basemeta)
@@ -1440,11 +1440,11 @@ class FSTD(SUPERSTAR):
     def make_templates(self, nmodel=100, vrad_meansig=(0.0, 200.0), rmagrange=(16.0, 19.0),
                        seed=None, redshift=None, mag=None, input_meta=None, star_properties=None,
                        nocolorcuts=False, restframe=False, verbose=False):
-        """Build Monte Carlo spectra/templates for FSTD stars.
+        """Build Monte Carlo spectra/templates for STD stars.
 
         See the SUPERSTAR.make_star_templates function for documentation on the
         arguments and inherited attributes.  Here we only document the arguments
-        which are specific to the FSTD class.
+        which are specific to the STD class.
 
         Args:
           rmagrange (float, optional): Minimum and maximum DECam r-band (AB)

--- a/py/desisim/test/test_obs.py
+++ b/py/desisim/test/test_obs.py
@@ -167,7 +167,7 @@ class TestObs(unittest.TestCase):
     def test_specter_objtype(self):
         self.assertEqual(obs.specter_objtype('MWS_STAR'), 'STAR')
         self.assertEqual(obs.specter_objtype(['MWS_STAR',])[0], 'STAR')
-        a = np.array(['STAR', 'MWS_STAR', 'QSO_BAD', 'FSTD', 'QSO', 'ELG'])
+        a = np.array(['STAR', 'MWS_STAR', 'QSO_BAD', 'STD', 'QSO', 'ELG'])
         b = np.array(['STAR', 'STAR', 'STAR', 'STAR', 'QSO', 'ELG'])
         self.assertTrue(np.all(obs.specter_objtype(a) == b))
 

--- a/py/desisim/test/test_quickcat.py
+++ b/py/desisim/test/test_quickcat.py
@@ -66,7 +66,7 @@ class TestQuickCat(unittest.TestCase):
         truth['TRUESPECTYPE'][ii] = 'GALAXY'
         ii = (targets['DESI_TARGET'] == desi_mask.QSO)
         truth['TRUESPECTYPE'][ii] = 'QSO'
-        starmask = desi_mask.mask('MWS_ANY|STD_FSTAR|STD_WD|STD_BRIGHT')
+        starmask = desi_mask.mask('MWS_ANY|STD|STD_WD|STD_BRIGHT')
         ii = (targets['DESI_TARGET'] & starmask) != 0
         truth['TRUESPECTYPE'][ii] = 'STAR'
 

--- a/py/desisim/test/test_quickcat.py
+++ b/py/desisim/test/test_quickcat.py
@@ -81,7 +81,7 @@ class TestQuickCat(unittest.TestCase):
         fiberassign = truth['TARGETID',]
         fiberassign['RA'] = np.random.uniform(0,5, size=n)
         fiberassign['DEC'] = np.random.uniform(0,5, size=n)
-        fiberassign.meta['EXTNAME'] = 'FIBER_ASSIGNMENTS'
+        fiberassign.meta['EXTNAME'] = 'FIBERASSIGN'
         nx = cls.nspec // cls.ntiles
         cls.targets_in_tile = dict()
         for i, filename in enumerate(cls.tilefiles):

--- a/py/desisim/test/test_templates.py
+++ b/py/desisim/test/test_templates.py
@@ -4,7 +4,7 @@ import os
 import unittest
 import numpy as np
 from astropy.table import Table, Column
-from desisim.templates import ELG, LRG, QSO, BGS, STAR, FSTD, MWS_STAR, WD, SIMQSO
+from desisim.templates import ELG, LRG, QSO, BGS, STAR, STD, MWS_STAR, WD, SIMQSO
 from desisim import lya_mock_p1d as lyamock
 
 desimodel_data_available = 'DESIMODEL' in os.environ
@@ -31,7 +31,7 @@ class TestTemplates(unittest.TestCase):
     def test_simple(self):
         '''Confirm that creating templates works at all'''
         print('In function test_simple, seed = {}'.format(self.seed))
-        for T in [ELG, LRG, QSO, BGS, STAR, FSTD, MWS_STAR, WD, SIMQSO]:
+        for T in [ELG, LRG, QSO, BGS, STAR, STD, MWS_STAR, WD, SIMQSO]:
             template_factory = T(wave=self.wave)
             flux, wave, meta = template_factory.make_templates(self.nspec, seed=self.seed)
             self._check_output_size(flux, wave, meta)


### PR DESCRIPTION
This resurrects quicksurvey to enable simulations of survey with multiple epochs.  It also removes references to the template (features file).  The primary change is in the subprocess call, which now uses the fiberassign script rather than going directly to the c++ executable fiberassign_exec.