### PR TITLE
Refactor S/N QA

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ desisim change log
 0.31.1 (unreleased)
 -------------------
 
-* No changes yet
+* Refactor S/N qa to load cframes only once (also updates OII for new TRUTH table)
 
 0.31.0 (2018-11-08)
 -------------------

--- a/py/desisim/scripts/qa_s2n.py
+++ b/py/desisim/scripts/qa_s2n.py
@@ -44,13 +44,10 @@ def main(args):
     # Grab nights
     nights = desispec.io.get_nights()
 
-    # Debugging
-    nights = [nights[0]]
 
     # Load all s2n (once)
     all_s2n_values = []
     channels = ['b', 'r', 'z']
-    channels = ['b'] # Debugging
     for channel in channels:
         print("Loading S/N for channel {}".format(channel))
         all_s2n_values.append(load_all_s2n_values(nights, channel))

--- a/py/desisim/scripts/qa_s2n.py
+++ b/py/desisim/scripts/qa_s2n.py
@@ -22,17 +22,18 @@ def parse(options=None):
     if options is None:
         args = parser.parse_args()
     else:
-        args = parser.parse_args(options)
+        args = parser.parse_args(namespace=options)
     return args
 
 def main(args):
     import os.path
     import numpy as np
-    import pdb
 
     import desispec.io
     from desiutil.log import get_logger
     from desisim.spec_qa.s2n import load_s2n_values, obj_s2n_wave, obj_s2n_z
+    from desisim.spec_qa.s2n import load_all_s2n_values
+    from desisim.spec_qa.s2n import parse_s2n_values
 
     # Initialize
     if args.qaprod_dir is not None:
@@ -43,8 +44,19 @@ def main(args):
     # Grab nights
     nights = desispec.io.get_nights()
 
+    # Debugging
+    nights = [nights[0]]
+
+    # Load all s2n (once)
+    all_s2n_values = []
+    channels = ['b', 'r', 'z']
+    channels = ['b'] # Debugging
+    for channel in channels:
+        print("Loading S/N for channel {}".format(channel))
+        all_s2n_values.append(load_all_s2n_values(nights, channel))
+
     # Loop on channel
-    for channel in ['b', 'r', 'z']:
+    for ss, channel in enumerate(channels):
         if channel == 'b':
             wv_bins = np.arange(3570., 5700., 20.)
         elif channel == 'r':
@@ -53,7 +65,7 @@ def main(args):
             wv_bins = np.arange(7500., 9800., 20.)
             z_bins = np.linspace(1.0, 1.6, 100) # z camera
         else:
-            pdb.set_trace()
+            raise IOError("Bad channel value: {}".format(channel))
         # Loop on OBJTYPE
         for objtype in ['ELG', 'LRG', 'QSO']:
             if objtype == 'ELG':
@@ -63,16 +75,17 @@ def main(args):
                 flux_bins = np.linspace(16., 22., 6)
             elif objtype == 'QSO':
                 flux_bins = np.linspace(15., 24., 6)
-            # Load
-            s2n_values = load_s2n_values(objtype, nights, channel)#, sub_exposures=exposures)
+            # Parse
+            fdict = all_s2n_values[ss]
+            s2n_dict = parse_s2n_values(objtype, fdict)
             # Plot
             outfile = qaprod_dir+'/QA_s2n_{:s}_{:s}.png'.format(objtype, channel)
             desispec.io.util.makepath(outfile)
-            obj_s2n_wave(s2n_values, wv_bins, flux_bins, objtype, outfile=outfile)
+            obj_s2n_wave(s2n_dict, wv_bins, flux_bins, objtype, outfile=outfile)
             # S/N vs. z for ELG
             if (channel == 'z') & (objtype=='ELG'):
                 outfile = qaprod_dir+'/QA_s2n_{:s}_{:s}_redshift.png'.format(objtype,channel)
                 desispec.io.util.makepath(outfile)
-                obj_s2n_z(s2n_values, z_bins, oii_bins, objtype, outfile=outfile)
+                obj_s2n_z(s2n_dict, z_bins, oii_bins, objtype, outfile=outfile)
 
 

--- a/py/desisim/spec_qa/s2n.py
+++ b/py/desisim/spec_qa/s2n.py
@@ -9,7 +9,7 @@ import matplotlib
 # matplotlib.use('Agg')
 
 import numpy as np
-import sys, os, pdb, glob
+import sys, os, glob
 
 from matplotlib import pyplot as plt
 import matplotlib.gridspec as gridspec
@@ -30,12 +30,12 @@ def load_all_s2n_values(nights, channel, sub_exposures=None):
 
     Args:
         nights: list
-        channel: str
+        channel: str  ('b','r','z')
         sub_exposures:
 
     Returns:
         fdict: dict
-          Contains S/N info
+          Contains all the S/N info for all nights in the given channel
 
     """
     fdict = dict(waves=[], s2n=[], fluxes=[], exptime=[], OII=[], objtype=[])
@@ -58,12 +58,14 @@ def load_all_s2n_values(nights, channel, sub_exposures=None):
             sps_tab = Table(sps_hdu['TRUTH'].data,masked=True)
 
             #- Get OIIFLUX from separate HDU and join
+            '''
             if 'TRUTH_ELG' in sps_hdu:
                 elg_truth = Table(sps_hdu['TRUTH_ELG'].data)
                 sps_tab = join(sps_tab, elg_truth['TARGETID', 'OIIFLUX'],
                           keys='TARGETID', join_type='left')
             else:
                 sps_tab['OIIFLUX'] = 0.0
+            '''
 
             sps_hdu.close()
             #objs = sps_tab['TEMPLATETYPE'] == objtype
@@ -97,6 +99,19 @@ def load_all_s2n_values(nights, channel, sub_exposures=None):
     return fdict
 
 def parse_s2n_values(objtype, fdict):
+    """
+    Parse the input set of S/N measurements on objtype
+
+    Args:
+        objtype: str
+        fdict: dict
+          Contains all the S/N info for all nights in a given channel
+
+    Returns:
+        pdict: dict
+          Contains all the S/N info for the given objtype
+
+    """
     pdict = dict(waves=[], s2n=[], fluxes=[], exptime=[], OII=[], objtype=[])
     # Loop on all the entries
     for ss, wave in enumerate(fdict['waves']):
@@ -151,12 +166,14 @@ def load_s2n_values(objtype, nights, channel, sub_exposures=None):
             sps_tab = Table(sps_hdu['TRUTH'].data,masked=True)
 
             #- Get OIIFLUX from separate HDU and join
+            '''
             if 'TRUTH_ELG' in sps_hdu:
                 elg_truth = Table(sps_hdu['TRUTH_ELG'].data)
                 sps_tab = join(sps_tab, elg_truth['TARGETID', 'OIIFLUX'],
                           keys='TARGETID', join_type='left')
             else:
                 sps_tab['OIIFLUX'] = 0.0
+            '''
 
             sps_hdu.close()
             objs = sps_tab['TEMPLATETYPE'] == objtype


### PR DESCRIPTION
Refactor `desi_qa_s2n` to perform all S/N calculations on all cframes (per channel)
before then parsing by objtype, etc.

Also updated for new Truth table.

Tested on mini 18.7.  Now runs in ~120s.

Addresses Issue #444 