### PR TITLE
use desisim-testdata 0.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ env:
         - SPECTER_VERSION=0.8.3
         - DESIMODEL_VERSION=0.9.6
         - DESIMODEL_DATA=branches/test-0.9.6
-        - DESISIM_TESTDATA_VERSION=master
+        - DESISIM_TESTDATA_VERSION=0.6.1
         - SPECSIM_VERSION=v0.12
         - DESISPEC_VERSION=0.26.0
         - DESITARGET_VERSION=0.25.0

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -15,6 +15,7 @@ desisim change log
 
 * Precompute colors for star and galaxy templates. (`PR #453`_).
 * Refactor S/N qa to load cframes only once (also updates OII for new TRUTH table) (`PR #459`_).
+* Use basis_templates v3.1 and matching desisim-testdata 0.6.1 (`PR #464`_).
 
 .. _`PR #450`: https://github.com/desihub/desisim/pull/450
 .. _`PR #452`: https://github.com/desihub/desisim/pull/452
@@ -23,6 +24,7 @@ desisim change log
 .. _`PR #455`: https://github.com/desihub/desisim/pull/455
 .. _`PR #457`: https://github.com/desihub/desisim/pull/457
 .. _`PR #459`: https://github.com/desihub/desisim/pull/459
+.. _`PR #464`: https://github.com/desihub/desisim/pull/464
 
 0.31.0 (2018-11-08)
 -------------------


### PR DESCRIPTION
Update travis testing to use desisim-testdata/0.6.1.  This version of the test data matches basis_templates v3.1; the etc/desisim.module file was updated directly in master to use that basis_templates version.

No code changes.