### PR TITLE
Default exposure types to be processed, added logs for skipped files.  if not done, do logic now applies to outdir reroute.

### DIFF
--- a/bin/wrap-fastframe
+++ b/bin/wrap-fastframe
@@ -15,6 +15,7 @@ parser.add_argument('--mpi', action='store_true', help="use MPI parallelism")
 parser.add_argument('--start', type=str, help="start date YEARMMDD")
 parser.add_argument('--stop', type=str, help="stop date YEARMMDD")
 parser.add_argument('--cframe',  action='store_true', help="directly write cframe")
+parser.add_argument('--exptypes', type=str, help="comma separated list of exposure types for processing", default='flat,science')
 args = parser.parse_args()
 
 #- Load MPI and establish communication
@@ -67,19 +68,37 @@ if rank == 0:
         night = os.path.basename(os.path.dirname(os.path.dirname(filename)))
         if (args.start <= night) & (night < args.stop):
             flavor = fits.getval(filename, 'FLAVOR')
+
             expid = fits.getval(filename, 'EXPID')
-            if flavor not in ('flat', 'science'):
+
+            if flavor not in tuple(args.exptypes.split(',')):
                 print('night {} expid {} is {}; skipping'.format(
                     night, expid, flavor))
+
+                logfile = filename.replace('simspec', 'fastframe').replace('.fits', '.log')
+
+                assert logfile != filename
+
+                if args.outdir:
+                  ##  If outdir provided, log files inherit /night/exposure structure of simspec files but in outdir.                                                                                          
+                  ##  Else placed in original dir. with simspecs.                                                                                                                                              
+
+                  logfile = logfile.replace(desisim.io.simdir(), args.outdir)
+                
+                os.makedirs(os.path.dirname(logfile), exist_ok=args.clobber)
+
+                with open(logfile, "w") as openfile:
+                    print('night {} expid {} is {}; skipping'.format(night, expid, flavor), file=openfile)
+
                 continue
 
             #- This precheck could get slow; consider caching differently
             done = True
             for camera in cameras:
                 if args.cframe :
-                    framefile = desispec.io.findfile('cframe', night, expid, camera)
+                    framefile = desispec.io.findfile('cframe', night, expid, camera, specprod_dir=args.outdir)
                 else :
-                    framefile = desispec.io.findfile('frame', night, expid, camera)
+                    framefile = desispec.io.findfile('frame', night, expid, camera, specprod_dir=args.outdir)
 
                 if args.clobber or not os.path.exists(framefile):
                     simspecfiles.append( (flavor, filename) )
@@ -130,7 +149,8 @@ if rank < len(simspecfiles):
                 ##  If outdir provided, log files inherit /night/exposure structure of simspec files but in outdir. 
                 ##  Else placed in original dir. with simspecs.
                 logfile = logfile.replace(desisim.io.simdir(), args.outdir)
-                os.makedirs(os.path.dirname(logfile), exist_ok=args.clobber)
+            
+            os.makedirs(os.path.dirname(logfile), exist_ok=args.clobber)
 
             #- Use subprocess.call instead of fastframe.main() to avoid
             #- potential memory leaks and separate logging; this does incur
@@ -168,4 +188,3 @@ if rank == 0:
 
 if comm is not None:
     MPI.Finalize()
-    


### PR DESCRIPTION
Added argument (with defaults) for exposure types to be processed; added logs for skipped exposures / arcs; further tweaks for clobber:  if not done, do now also applies to outdir aswell as simdir, as should be the case.