### PR TITLE
don't include MgII emission in galaxy templates by default

### DIFF
--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -423,7 +423,7 @@ class GALAXY(object):
 
         # Initialize the EMSpectrum object with the same wavelength array as
         # the "base" (continuum) templates so that we don't have to resample.
-         if self.normline is not None:
+        if self.normline is not None:
             if self.normline.upper() not in ('OII', 'HBETA'):
                 log.warning('Unrecognized normline input {}; setting to None.'.format(self.normline))
                 self.normline = None


### PR DESCRIPTION
At @londumas's request, this PR makes MgII narrow-line emission optional, rather than the default added in #417.  In detail, Mg II only occurs in a fraction of emission-line galaxies, and so its inclusion was causing some confusion with [OII] in low-redshift galaxies (a small fraction, but some fraction nonetheless).

Clearly there's more work to be done wrt optimizing the galaxy templates, but this is a pretty good baseline.

Also found a 6%+ speedup, which should help `select_mock_targets` when run over a large area.