### PR TITLE
fixing bug with objmeta

### DIFF
--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -779,6 +779,8 @@ def get_mock_spectra(fiberassign, mockdir=None, nside=64):
         assert np.all(wave == tmpwave)
 
         for key in tmpobjmeta.keys():
+            if key not in objmeta:
+                objmeta[key] = list()
             objmeta[key].append(tmpobjmeta[key])
 
     #- Stack the per-objtype meta tables


### PR DESCRIPTION
The change suggested by @sbailey solves the issues with newexp-mock found in the minitest. 