### PR TITLE
precompute colors for star and galaxy templates

### DIFF
--- a/bin/precompute-template-colors
+++ b/bin/precompute-template-colors
@@ -18,10 +18,7 @@ def get_zgrid():
     """Minimum, maximum, and redshift spacing.
 
     """
-    if False: # for testing
-        zmin, zmax, dz = 0.0, 0.5, 0.1
-    else:
-        zmin, zmax, dz = 0.0, 2.5, 0.25
+    zmin, zmax, dz = 0.0, 2.5, 0.05
     nz = np.round( (zmax - zmin) / dz ).astype('i2')
 
     return zmin, zmax, dz, nz
@@ -48,17 +45,14 @@ def zgrid_colors(objtype, zgrid=True, isstar=False):
 
     # Read the templates.
     flux, wave, meta = read_basis_templates(objtype)
-    #print('HACK!!!')
-    #flux = flux[:10, :]
-    #meta = meta[:10]
     nt = len(meta)
 
     # Redshift grid.
     if zgrid:
         zmin, zmax, dz, nz = get_zgrid()
         redshift = np.linspace(zmin, zmax, nz).astype('f4')
-        #print('Redshift grid: {}-{} with dz={} and nz={}'.format(
-        #    zmin, zmax, dz, nz))
+        print('Redshift grid: {}-{} with dz={} and nz={}'.format(
+            zmin, zmax, dz, nz))
 
     phot = Table()
     if zgrid:

--- a/bin/precompute-template-colors
+++ b/bin/precompute-template-colors
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+
+"""Pre-compute synthetic colors for DESI templates and add them to an HDU.
+
+Specifically: compute colors for ELG, BGS, and LRG on a uniform redshift grid
+and fixed colors for STAR and WD.  All other templates are skipped.  Also, for
+STAR we do not compute WISE colors because the templates do not extend red
+enough.
+
+"""
+import os, glob, pdb
+import shutil, warnings
+import numpy as np
+from astropy.io import fits
+from astropy.table import Table, Column
+
+def get_zgrid():
+    """Minimum, maximum, and redshift spacing.
+
+    """
+    if False: # for testing
+        zmin, zmax, dz = 0.0, 0.5, 0.1
+    else:
+        zmin, zmax, dz = 0.0, 2.5, 0.25
+    nz = np.round( (zmax - zmin) / dz ).astype('i2')
+
+    return zmin, zmax, dz, nz
+
+def get_filters(isstar=False):
+    """Get the filter curves."""
+    from speclite import filters
+
+    if isstar: # no WISE
+        return filters.load_filters('decam2014-*', 'BASS-*', 'MzLS-z',
+                                    'sdss2010-*')
+    else:
+        return filters.load_filters('decam2014-*', 'BASS-*', 'MzLS-z',
+                                    'sdss2010-*',
+                                    'wise2010-W1', 'wise2010-W2')
+
+def zgrid_colors(objtype, zgrid=True, isstar=False):
+    """Compute colors a galaxy template set on a fixed redshift grid.
+
+    """
+    from desisim.io import read_basis_templates
+
+    filt = get_filters(isstar=isstar)
+
+    # Read the templates.
+    flux, wave, meta = read_basis_templates(objtype)
+    #print('HACK!!!')
+    #flux = flux[:10, :]
+    #meta = meta[:10]
+    nt = len(meta)
+
+    # Redshift grid.
+    if zgrid:
+        zmin, zmax, dz, nz = get_zgrid()
+        redshift = np.linspace(zmin, zmax, nz).astype('f4')
+        #print('Redshift grid: {}-{} with dz={} and nz={}'.format(
+        #    zmin, zmax, dz, nz))
+
+    phot = Table()
+    if zgrid:
+        for name in filt.names:
+            colname = name.replace('-', '_').upper()
+            phot.add_column(Column(name=colname, data=np.zeros( (nt, nz) ).astype('f4')))
+
+        for iz, red in enumerate(redshift):
+            zwave = wave.astype('float') * (1 + red)
+            padflux, padzwave = filt.pad_spectrum(flux, zwave, method='edge')
+            
+            phot1 = filt.get_ab_maggies(padflux, padzwave, mask_invalid=False)
+            for name in phot1.colnames:
+                colname = name.replace('-', '_').upper()
+                phot[colname][:, iz] = phot1[name]
+
+    else:
+        for name in filt.names:
+            colname = name.replace('-', '_').upper()
+            phot.add_column(Column(name=colname, data=np.zeros(nt).astype('f4')))
+        
+        padflux, padwave = filt.pad_spectrum(flux, wave, method='edge')
+        phot1 = filt.get_ab_maggies(padflux, padwave, mask_invalid=False)
+        for name in phot1.colnames:
+            colname = name.replace('-', '_').upper()
+            phot[colname][:] = phot1[name]
+                
+    return phot
+
+def main():
+
+    olddir = os.getenv('DESI_BASIS_TEMPLATES')
+    oldver = os.path.basename(olddir)
+    print('Input directory: {}'.format(olddir))
+
+    newver = 'v' + str( (float(oldver[1:]) * 10 + 1) / 10 )
+    newdir = os.path.join( os.path.dirname(olddir), newver )
+    if not os.path.isdir(newdir):
+        os.makedirs(newdir, exist_ok=True)
+    print('Output directory: {}'.format(newdir))
+
+    obj2type = {'BGS': 'GALAXY',
+                'ELG': 'GALAXY',
+                'LRG': 'GALAXY',
+                'STAR': 'STAR',
+                'WD': 'STAR'}
+
+    alloldpathfits = glob.glob( os.path.join(olddir, '*.fits') )
+    for oldpathfits in sorted(alloldpathfits):
+
+        oldfits = os.path.basename(oldpathfits)
+        obj, word, ver = oldfits.split('_')
+
+        objtype = obj.upper()
+        oldver = ver[:4]
+
+        if objtype in obj2type.keys():
+            newver = 'v' + str( (float(oldver[1:]) * 10 + 1) / 10 )
+            newfits = '{}_{}_{}.fits'.format(obj, word, newver)
+
+            isstar = objtype == 'STAR'
+            zgrid = obj2type[objtype] == 'GALAXY'
+            phot = zgrid_colors(objtype, zgrid=zgrid, isstar=isstar)
+
+            hdu = fits.convenience.table_to_hdu(phot)
+            hdu.header['EXTNAME'] = 'DESI-COLORS'
+            hdu.header['BUNIT'] = 'maggies'
+            if zgrid:
+                zmin, zmax, dz, nz = get_zgrid()
+                hdu.header['NZ'] = nz
+                hdu.header['ZMIN'] = np.float('{:.4f}'.format(zmin))
+                hdu.header['ZMAX'] = np.float('{:.4f}'.format(zmax))
+                hdu.header['DZ'] = np.float(dz)
+        else:
+            newver = 'v' + str( (float(oldver[1:]) * 10 + 1) / 10 )
+            newfits = oldfits
+
+            hdu = None
+
+        newpathfits = os.path.join( newdir, newfits )
+        if os.path.isfile(newpathfits):
+            os.remove(newpathfits)
+
+        print('Writing {}'.format(newpathfits))
+        shutil.copy2(oldpathfits, newpathfits)
+
+        if hdu is not None:
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                with fits.open(newpathfits, mode='update') as fx:
+                    fx.append(hdu)
+                    fx.flush()
+                
+if __name__ == '__main__':
+    main()

