### PR TITLE
Fix bug when reading transmision files with hdu named F_METALS.

### DIFF
--- a/py/desisim/lya_spectra.py
+++ b/py/desisim/lya_spectra.py
@@ -128,14 +128,17 @@ def read_lya_skewers(lyafile,indices=None,read_dlas=False,add_metals=False,add_l
           if "F_METALS" in h:
               metals = h["F_METALS"].read()
               trans *= metals
+              log.info('Added F_Metals from file')
           #For format london v<7.3
-          if "METALS" in h :
+          elif "METALS" in h :
               metals = h["METALS"].read()
               trans *= metals
-          else :
+              log.info('Added Metals from file')
+          else:
               nom="No HDU with EXTNAME='METALS' or EXTNAME='F_METALS' in transmission file {}".format(lyafile)
               log.error(nom)
-              raise KeyError(nom)           
+              raise KeyError(nom)
+                     
        else: 
           if add_metals=='all-dev':
              metal_list=['F_SI1260','F_SI1207','F_SI1193','F_SI1190']

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -712,11 +712,15 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
     else:
         log.info('Z_noRSD field not present in transmission file. Z_NORSD not saved to truth file')
 
+    #Save global seed and pixel seed to primary header
+    hdr=pyfits.Header()
+    hdr['GSEED']=global_seed
+    hdr['PIXSEED']=seed
     hdu = pyfits.convenience.table_to_hdu(meta)
     hdu.header['EXTNAME'] = 'TRUTH'
     hduqso=pyfits.convenience.table_to_hdu(qsometa)
     hduqso.header['EXTNAME'] = 'QSO_META'
-    hdulist=pyfits.HDUList([pyfits.PrimaryHDU(),hdu,hduqso])
+    hdulist=pyfits.HDUList([pyfits.PrimaryHDU(header=hdr),hdu,hduqso])
     if args.dla:
         hdulist.append(hdu_dla)
     if args.balprob:


### PR DESCRIPTION
This PR fixes a bug found when trying to run quickquasar on the London mocks v8.0, and we are also using it to save global seed and pixel seed in the truth files. Output is as indicated below... 

```
test=fits.open("/project/projectdirs/desi/users/alxogm/desi/mocks/london/metals/v8.0.0/truth-16-0.fits")
test.info()
Filename: /project/projectdirs/desi/users/alxogm/desi/mocks/london/metals/v8.0.0/truth-16-0.fits
No.    Name      Ver    Type      Cards   Dimensions   Format
  0  PRIMARY       1 PrimaryHDU       6   ()      
  1  TRUTH         1 BinTableHDU     51   5R x 18C   [K, 10A, 10A, I, K, E, E, 15A, E, E, E, E, E, E, D, D, D, E]   
  2  QSO_META      1 BinTableHDU     21   5R x 5C   [K, E, 5E, 186E, I]   

test[0].header
[32]:
SIMPLE  =                    T / conforms to FITS standard                      
BITPIX  =                    8 / array data type                                
NAXIS   =                    0 / number of array dimensions                     
EXTEND  =                    T                                                  
GSEED   =                  123                                                  
PIXSEED =                 2866   
```