### PR TITLE
Qquasar readmetal

### DIFF
--- a/py/desisim/lya_spectra.py
+++ b/py/desisim/lya_spectra.py
@@ -118,7 +118,7 @@ def read_lya_skewers(lyafile,indices=None,read_dlas=False,add_metals=False,add_l
         else:
             nolyb="No HDU with EXTNAME='F_LYB' in transmission file {}".format(lyafile)
             log.error(nolyb)
-            raise KeyError(nlyb) 
+            raise KeyError(nolyb) 
     
 
     if add_metals:
@@ -140,7 +140,7 @@ def read_lya_skewers(lyafile,indices=None,read_dlas=False,add_metals=False,add_l
           if add_metals=='all-dev':
              metal_list=['F_SI1260','F_SI1207','F_SI1193','F_SI1190']
           else:      
-             metal_list=['F_'+m for m in add_metals.split(' ')]    
+             metal_list=['F_'+m for m in add_metals.split(',')]    
      
           log.info('add {} metals from file'.format(metal_list))
           for metal in metal_list:
@@ -148,7 +148,7 @@ def read_lya_skewers(lyafile,indices=None,read_dlas=False,add_metals=False,add_l
                   metals = h[metal].read()
                   trans *= metals
               else:
-                  nom="No HDU with EXTNAME={} in transmission file {}".format(metal,lyafile)
+                  nom="No HDU with EXTNAME={} in transmission file {} ".format(metal,lyafile)
                   log.error(nom)
                   raise KeyError(nom)
 

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -102,7 +102,8 @@ def parse(options=None):
     parser.add_argument('--metals', type=str, default=None, required=False, help = "list of metals to get the\
         transmission from, if 'all' runs on all metals", nargs='*')
 
-    parser.add_argument('--metals-from-file', action = 'store_true', help = "add metals from HDU in file")
+    #parser.add_argument('--metals-from-file', action = 'store_true', help = "add metals from HDU in file")
+    parser.add_argument('--metals-from-file',type=str, const='old_fmt',help = "add metals from HDU in file",nargs='?') 
 
     parser.add_argument('--dla',type=str,required=False, help="Add DLA to simulated spectra either randonmly\
         (--dla random) or from transmision file (--dla file)")
@@ -296,6 +297,7 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
     # Read transmission from files. It might include DLA information, and it
     # might add metal transmission as well (from the HDU file).
     log.info("Read transmission file {}".format(ifilename))
+
     trans_wave, transmission, metadata, dla_info = read_lya_skewers(ifilename,read_dlas=(args.dla=='file'),add_metals=args.metals_from_file)
 
     ### Add Finger-of-God, before generate the continua
@@ -564,7 +566,7 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
     # if requested, compute metal transmission on the fly
     # (if not included already from the transmission file)
     if args.metals is not None:
-        if args.metals_from_file:
+        if args.metals_from_file :
             log.error('you cannot add metals twice')
             raise ValueError('you cannot add metals twice')
         if args.no_transmission:

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -104,7 +104,8 @@ def parse(options=None):
         transmission from, if 'all' runs on all metals", nargs='*')
 
     #parser.add_argument('--metals-from-file', action = 'store_true', help = "add metals from HDU in file")
-    parser.add_argument('--metals-from-file',type=str, const='all',help = "add metals from HDU in file",nargs='?') 
+    parser.add_argument('--metals-from-file',type=str,const='all',help = "list of metals,'SI1260,SI1207' etc, to get from HDUs in file. \
+Use 'all' or no argument for mock version < 7.3 or final metal runs. ",nargs='?') 
 
     parser.add_argument('--dla',type=str,required=False, help="Add DLA to simulated spectra either randonmly\
         (--dla random) or from transmision file (--dla file)")

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -98,12 +98,13 @@ def parse(options=None):
     parser.add_argument('--mags', action = "store_true", help="DEPRECATED; use --bbflux")
 
     parser.add_argument('--bbflux', action = "store_true", help="compute and write the QSO broad-band fluxes in the fibermap")
+    parser.add_argument('--add-LYB', action='store_true', help = "Add LYB absorption from transmision file")
 
     parser.add_argument('--metals', type=str, default=None, required=False, help = "list of metals to get the\
         transmission from, if 'all' runs on all metals", nargs='*')
 
     #parser.add_argument('--metals-from-file', action = 'store_true', help = "add metals from HDU in file")
-    parser.add_argument('--metals-from-file',type=str, const='old_fmt',help = "add metals from HDU in file",nargs='?') 
+    parser.add_argument('--metals-from-file',type=str, const='all',help = "add metals from HDU in file",nargs='?') 
 
     parser.add_argument('--dla',type=str,required=False, help="Add DLA to simulated spectra either randonmly\
         (--dla random) or from transmision file (--dla file)")
@@ -298,7 +299,7 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
     # might add metal transmission as well (from the HDU file).
     log.info("Read transmission file {}".format(ifilename))
 
-    trans_wave, transmission, metadata, dla_info = read_lya_skewers(ifilename,read_dlas=(args.dla=='file'),add_metals=args.metals_from_file)
+    trans_wave, transmission, metadata, dla_info = read_lya_skewers(ifilename,read_dlas=(args.dla=='file'),add_metals=args.metals_from_file,add_lyb=args.add_LYB)
 
     ### Add Finger-of-God, before generate the continua
     log.info("Add FOG to redshift with sigma {} to quasar redshift".format(args.sigma_kms_fog))


### PR DESCRIPTION
This PR allows to run quickquasars on the newest version of London mocks (>v7.3), which includes metal transmission in separate HDU's which is to be used for individual tunning of the metals. It is compatible with old format and with the final format once the metals are tunned individually. Optional argument names didn't change, only allows for a list of arguments instead of being a boolean argument. Works as follows:

--metals-from-file  all (default)   : Looks for "F_METALS" or "METALS" HDU in transmission file, to be used for old format or final format. 
--metals-from-file all-dev : Adds all the current metals added in the transmission files['F_SI1260','F_SI1207','F_SI1193','F_SI1190']    

--metals-from-file  SI1260 SI1207 : Adds only the specified metals if present in transmission file, rise an error otherwise... ( A comment here is that it would be easier to remember the sintaxis if we use the same notation  as in the --metals option... which for this example would be like --metals SII(1260), 'SII(1207') ) 

@andreufont I think this works and is not too messy. Maybe I can make it more compact in a function so that code is cleaner...  I've tested it only on small runs from the notebook. If you think is ok, then I can test it in a full run to make sure it don't crashes... or I can explore the config file option, but I don't think is needed... 