### PR TITLE
below wanted_min_wave, corresponding to z=1.7, we set F=1

### DIFF
--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -257,17 +257,17 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
         
         if trans_wave[0]>wanted_min_wave :
             log.info("Increase wavelength range from {}:{} to {}:{} to compute magnitudes".format(int(trans_wave[0]),int(trans_wave[-1]),int(wanted_min_wave),int(trans_wave[-1])))
-            # pad with zeros at short wavelength because we assume transmission = 0
-            # and we don't need any wavelength resolution here
+            # pad with ones at short wavelength, we assume F = 1 for z <~ 1.7
+            # we don't need any wavelength resolution here
             new_trans_wave = np.append([wanted_min_wave,trans_wave[0]-0.01],trans_wave)
-            new_transmission = np.zeros((transmission.shape[0],new_trans_wave.size))
+            new_transmission = np.ones((transmission.shape[0],new_trans_wave.size))
             new_transmission[:,2:] = transmission
             trans_wave   = new_trans_wave
             transmission = new_transmission
                     
         if trans_wave[-1]<wanted_max_wave :
             log.info("Increase wavelength range from {}:{} to {}:{} to compute magnitudes".format(int(trans_wave[0]),int(trans_wave[-1]),int(trans_wave[0]),int(wanted_max_wave)))
-            # pad with ones at long wavelength because we assume transmission = 1
+            # pad with ones at long wavelength because we assume F = 1
             coarse_dwave = 2. # we don't care about resolution, we just need a decent QSO spectrum, there is no IGM transmission in this range
             n = int((wanted_max_wave-trans_wave[-1])/coarse_dwave)+1
             new_trans_wave = np.append(trans_wave,np.linspace(trans_wave[-1]+coarse_dwave,trans_wave[-1]+coarse_dwave*(n+1),n))


### PR DESCRIPTION
This PR addresses issue #364.

Currently the transmission files end at lambda=3550 A, and if we need to go below that it is better to set F=1 than F=0 (as it was implemented). Even better would be to set it to the mean flux, but I really don't think this will ever matter for two reasons:
 - the mean flux is above 0.9 by then, very close to 1
 - I still don't see why we would ever go below 3550, all the way to 3329. The code says it is to compute the DECAM-r magnitude, but I guess it means DECAM-u? Even then, below 3550A the filter is almost dying, so whether it is F=0.9 or F=1 should have no impact on the overall "u" magnitude.