### PR TITLE
adjust and update nebular emission lines in galaxy templates

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,6 +5,8 @@ desisim change log
 0.30.1 (unreleased)
 -------------------
 
+* Add and adjust the nebular emission line spectra added to galaxy templates
+  (`PR #424`_).  
 * Read and write `select_mock_targets` style `simspec` file (`PR #416`_). 
 * Restore `quickquasars` to a functioning state, after being broken in `PR #409`_ (`PR #413`_). 
 * Add optional `nside` and `overwrite` arguments to `wrap-newexp` and
@@ -16,6 +18,7 @@ desisim change log
 .. _`PR #412`: https://github.com/desihub/desisim/pull/412
 .. _`PR #413`: https://github.com/desihub/desisim/pull/413
 .. _`PR #416`: https://github.com/desihub/desisim/pull/416
+.. _`PR #424`: https://github.com/desihub/desisim/pull/424
 
 0.30.0 (2018-08-09)
 -------------------

--- a/py/desisim/data/forbidden_lines.ecsv
+++ b/py/desisim/data/forbidden_lines.ecsv
@@ -9,14 +9,25 @@
 #     wavelengths.  The ratio column is a dummy column needed by desisim.templates.
 # 
 #     The wavelengths are laboratory wavelengths in vacuum (Angstroms).
+#
+#     Additional lines: [OI] doublet, [SIII] doublet, [ArIII] doublet
+#     and MgII doublet added 2018 Sep 21.
 # 
 #     J. Moustakas, Siena, 2015 May 7'}
 name wave ratio
-[OIII]_5007  5008.239  2.8875
-[OIII]_4959  4960.295  1.0
- [NII]_6584  6585.277  2.93579
- [NII]_6548  6549.852  1.0 
- [SII]_6716  6718.294  1.3 
- [SII]_6731  6732.673  1.0 
- [OII]_3726  3727.092  0.73 
- [OII]_3729  3729.874  1.0 
+[OIII]_5007   5008.239  2.8875
+[OIII]_4959   4960.295  1.0
+ [NII]_6584   6585.277  2.93579
+ [NII]_6548   6549.852  1.0 
+ [SII]_6716   6718.294  1.3 
+ [SII]_6731   6732.673  1.0 
+ [OII]_3726   3727.092  0.73 
+ [OII]_3729   3729.874  1.0 
+ [OI]_6300    6302.046  3.03502
+ [OI]_6363    6365.535  1.0
+ [SIII]_9532  9533.2    2.4686
+ [SIII]_9069  9071.1    1.0
+ [ArIII]_7135 7137.77   4.16988
+ [ArIII]_7751 7753.19   1.0
+ MgII_2800a   2796.352  1.0
+ MgII_2800b   2803.530  1.0

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -127,8 +127,12 @@ class EMSpectrum(object):
 
         self.forbidmog = GaussianMixtureModel.load(forbidmogfile)
 
-        self.oiiidoublet = 2.8875
-        self.niidoublet = 2.93579
+        self.oiiidoublet = 2.8875   # [OIII] 5007/4959
+        self.niidoublet = 2.93579   # [NII] 6584/6548
+        self.oidoublet = 3.03502    # [OI] 6300/6363
+        self.siiidoublet = 2.4686   # [SIII] 9532/9069
+        self.ariiidoublet = 4.16988 # [ArIII] 7135/7751
+        self.mgiidoublet = 1.0      # MgII 2803/2796
 
     def spectrum(self, oiiihbeta=None, oiihbeta=None, niihbeta=None,
                  siihbeta=None, oiidoublet=0.73, siidoublet=1.3,
@@ -205,6 +209,15 @@ class EMSpectrum(object):
         is3726 = np.where(line['name'] == '[OII]_3726')[0]
         is3729 = np.where(line['name'] == '[OII]_3729')[0]
 
+        is6300 = np.where(line['name'] == '[OI]_6300')[0]
+        is6363 = np.where(line['name'] == '[OI]_6363')[0]
+        is9532 = np.where(line['name'] == '[SIII]_9532')[0]
+        is9069 = np.where(line['name'] == '[SIII]_9069')[0]
+        is7135 = np.where(line['name'] == '[ArIII]_7135')[0]
+        is7751 = np.where(line['name'] == '[ArIII]_7751')[0]
+        is2800a = np.where(line['name'] == 'MgII_2800a')[0]
+        is2800b = np.where(line['name'] == 'MgII_2800b')[0]
+
         # Draw from the MoGs for forbidden lines.
         if oiiihbeta is None or oiihbeta is None or niihbeta is None or siihbeta is None:
             oiiihbeta, oiihbeta, niihbeta, siihbeta = \
@@ -222,6 +235,24 @@ class EMSpectrum(object):
         line['ratio'][is6716] = 10**siihbeta # [SII]/Hbeta
         line['ratio'][is6731] = line['ratio'][is6716]/siidoublet
 
+        # Hack! For the following lines use constant ratios relative to H-beta--
+
+        # Normalize [OI]
+        line['ratio'][is6300] = 0.1 # [OI]6300/Hbeta
+        line['ratio'][is6363] = line['ratio'][is6300]/self.oidoublet 
+
+        # Normalize [SIII]
+        line['ratio'][is9532] = 0.75 # [SIII]9532/Hbeta
+        line['ratio'][is9069] = line['ratio'][is9532]/self.siiidoublet
+        
+        # Normalize [ArIII]
+        line['ratio'][is7135] = 0.04 # [ArIII]7135/Hbeta
+        line['ratio'][is7751] = line['ratio'][is7135]/self.ariiidoublet
+
+        # Normalize MgII
+        line['ratio'][is2800a] = 0.3 # MgII2796/Hbeta
+        line['ratio'][is2800a] = line['ratio'][is2800a]/self.mgiidoublet
+        
         ## Normalize [NeIII] 3869.
         #coeff = np.asarray([1.0876,-1.1647])
         #disp = 0.1 # dex


### PR DESCRIPTION
Addresses #417 by adjusting the emission-line spectra in the ELG and BGS templates to account for (in)consistencies relative to SDSS/BOSS stacks.

Specifically, I've added the [OI] 6300,6363, [SIII] 9069,9532, [ArIII] 7135,7751, and MgII 2803/2796 emission-line doublets.  The relative strengths of the forbidden doublets relative to one another is set by nebular physics, while the MgII doublet strength I've set to be unity.  

In addition, for simplicity I took the strength of the stronger line (in each doublet) relative to H-beta to be a (physically motivated) constant, which definitely leaves room for improvement.

I also added a minor speed-up in that only lines within the specified (output) spectral range are handled.

I'll merge once tests pass (although the template tests already pass on my laptop).