### PR TITLE
Add feature to quickquasars

### DIFF
--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -5,6 +5,8 @@ import argparse
 import time
 
 import numpy as np
+from scipy.constants import speed_of_light
+from scipy.stats import cauchy
 from astropy.table import Table,Column
 import astropy.io.fits as pyfits
 import multiprocessing
@@ -27,6 +29,7 @@ from desimodel.io import load_pixweight
 from desimodel import footprint
 from speclite import filters
 from desitarget.cuts import isQSO_colors
+
 c = speed_of_light/1000. #- km/s
 
 
@@ -63,7 +66,7 @@ def parse(options=None):
 
     parser.add_argument('--sigma_kms_fog',type=float,default=150, help="Adds a gaussian error to the quasar redshift that simulate the fingers of god effect")
 
-        parser.add_argument('--sigma_kms_zfit',nargs='?',type=float,const=400,help="Adds a Lorentzian distributed shift to the quasar redshift, to simulate the redshift fitting step. E.g. --sigma_kms_zfit 200 will use a sigma value of 200 km/s. If a number is not specified the default is used.")
+    parser.add_argument('--sigma_kms_zfit',nargs='?',type=float,const=200,help="Adds a Lorentzian distributed shift to the quasar redshift, to simulate the redshift fitting step. E.g. --sigma_kms_zfit 200 will use a sigma value of 200 km/s. If a number is not specified the default is used.")
 
 
     parser.add_argument('--overwrite', action = "store_true" ,help="rerun if spectra exists (default is skip)")
@@ -645,7 +648,7 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
             ('BRICKNAME', (str,8))]
         zbest = Table(np.zeros(nqso, dtype=columns))
         zbest["CHI2"][:]      = 0.
-        zbest["Z"]            = metadata['Z']+dz_fog
+        zbest["Z"]            = metadata['Z']
         zbest["ZERR"][:]      = 0.
 
         if args.sigma_kms_zfit:
@@ -653,7 +656,7 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
            dz_fit=mod_cauchy(loc=0,scale=args.sigma_kms_zfit,size=nqso,cut=3000)*(1.+metadata['Z'])/c
            zbest["Z"]+=dz_fit
 
-         zbest["ZERR"][:]     = 0
+        zbest["ZERR"][:]     = 0
         zbest["ZWARN"][:]     = 0
         zbest["SPECTYPE"][:]  = "QSO"
         zbest["SUBTYPE"][:]   = ""

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -62,11 +62,11 @@ def parse(options=None):
     parser.add_argument('--dwave', type=float, default=0.2,help="Internal wavelength step (don't change this)")
     parser.add_argument('--nproc', type=int, default=1,help="number of processors to run faster")
 
-    parser.add_argument('--zbest', action = "store_true",help="add a zbest file per spectrum either with the truth redshift or adding some error (optionally use it with --sigma_kms_fog and/or --sigma_kms_zfit)")
+    parser.add_argument('--zbest', action = "store_true",help="add a zbest file per spectrum either with the truth redshift or adding some error (optionally use it with --sigma_kms_fog and/or --scale_kms_zfit)")
 
     parser.add_argument('--sigma_kms_fog',type=float,default=150, help="Adds a gaussian error to the quasar redshift that simulate the fingers of god effect")
 
-    parser.add_argument('--sigma_kms_zfit',nargs='?',type=float,const=200,help="Adds a Lorentzian distributed shift to the quasar redshift, to simulate the redshift fitting step. E.g. --sigma_kms_zfit 200 will use a sigma value of 200 km/s. If a number is not specified the default is used.")
+    parser.add_argument('--scale_kms_zfit',nargs='?',type=float,const=200,help="Adds a Lorentzian distributed shift to the quasar redshift, to simulate the redshift fitting step. E.g. --scale_kms_zfit 200 will use a scale parameter of 200 km/s . If a number is not specified the default is used.")
 
 
     parser.add_argument('--overwrite', action = "store_true" ,help="rerun if spectra exists (default is skip)")
@@ -650,9 +650,9 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
         zbest["Z"]            = metadata['Z']
         zbest["ZERR"][:]      = 0.
 
-        if args.sigma_kms_zfit:
-           log.info("Added zfit error with sigma {} to zbest".format(args.sigma_kms_zfit))
-           dz_fit=mod_cauchy(loc=0,scale=args.sigma_kms_zfit,size=nqso,cut=3000)*(1.+metadata['Z'])/c
+        if args.scale_kms_zfit:
+           log.info("Added zfit error with sigma {} to zbest".format(args.scale_kms_zfit))
+           dz_fit=mod_cauchy(loc=0,scale=args.scale_kms_zfit,size=nqso,cut=3000)*(1.+metadata['Z'])/c
            zbest["Z"]+=dz_fit
 
         zbest["ZERR"][:]     = 0
