### PR TITLE
restore quickquasars to functioning state after templates refactor

### DIFF
--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -355,11 +355,11 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
     # photometric systems.
     south = np.where( is_south(metadata['DEC']) )[0]
     north = np.where( ~is_south(metadata['DEC']) )[0]
-    meta, qsometa = empty_metatable(nqso, objtype='QSO', simqso=~args.no_simqso)
+    meta, qsometa = empty_metatable(nqso, objtype='QSO', simqso=not args.no_simqso)
     if args.no_simqso:
         log.info("Simulate {} QSOs with QSO templates".format(nqso))
-        tmp_qso_flux = np.zeros([nobj, len(model.eigenwave)], dtype='f4')
-        tmp_qso_wave = np.zeros_like(qso_flux)
+        tmp_qso_flux = np.zeros([nqso, len(model.eigenwave)], dtype='f4')
+        tmp_qso_wave = np.zeros_like(tmp_qso_flux)
     else:
         log.info("Simulate {} QSOs with SIMQSO templates".format(nqso))
         tmp_qso_flux = np.zeros([nqso, len(model.basewave)], dtype='f4')
@@ -368,7 +368,7 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
     for these, issouth in zip( (north, south), (False, True) ):
         if len(these) > 0:
             _tmp_qso_flux, _tmp_qso_wave, _meta, _qsometa = model.make_templates(
-                nmodel=nqso, redshift=metadata['Z'], lyaforest=False, nocolorcuts=True,
+                nmodel=len(these), redshift=metadata['Z'][these], lyaforest=False, nocolorcuts=True,
                 noresample=True, seed=seed, south=issouth)
             meta[these] = _meta
             qsometa[these] = _qsometa

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -46,7 +46,6 @@ def parse(options=None):
     parser.add_argument('--moonsep', type=float, default=None, help="Moon separation to tile [degrees]")
     parser.add_argument('--seed', type=int, default=None, required = False, help="Global random seed (will be used to generate a seed per each file")
     parser.add_argument('--skyerr', type=float, default=0.0, help="Fractional sky subtraction error")
-    parser.add_argument('--norm-filter', type=str, default="decam2014-g", help="Broadband filter for normalization")
     parser.add_argument('--nmax', type=int, default=None, help="Max number of QSO per input file, for debugging")
     parser.add_argument('--downsampling', type=float, default=None,help="fractional random down-sampling (value between 0 and 1)")
     parser.add_argument('--zmin', type=float, default=0,help="Min redshift")
@@ -355,6 +354,8 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
         log.info("Simulate {} QSOs with QSO templates".format(nqso))
         # if we wanted to use noresample=True here, we would have to modify 
         # downstream code since each quasar would have a different wave grid
+        import pdb ; pdb.set_trace()
+        
         tmp_qso_flux, tmp_qso_wave, meta, qsometa = model.make_templates(
             nmodel=nqso, redshift=metadata['Z'], 
             lyaforest=False, nocolorcuts=True, noresample=False, seed = seed)
@@ -519,8 +520,6 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
         hdulist.writeto(zbest_filename, overwrite=True)
         hdulist.close() # see if this helps with memory issue
 
-    import pdb ; pdb.set_trace()
-
 def _func(arg) :
     """ Used for multiprocessing.Pool """
     return simulate_one_healpix(**arg)
@@ -563,11 +562,9 @@ def main(args=None):
     
     if args.no_simqso:
         log.info("Load QSO model")
-        #model=QSO(normfilter=args.norm_filter)
         model=QSO()
     else:
         log.info("Load SIMQSO model")
-        #model=SIMQSO(normfilter=args.norm_filter,nproc=1)
         model=SIMQSO(nproc=1)
     
     decam_and_wise_filters = None

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -379,8 +379,13 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
 
     log.info("Resample to transmission wavelength grid")
     qso_flux=np.zeros((tmp_qso_flux.shape[0],trans_wave.size))
-    for q in range(tmp_qso_flux.shape[0]) :
-        qso_flux[q]=np.interp(trans_wave,tmp_qso_wave,tmp_qso_flux[q])
+    if args.no_simqso:
+        for q in range(tmp_qso_flux.shape[0]) :
+            qso_flux[q]=np.interp(trans_wave,tmp_qso_wave[q],tmp_qso_flux[q])
+    else:
+        for q in range(tmp_qso_flux.shape[0]) :
+            qso_flux[q]=np.interp(trans_wave,tmp_qso_wave,tmp_qso_flux[q])
+        
     tmp_qso_flux = qso_flux
     tmp_qso_wave = trans_wave
 
@@ -390,7 +395,8 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
             log.info("Adding BALs with probability {}".format(args.balprob))
             # save current random state
             rnd_state = np.random.get_state() 
-            tmp_qso_flux,meta_bal=bal.insert_bals(tmp_qso_wave,tmp_qso_flux, metadata['Z'], balprob=args.balprob,seed=seed)
+            tmp_qso_flux,meta_bal=bal.insert_bals(tmp_qso_wave,tmp_qso_flux, metadata['Z'],
+                                                  balprob=args.balprob,seed=seed)
             # restore random state to get the same random numbers later 
             # as when we don't insert BALs
             np.random.set_state(rnd_state) 


### PR DESCRIPTION
This PR addresses #411 by restoring `quickquasars` to a functioning state and:
* Self-consistently handles "north" (BASS/MzLS) vs "south" (DECaLS) photometry and target selection;
* Properly handles the output of `templates.SIMQSO` and `templates.QSO` when `noresample=True`, thereby removing one interpolation step.

@andreufont @alxogm @julienguy please test and let me know if you find any problems.

Note that I did not change the code to write out any additional metadata---or the *truth* spectra---to the *zbest.fits* file.  I leave this up to you to implement so you can build the data model you need.  However, in case it's helpful, [here](https://github.com/desihub/desitarget/blob/master/py/desitarget/mock/build.py#L875-L897) is where we write out the *truth.fits* files in `desitarget/bin/select_mock_targets`.

Finally, I agree that some unit tests for `quickquasars` would be valuable, but I have not implemented any here.