### PR TITLE
update to STD_FAINT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ env:
         - SPECSIM_VERSION=v0.12
         # - DESISPEC_VERSION=0.18.0
         - DESISPEC_VERSION=master
-        - DESITARGET_VERSION=0.22.0
+        - DESITARGET_VERSION=0.23.0
         - SIMQSO_VERSION=v1.2.1
         - DESI_LOGLEVEL=DEBUG
         - MAIN_CMD='python setup.py'

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -2,12 +2,15 @@
 desisim change log
 ==================
 
-0.29.1 (unreleased)
+0.30.0 (unreleased)
 -------------------
 
 * Update templates to DR7+ standard-star designation (FSTD-->STD) (`PR #400`_).
+* Update standard star bit name again STD -> STD_FAINT;
+  requires desitarget 0.23.0 (`PR #402`_).
 
 .. _`PR #400`: https://github.com/desihub/desisim/pull/400
+.. _`PR #402`: https://github.com/desihub/desisim/pull/402
 
 0.29.0 (2018-07-26)
 -------------------

--- a/py/desisim/scripts/quickspectra.py
+++ b/py/desisim/scripts/quickspectra.py
@@ -79,7 +79,7 @@ def sim_spectra(wave, flux, program, spectra_filename, obsconditions=None,
     
     # add DESI_TARGET 
     tm = desitarget.targetmask.desi_mask
-    frame_fibermap['DESI_TARGET'][sourcetype=="star"]=tm.STD
+    frame_fibermap['DESI_TARGET'][sourcetype=="star"]=tm.STD_FAINT
     frame_fibermap['DESI_TARGET'][sourcetype=="lrg"]=tm.LRG
     frame_fibermap['DESI_TARGET'][sourcetype=="elg"]=tm.ELG
     frame_fibermap['DESI_TARGET'][sourcetype=="qso"]=tm.QSO

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -326,8 +326,16 @@ def fibermeta2fibermap(fiberassign, meta):
 
     #- set OBJTYPE
     #- TODO: what about MWS science targets that are also standard stars?
-    stdmask = (desi_mask.STD | desi_mask.STD_WD | desi_mask.STD_BRIGHT)
+    #- Loop over STD options for backwards/forwards compatibility
+    stdmask = 0
+    for name in ['STD', 'STD_FSTAR', 'STD_WD'
+                 'STD_FAINT', 'STD_FAINT_BEST',
+                 'STD_BRIGHT', 'STD_BRIGHT_BEST']:
+        if name in desi_mask.names():
+            stdmask |= desi_mask[name]
+
     isSTD = (fiberassign['DESI_TARGET'] & stdmask) != 0
+
     isSKY = (fiberassign['DESI_TARGET'] & desi_mask.SKY) != 0
     isSCI = (~isSTD & ~isSKY)
     fibermap['OBJTYPE'][isSTD] = 'STD'
@@ -653,7 +661,14 @@ def get_source_types(fibermap):
     source_type[(fibermap['DESI_TARGET'] & tm.LRG) != 0] = 'lrg'
     source_type[(fibermap['DESI_TARGET'] & tm.QSO) != 0] = 'qso'
     source_type[(fibermap['DESI_TARGET'] & tm.BGS_ANY) != 0] = 'bgs'
-    starmask = tm.STD | tm.STD_WD | tm.STD_BRIGHT | tm.MWS_ANY
+
+    starmask = 0
+    for name in ['STD', 'STD_FSTAR', 'STD_WD', 'MWS_ANY',
+                 'STD_FAINT', 'STD_FAINT_BEST',
+                 'STD_BRIGHT', 'STD_BRIGHT_BEST']:
+        if name in desitarget.targetmask.desi_mask.names():
+            starmask |= desitarget.targetmask.desi_mask[name]
+
     source_type[(fibermap['DESI_TARGET'] & starmask) != 0] = 'star'
 
     #- Simulate unassigned fibers as sky

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -341,7 +341,11 @@ def get_targets(nspec, program, tileid=None, seed=None, specify_targets=dict(), 
             from desisim.templates import STD
             std = STD(wave=wave)
             simflux, wave1, meta1 = std.make_templates(nmodel=nobj, seed=seed, **obj_kwargs)
-            fibermap['DESI_TARGET'][ii] = desi_mask.STD
+            #- Loop options for forwards/backwards compatibility
+            for name in ['STD_FAINT', 'STD_FSTAR', 'STD']:
+                if name in desi_mask.names():
+                    fibermap['DESI_TARGET'][ii] |= desi_mask[name]
+                    break
 
         elif objtype == 'MWS_STAR':
             from desisim.templates import MWS_STAR
@@ -350,7 +354,7 @@ def get_targets(nspec, program, tileid=None, seed=None, specify_targets=dict(), 
             if 'rmagrange' not in obj_kwargs.keys():
                 obj_kwargs['rmagrange'] = (15.0,20.0)
             simflux, wave1, meta1 = mwsstar.make_templates(nmodel=nobj, seed=seed, **obj_kwargs)
-            fibermap['DESI_TARGET'][ii] = desi_mask.MWS_ANY
+            fibermap['DESI_TARGET'][ii] |= desi_mask.MWS_ANY
             #- MWS bit names changed after desitarget 0.6.0 so use number
             #- instead of name for now (bit 0 = mask 1 = MWS_MAIN currently)
             fibermap['MWS_TARGET'][ii] = 1

--- a/py/desisim/test/test_quickcat.py
+++ b/py/desisim/test/test_quickcat.py
@@ -66,7 +66,7 @@ class TestQuickCat(unittest.TestCase):
         truth['TRUESPECTYPE'][ii] = 'GALAXY'
         ii = (targets['DESI_TARGET'] == desi_mask.QSO)
         truth['TRUESPECTYPE'][ii] = 'QSO'
-        starmask = desi_mask.mask('MWS_ANY|STD|STD_WD|STD_BRIGHT')
+        starmask = desi_mask.mask('MWS_ANY|STD_FAINT|STD_WD|STD_BRIGHT')
         ii = (targets['DESI_TARGET'] & starmask) != 0
         truth['TRUESPECTYPE'][ii] = 'STAR'
 


### PR DESCRIPTION
Updates for compatibility with desitarget/0.23.0 which renamed bit STD -> STD_FAINT.

When it wouldn't clutter the code too much, this also maintains backwards compatibility with previous names (STD, STD_FSTAR).  quickspectra and quickcat are not backwards compatible but simexp is.

Companion PR to desihub/desitarget#341 .