### PR TITLE
update templates to DR7 standard stars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ env:
         - SPECSIM_VERSION=v0.12
         # - DESISPEC_VERSION=0.18.0
         - DESISPEC_VERSION=master
-        - DESITARGET_VERSION=0.19.0
+        - DESITARGET_VERSION=0.22.0
         - SIMQSO_VERSION=v1.2.1
         - DESI_LOGLEVEL=DEBUG
         - MAIN_CMD='python setup.py'

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desisim change log
 0.29.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Update templates to DR7+ standard-star designation (FSTD-->STD) (`PR #400`_).
+
+.. _`PR #400`: https://github.com/desihub/desisim/pull/400
 
 0.29.0 (2018-07-26)
 -------------------

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -831,7 +831,7 @@ def read_basis_templates(objtype, subtype='', outwave=None, nspec=None,
 
     Args:
 
-        objtype (str): object type to read (e.g., ELG, LRG, QSO, STAR, FSTD, WD,
+        objtype (str): object type to read (e.g., ELG, LRG, QSO, STAR, STD, WD,
           MWS_STAR, BGS).
         subtype (str, optional): template subtype, currently only for white
             dwarfs.  The choices are DA and DB and the default is to read both
@@ -866,7 +866,7 @@ def read_basis_templates(objtype, subtype='', outwave=None, nspec=None,
         log = get_logger()
 
     ltype = objtype.lower()
-    if objtype == 'FSTD':
+    if objtype == 'STD':
         ltype = 'star'
     if objtype == 'MWS_STAR':
         ltype = 'star'

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -226,7 +226,7 @@ def specter_objtype(desitype):
     '''
     intype = np.atleast_1d(desitype)
     desi2specter = dict(
-        STAR='STAR', STD='STAR', STD_FSTAR='STAR', FSTD='STAR', MWS_STAR='STAR',
+        STAR='STAR', STD='STAR', STD='STAR', MWS_STAR='STAR',
         LRG='LRG', ELG='ELG', QSO='QSO', QSO_BAD='STAR',
         BGS='LRG', # !!!
         SKY='SKY'

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -226,7 +226,7 @@ def specter_objtype(desitype):
     '''
     intype = np.atleast_1d(desitype)
     desi2specter = dict(
-        STAR='STAR', STD='STAR', STD='STAR', MWS_STAR='STAR',
+        STAR='STAR', STD='STAR', MWS_STAR='STAR',
         LRG='LRG', ELG='ELG', QSO='QSO', QSO_BAD='STAR',
         BGS='LRG', # !!!
         SKY='SKY'

--- a/py/desisim/scripts/quickgen.py
+++ b/py/desisim/scripts/quickgen.py
@@ -277,8 +277,8 @@ def main(args):
                 bgs = desisim.templates.BGS(wave=wavelengths, add_SNeIa=args.add_SNeIa)
                 flux, tmpwave, meta1 = bgs.make_templates(nmodel=nobj, seed=args.seed, zrange=args.zrange_bgs,rmagrange=args.rmagrange_bgs,sne_rfluxratiorange=args.sne_rfluxratiorange)
             elif thisobj =='STD':
-                fstd = desisim.templates.FSTD(wave=wavelengths)
-                flux, tmpwave, meta1 = fstd.make_templates(nmodel=nobj, seed=args.seed)
+                std = desisim.templates.STD(wave=wavelengths)
+                flux, tmpwave, meta1 = std.make_templates(nmodel=nobj, seed=args.seed)
             elif thisobj == 'QSO_BAD': # use STAR template no color cuts
                 star = desisim.templates.STAR(wave=wavelengths)
                 flux, tmpwave, meta1 = star.make_templates(nmodel=nobj, seed=args.seed)

--- a/py/desisim/scripts/quickspectra.py
+++ b/py/desisim/scripts/quickspectra.py
@@ -79,7 +79,7 @@ def sim_spectra(wave, flux, program, spectra_filename, obsconditions=None,
     
     # add DESI_TARGET 
     tm = desitarget.targetmask.desi_mask
-    frame_fibermap['DESI_TARGET'][sourcetype=="star"]=tm.STD_FSTAR
+    frame_fibermap['DESI_TARGET'][sourcetype=="star"]=tm.STD
     frame_fibermap['DESI_TARGET'][sourcetype=="lrg"]=tm.LRG
     frame_fibermap['DESI_TARGET'][sourcetype=="elg"]=tm.ELG
     frame_fibermap['DESI_TARGET'][sourcetype=="qso"]=tm.QSO

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -326,7 +326,7 @@ def fibermeta2fibermap(fiberassign, meta):
 
     #- set OBJTYPE
     #- TODO: what about MWS science targets that are also standard stars?
-    stdmask = (desi_mask.STD_FSTAR | desi_mask.STD_WD | desi_mask.STD_BRIGHT)
+    stdmask = (desi_mask.STD | desi_mask.STD_WD | desi_mask.STD_BRIGHT)
     isSTD = (fiberassign['DESI_TARGET'] & stdmask) != 0
     isSKY = (fiberassign['DESI_TARGET'] & desi_mask.SKY) != 0
     isSCI = (~isSTD & ~isSKY)
@@ -653,7 +653,7 @@ def get_source_types(fibermap):
     source_type[(fibermap['DESI_TARGET'] & tm.LRG) != 0] = 'lrg'
     source_type[(fibermap['DESI_TARGET'] & tm.QSO) != 0] = 'qso'
     source_type[(fibermap['DESI_TARGET'] & tm.BGS_ANY) != 0] = 'bgs'
-    starmask = tm.STD_FSTAR | tm.STD_WD | tm.STD_BRIGHT | tm.MWS_ANY
+    starmask = tm.STD | tm.STD_WD | tm.STD_BRIGHT | tm.MWS_ANY
     source_type[(fibermap['DESI_TARGET'] & starmask) != 0] = 'star'
 
     #- Simulate unassigned fibers as sky

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -338,10 +338,10 @@ def get_targets(nspec, program, tileid=None, seed=None, specify_targets=dict(), 
             fibermap['DESI_TARGET'][ii] = desi_mask.QSO
 
         elif objtype == 'STD':
-            from desisim.templates import FSTD
-            fstd = FSTD(wave=wave)
-            simflux, wave1, meta1 = fstd.make_templates(nmodel=nobj, seed=seed, **obj_kwargs)
-            fibermap['DESI_TARGET'][ii] = desi_mask.STD_FSTAR
+            from desisim.templates import STD
+            std = STD(wave=wave)
+            simflux, wave1, meta1 = std.make_templates(nmodel=nobj, seed=seed, **obj_kwargs)
+            fibermap['DESI_TARGET'][ii] = desi_mask.STD
 
         elif objtype == 'MWS_STAR':
             from desisim.templates import MWS_STAR

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -1407,19 +1407,19 @@ class STAR(SUPERSTAR):
                                                        restframe=restframe, verbose=verbose)
         return outflux, wave, meta
 
-class FSTD(SUPERSTAR):
+class STD(SUPERSTAR):
     """Generate Monte Carlo spectra of (metal-poor, main sequence turnoff) standard
-    stars (FSTD).
+    stars (STD).
 
     """
     def __init__(self, minwave=3600.0, maxwave=10000.0, cdelt=0.2, wave=None,
                  normfilter='decam2014-r', colorcuts_function=None,
                  baseflux=None, basewave=None, basemeta=None):
-        """Initialize the FSTD class.  See the SUPERSTAR.__init__ method for
+        """Initialize the STD class.  See the SUPERSTAR.__init__ method for
         documentation on the arguments plus the inherited attributes.
 
         Note:
-          We assume that the FSTD templates will always be normalized in the
+          We assume that the STD templates will always be normalized in the
           DECam r-band filter.
 
         Args:
@@ -1430,9 +1430,9 @@ class FSTD(SUPERSTAR):
 
         """
         if colorcuts_function is None:
-            from desitarget.cuts import isFSTD_colors as colorcuts_function
+            from desitarget.cuts import isSTD_colors as colorcuts_function
 
-        super(FSTD, self).__init__(objtype='FSTD', minwave=minwave, maxwave=maxwave,
+        super(STD, self).__init__(objtype='STD', minwave=minwave, maxwave=maxwave,
                                    cdelt=cdelt, wave=wave, colorcuts_function=colorcuts_function,
                                    normfilter=normfilter, baseflux=baseflux, basewave=basewave,
                                    basemeta=basemeta)
@@ -1440,11 +1440,11 @@ class FSTD(SUPERSTAR):
     def make_templates(self, nmodel=100, vrad_meansig=(0.0, 200.0), rmagrange=(16.0, 19.0),
                        seed=None, redshift=None, mag=None, input_meta=None, star_properties=None,
                        nocolorcuts=False, restframe=False, verbose=False):
-        """Build Monte Carlo spectra/templates for FSTD stars.
+        """Build Monte Carlo spectra/templates for STD stars.
 
         See the SUPERSTAR.make_star_templates function for documentation on the
         arguments and inherited attributes.  Here we only document the arguments
-        which are specific to the FSTD class.
+        which are specific to the STD class.
 
         Args:
           rmagrange (float, optional): Minimum and maximum DECam r-band (AB)

--- a/py/desisim/test/test_obs.py
+++ b/py/desisim/test/test_obs.py
@@ -167,7 +167,7 @@ class TestObs(unittest.TestCase):
     def test_specter_objtype(self):
         self.assertEqual(obs.specter_objtype('MWS_STAR'), 'STAR')
         self.assertEqual(obs.specter_objtype(['MWS_STAR',])[0], 'STAR')
-        a = np.array(['STAR', 'MWS_STAR', 'QSO_BAD', 'FSTD', 'QSO', 'ELG'])
+        a = np.array(['STAR', 'MWS_STAR', 'QSO_BAD', 'STD', 'QSO', 'ELG'])
         b = np.array(['STAR', 'STAR', 'STAR', 'STAR', 'QSO', 'ELG'])
         self.assertTrue(np.all(obs.specter_objtype(a) == b))
 

--- a/py/desisim/test/test_quickcat.py
+++ b/py/desisim/test/test_quickcat.py
@@ -66,7 +66,7 @@ class TestQuickCat(unittest.TestCase):
         truth['TRUESPECTYPE'][ii] = 'GALAXY'
         ii = (targets['DESI_TARGET'] == desi_mask.QSO)
         truth['TRUESPECTYPE'][ii] = 'QSO'
-        starmask = desi_mask.mask('MWS_ANY|STD_FSTAR|STD_WD|STD_BRIGHT')
+        starmask = desi_mask.mask('MWS_ANY|STD|STD_WD|STD_BRIGHT')
         ii = (targets['DESI_TARGET'] & starmask) != 0
         truth['TRUESPECTYPE'][ii] = 'STAR'
 

--- a/py/desisim/test/test_templates.py
+++ b/py/desisim/test/test_templates.py
@@ -4,7 +4,7 @@ import os
 import unittest
 import numpy as np
 from astropy.table import Table, Column
-from desisim.templates import ELG, LRG, QSO, BGS, STAR, FSTD, MWS_STAR, WD, SIMQSO
+from desisim.templates import ELG, LRG, QSO, BGS, STAR, STD, MWS_STAR, WD, SIMQSO
 from desisim import lya_mock_p1d as lyamock
 
 desimodel_data_available = 'DESIMODEL' in os.environ
@@ -31,7 +31,7 @@ class TestTemplates(unittest.TestCase):
     def test_simple(self):
         '''Confirm that creating templates works at all'''
         print('In function test_simple, seed = {}'.format(self.seed))
-        for T in [ELG, LRG, QSO, BGS, STAR, FSTD, MWS_STAR, WD, SIMQSO]:
+        for T in [ELG, LRG, QSO, BGS, STAR, STD, MWS_STAR, WD, SIMQSO]:
             template_factory = T(wave=self.wave)
             flux, wave, meta = template_factory.make_templates(self.nspec, seed=self.seed)
             self._check_output_size(flux, wave, meta)


### PR DESCRIPTION
Update templates code to accommodate the changes to `desitarget` in https://github.com/desihub/desitarget/pull/338, largely related to changing the standard-star designation from `FSTD` to `STD`.