@@ -741,8 +741,8 @@ def main(args=None):
         footprint_healpix_nside=256 # same resolution as original map so we don't loose anything
         footprint_healpix_weight = load_pixweight(footprint_healpix_nside, pixmap=pixmap)
 
-    if args.sigma_kms_zfit and not args.zbest:
-       log.info("Setting --zbest to true as required by --sigma_kms_zfit")
+    if args.scale_kms_zfit and not args.zbest:
+       log.info("Setting --zbest to true as required by --scale_kms_zfit")
        args.zbest = True
 
     if args.balprob:

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -62,11 +62,11 @@ def parse(options=None):
     parser.add_argument('--dwave', type=float, default=0.2,help="Internal wavelength step (don't change this)")
     parser.add_argument('--nproc', type=int, default=1,help="number of processors to run faster")
 
-    parser.add_argument('--zbest', action = "store_true",help="add a zbest file per spectrum either with the truth redshift or adding some error (optionally use it with --sigma_kms_fog and/or --scale_kms_zfit)")
+    parser.add_argument('--zbest', action = "store_true",help="add a zbest file per spectrum either with the truth redshift or adding some error (optionally use it with --sigma_kms_fog and/or --gamma_kms_zfit)")
 
     parser.add_argument('--sigma_kms_fog',type=float,default=150, help="Adds a gaussian error to the quasar redshift that simulate the fingers of god effect")
 
-    parser.add_argument('--scale_kms_zfit',nargs='?',type=float,const=200,help="Adds a Lorentzian distributed shift to the quasar redshift, to simulate the redshift fitting step. E.g. --scale_kms_zfit 200 will use a scale parameter of 200 km/s . If a number is not specified the default is used.")
+    parser.add_argument('--gamma_kms_zfit',nargs='?',type=float,const=200,help="Adds a Lorentzian distributed shift to the quasar redshift, to simulate the redshift fitting step. E.g. --gamma_kms_zfit 200 will use a gamma parameter of 200 km/s . If a number is not specified the default is used.")
 
 
     parser.add_argument('--overwrite', action = "store_true" ,help="rerun if spectra exists (default is skip)")
@@ -650,9 +650,9 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
         zbest["Z"]            = metadata['Z']
         zbest["ZERR"][:]      = 0.
 
-        if args.scale_kms_zfit:
-           log.info("Added zfit error with sigma {} to zbest".format(args.scale_kms_zfit))
-           dz_fit=mod_cauchy(loc=0,scale=args.scale_kms_zfit,size=nqso,cut=3000)*(1.+metadata['Z'])/c
+        if args.gamma_kms_zfit:
+           log.info("Added zfit error with sigma {} to zbest".format(args.gamma_kms_zfit))
+           dz_fit=mod_cauchy(loc=0,scale=args.gamma_kms_zfit,size=nqso,cut=3000)*(1.+metadata['Z'])/c
            zbest["Z"]+=dz_fit
 
         zbest["ZERR"][:]     = 0
@@ -741,8 +741,8 @@ def main(args=None):
         footprint_healpix_nside=256 # same resolution as original map so we don't loose anything
         footprint_healpix_weight = load_pixweight(footprint_healpix_nside, pixmap=pixmap)
 
-    if args.scale_kms_zfit and not args.zbest:
-       log.info("Setting --zbest to true as required by --scale_kms_zfit")
+    if args.gamma_kms_zfit and not args.zbest:
+       log.info("Setting --zbest to true as required by --gamma_kms_zfit")
        args.zbest = True
 
     if args.balprob:

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -252,7 +252,6 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
     trans_wave, transmission, metadata, dla_info = read_lya_skewers(ifilename,read_dlas=(args.dla=='file'),add_metals=args.metals_from_file)
 
 ###ADD dz_fog before generate the continua
-
     Z_noFOG=np.copy(metadata['Z'])
     log.info("Add FOG to redshift with sigma {} to quasar redshift".format(args.sigma_kms_fog)) 
     dz_fog=(args.sigma_kms_fog/c)*(1.+metadata['Z'])*np.random.normal(0,1,len(metadata['Z']))    


### PR DESCRIPTION
This PR supersede #449 due to some confusing conflicts when merging with master branch. 

Summary of this PR:

Adds a random shift to the true redshift. This is to simulate as if we have run redrock to find the redshift from the spectra. This shift is now sampled from a modified Cauchy distribution instead of a Normal (as it was before), this is motivated by the distribution observed in Zarrouk et al 2018 (https://arxiv.org/pdf/1801.03062.pdf) See #441. L609
Right now we completely changed from normal to lorentzian distribution. If you think we should keep the option of a gaussian, we can add it as an option with two parameters.

Adds a shift to redshift according to table 4 of du Mas des Bourboux et al 2017 (https://arxiv.org/pdf/1708.02225.pdf) L571

Change the location for the addition of the FoG shift to the beginning of the simulation, so that it happens before generating the templates, see #447. L255