--- a/bin/precompute-template-colors
+++ b/bin/precompute-template-colors
@@ -57,7 +57,7 @@ def zgrid_colors(objtype, zgrid=True, isstar=False):
     phot = Table()
     if zgrid:
         for name in filt.names:
-            colname = name.replace('-', '_').upper()
+            colname = 'SYNTH_{}'.format(name.replace('-', '_').upper())
             phot.add_column(Column(name=colname, data=np.zeros( (nt, nz) ).astype('f4')))
 
         for iz, red in enumerate(redshift):
@@ -66,18 +66,18 @@ def zgrid_colors(objtype, zgrid=True, isstar=False):
             
             phot1 = filt.get_ab_maggies(padflux, padzwave, mask_invalid=False)
             for name in phot1.colnames:
-                colname = name.replace('-', '_').upper()
+                colname = 'SYNTH_{}'.format(name.replace('-', '_').upper())
                 phot[colname][:, iz] = phot1[name]
 
     else:
         for name in filt.names:
-            colname = name.replace('-', '_').upper()
+            colname = 'SYNTH_{}'.format(name.replace('-', '_').upper())
             phot.add_column(Column(name=colname, data=np.zeros(nt).astype('f4')))
         
         padflux, padwave = filt.pad_spectrum(flux, wave, method='edge')
         phot1 = filt.get_ab_maggies(padflux, padwave, mask_invalid=False)
         for name in phot1.colnames:
-            colname = name.replace('-', '_').upper()
+            colname = 'SYNTH_{}'.format(name.replace('-', '_').upper())
             phot[colname][:] = phot1[name]
                 
     return phot

--- a/bin/precompute-template-colors
+++ b/bin/precompute-template-colors
@@ -35,8 +35,10 @@ def get_filters(isstar=False):
                                     'sdss2010-*',
                                     'wise2010-W1', 'wise2010-W2')
 
