### PR TITLE
re-enable newer per-templatetype truth tables for QA

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -14,7 +14,7 @@ desisim change log
   * Fix quickquasars targetid truth (`PR #457`_).
 
 * Precompute colors for star and galaxy templates. (`PR #453`_).
-* Refactor S/N qa to load cframes only once (also updates OII for new TRUTH table) (`PR #459`_).
+* Refactor S/N qa to load cframes only once (also updates OII for new TRUTH table) (`PR #459`_, `PR #465`_).
 * Use basis_templates v3.1 and matching desisim-testdata 0.6.1 (`PR #464`_).
 
 .. _`PR #450`: https://github.com/desihub/desisim/pull/450
@@ -25,6 +25,7 @@ desisim change log
 .. _`PR #457`: https://github.com/desihub/desisim/pull/457
 .. _`PR #459`: https://github.com/desihub/desisim/pull/459
 .. _`PR #464`: https://github.com/desihub/desisim/pull/464
+.. _`PR #465`: https://github.com/desihub/desisim/pull/465
 
 0.31.0 (2018-11-08)
 -------------------

--- a/py/desisim/spec_qa/s2n.py
+++ b/py/desisim/spec_qa/s2n.py
@@ -58,14 +58,12 @@ def load_all_s2n_values(nights, channel, sub_exposures=None):
             sps_tab = Table(sps_hdu['TRUTH'].data,masked=True)
 
             #- Get OIIFLUX from separate HDU and join
-            '''
-            if 'TRUTH_ELG' in sps_hdu:
+            if ('OIIFLUX' not in sps_tab.colnames) and ('TRUTH_ELG' in sps_hdu):
                 elg_truth = Table(sps_hdu['TRUTH_ELG'].data)
                 sps_tab = join(sps_tab, elg_truth['TARGETID', 'OIIFLUX'],
                           keys='TARGETID', join_type='left')
             else:
                 sps_tab['OIIFLUX'] = 0.0
-            '''
 
             sps_hdu.close()
             #objs = sps_tab['TEMPLATETYPE'] == objtype
@@ -79,7 +77,7 @@ def load_all_s2n_values(nights, channel, sub_exposures=None):
                 try:
                     log.debug('Reading from {}'.format(cframe_path))
                     cframe = read_frame(cframe_path)
-                except:
+                except (IOError, OSError):
                     log.warn("Cannot find file: {:s}".format(cframe_path))
                     continue
                 # Calculate S/N per Ang
@@ -166,14 +164,12 @@ def load_s2n_values(objtype, nights, channel, sub_exposures=None):
             sps_tab = Table(sps_hdu['TRUTH'].data,masked=True)
 
             #- Get OIIFLUX from separate HDU and join
-            '''
-            if 'TRUTH_ELG' in sps_hdu:
+            if ('OIIFLUX' not in sps_tab.colnames) and ('TRUTH_ELG' in sps_hdu):
                 elg_truth = Table(sps_hdu['TRUTH_ELG'].data)
                 sps_tab = join(sps_tab, elg_truth['TARGETID', 'OIIFLUX'],
                           keys='TARGETID', join_type='left')
             else:
                 sps_tab['OIIFLUX'] = 0.0
-            '''
 
             sps_hdu.close()
             objs = sps_tab['TEMPLATETYPE'] == objtype
@@ -187,7 +183,7 @@ def load_s2n_values(objtype, nights, channel, sub_exposures=None):
                 try:
                     log.debug('Reading {} from {}'.format(objtype, cframe_path))
                     cframe = read_frame(cframe_path)
-                except:
+                except (IOError, OSError):
                     log.warn("Cannot find file: {:s}".format(cframe_path))
                     continue
                 # Calculate S/N per Ang


### PR DESCRIPTION
PR #459 made S/N QA much faster, but was tested on reference run 18.7 which used an older format of truth tables, and that PR commented out the code that let it work with the newer format.  This PR re-enables the QA to work on the newer truth tables that keep per templatetype specific columns (like OIIFLUX or LOGG) in separate HDUs.  It does this in a way that is also backwards compatible with the older format.

Tested on reference run 18.7 (old format) and a current run of master (new format).

Needed for the 18.12 integration test.