-def zgrid_colors(objtype, zgrid=True, isstar=False):
+def zgrid_colors(objtype, zgrid=True, isstar=False, rmag=20):
     """Compute colors a galaxy template set on a fixed redshift grid.
+
+    rmag - arbitrary normalization magnitude (in DECam-r).
 
     """
     from desisim.io import read_basis_templates
@@ -69,6 +71,12 @@ def zgrid_colors(objtype, zgrid=True, isstar=False):
                 colname = 'SYNTH_{}'.format(name.replace('-', '_').upper())
                 phot[colname][:, iz] = phot1[name]
 
+            # normalize to r=rmag
+            rnorm = 10**(-0.4 * (rmag - 22.5) ) / phot['SYNTH_DECAM2014_R'][:, iz].data
+            for name in phot1.colnames:
+                colname = 'SYNTH_{}'.format(name.replace('-', '_').upper())
+                phot[colname][:, iz] *= rnorm
+                
     else:
         for name in filt.names:
             colname = 'SYNTH_{}'.format(name.replace('-', '_').upper())
@@ -80,6 +88,12 @@ def zgrid_colors(objtype, zgrid=True, isstar=False):
             colname = 'SYNTH_{}'.format(name.replace('-', '_').upper())
             phot[colname][:] = phot1[name]
                 
+        # normalize to r=rmag
+        rnorm = 10**(-0.4 * (rmag - 22.5) ) / phot['SYNTH_DECAM2014_R'].data
+        for name in phot1.colnames:
+            colname = 'SYNTH_{}'.format(name.replace('-', '_').upper())
+            phot[colname][:] *= rnorm
+
     return phot
 
 def main():

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ desisim change log
 0.31.1 (unreleased)
 -------------------
 
-* No changes yet
+* Precompute colors for star and galaxy templates. (`PR #453`_).
+
+.. _`PR #453`: https://github.com/desihub/desisim/pull/453
 
 0.31.0 (2018-11-08)
 -------------------

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -995,6 +995,11 @@ def read_basis_templates(objtype, subtype='', outwave=None, nspec=None,
                 for ii, col in enumerate(hdr['COLORS'].split(',')):
                     meta[col.upper()] = colors[:, ii].flatten()
 
+            if 'DESI-COLORS' in fx:
+                colors = fx['DESI-COLORS'].data
+                for col in colors.names:
+                    meta[col.upper()] = colors[col]
+
         #- Check if we have correct version
         if objtype.upper() in ('ELG', 'LRG'):
             if 'BASS_G' not in meta.keys():

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -1476,15 +1476,15 @@ class SUPERSTAR(object):
 
                 restflux = baseflux[templateid, :]
 
-                # With radial velocity shifts, the >v3.0 templates do not go red
-                # enough to cover the full r-band spectral range, so pad here.
-                padflux, padzwave = normfilt[magfilter[ii]].pad_spectrum(restflux, zwave, method='edge')
-                
                 # Synthesize photometry to determine which models will pass the
-                # color-cuts.
+                # color-cuts.  Also, with radial velocity shifts, the >v3.0
+                # templates do not go red enough to cover the full r-band
+                # spectral range, so pad here.
                 if south:
+                    padflux, padzwave = self.decamwise.pad_spectrum(restflux, zwave, method='edge')
                     maggies = self.decamwise.get_ab_maggies(padflux, padzwave, mask_invalid=True)
                 else:
+                    padflux, padzwave = self.bassmzlswise.pad_spectrum(restflux, zwave, method='edge')
                     maggies = self.bassmzlswise.get_ab_maggies(padflux, padzwave, mask_invalid=True)
 
                 if 'W1-R' in self.basemeta.colnames: # new templates
@@ -1508,7 +1508,6 @@ class SUPERSTAR(object):
                     gflux, rflux, zflux, w1flux, w2flux = synthnano['BASS-g'], \
                       synthnano['BASS-r'], synthnano['MzLS-z'], \
                       synthnano['wise2010-W1'], synthnano['wise2010-W2']
-
 
                 if nocolorcuts or self.colorcuts_function is None:
                     colormask = np.repeat(1, nbasechunk)


### PR DESCRIPTION
Simple PR which adds a command-line script to compute colors for ELG, BGS, and LRG templates on a uniform redshift grid from `z=0-2.5` and fixed (rest-frame) colors for STAR and WD templates.  The results are written to a dedicated HDU named `DESI-COLORS` which is only read by `io.read_basis_templates` if present (in other words, the changes here are backwards-compatible).

Note that for STAR templates we do not compute WISE colors because the templates do not extend red enough, but this issues is handled elsewhere (e.g., in `templates.STAR.make_templates` and `desitarget.mock.mockmaker.STARMaker`).

For the record, the following filters are used: `decam2014-*`, `BASS-*`, `MzLS-z`, and `sdss2010-*`.

The new set of templates (with this HDU included) will be added in a separate PR after some additional testing.