### PR TITLE
pixsim updates for SV and consistency with real data

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
         - ASTROPY_VERSION=2.0.8
         # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=1.9.15
-        - SPECLITE_VERSION=master
+        - SPECLITE_VERSION=0.8
         - SPECTER_VERSION=0.8.3
         - DESIMODEL_VERSION=0.9.6
         - DESIMODEL_DATA=branches/test-0.9.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,14 @@ env:
         - ASTROPY_VERSION=2.0.8
         # - SPHINX_VERSION=1.6.6
         - DESIUTIL_VERSION=1.9.15
-        - SPECLITE_VERSION=0.8
+        - SPECLITE_VERSION=master
         - SPECTER_VERSION=0.8.3
         - DESIMODEL_VERSION=0.9.6
         - DESIMODEL_DATA=branches/test-0.9.6
-        - DESISIM_TESTDATA_VERSION=0.6.1
+        - DESISIM_TESTDATA_VERSION=master
         - SPECSIM_VERSION=v0.12
-        - DESISPEC_VERSION=0.26.0
+        # - DESISPEC_VERSION=0.26.0
+        - DESISPEC_VERSION=master
         - DESITARGET_VERSION=0.29.1
         - SIMQSO_VERSION=v1.2.3
         - DESI_LOGLEVEL=DEBUG

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -704,7 +704,7 @@ def find_cosmics(camera, exptime=1000, cosmics_dir=None):
         exptime (int, optional): exposure time in seconds
         cosmics_dir (str, optional): directory to look for cosmics templates; defaults to
             $DESI_COSMICS_TEMPLATES if set or otherwise
-            $DESI_ROOT/spectro/templates/cosmics/v0.2  (note HARDCODED version)
+            $DESI_ROOT/spectro/templates/cosmics/v0.3  (note HARDCODED version)
 
     Exposure times <120 sec will use the bias templates; otherwise they will
     use the dark cosmics templates
@@ -713,7 +713,7 @@ def find_cosmics(camera, exptime=1000, cosmics_dir=None):
         if 'DESI_COSMICS_TEMPLATES' in os.environ:
             cosmics_dir = os.environ['DESI_COSMICS_TEMPLATES']
         else:
-            cosmics_dir = os.environ['DESI_ROOT']+'/spectro/templates/cosmics/v0.2/'
+            cosmics_dir = os.environ['DESI_ROOT']+'/spectro/templates/cosmics/v0.3/'
 
     if exptime < 120:
         exptype = 'bias'

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -806,29 +806,29 @@ def read_cosmics(filename, expid=1, shape=None, jitter=True):
 
     if 'RDNOISE0' in meta :
         del meta['RDNOISE0']
-    #- Amp 1 lower left
+    #- Amp A lower left
     nx = pix.shape[1] // 2
     ny = pix.shape[0] // 2
     iixy = np.s_[0:ny, 0:nx]
     cx = pix[iixy][mask[iixy] == 0]
     mean, median, std = sigma_clipped_stats(cx, sigma=3, iters=5)
-    meta['RDNOISE1'] = std
+    meta['RDNOISEA'] = std
 
-    #- Amp 2 lower right
+    #- Amp B lower right
     iixy = np.s_[0:ny, nx:2*nx]
     cx = pix[iixy][mask[iixy] == 0]
     mean, median, std = sigma_clipped_stats(cx, sigma=3, iters=5)
-    meta['RDNOISE2'] = std
+    meta['RDNOISEB'] = std
 
-    #- Amp 3 upper left
+    #- Amp C upper left
     iixy = np.s_[ny:2*ny, 0:nx]
     mean, median, std = sigma_clipped_stats(pix[iixy], sigma=3, iters=5)
-    meta['RDNOISE3'] = std
+    meta['RDNOISEC'] = std
 
-    #- Amp 4 upper right
+    #- Amp D upper right
     iixy = np.s_[ny:2*ny, nx:2*nx]
     mean, median, std = sigma_clipped_stats(pix[iixy], sigma=3, iters=5)
-    meta['RDNOISE4'] = std
+    meta['RDNOISED'] = std
     fx.close()
 
     return Image(pix, ivar, mask, meta=meta)

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -281,6 +281,7 @@ def simulate(camera, simspec, psf, nspec=None, ncpu=None,
                 rdnoiseC = cosmics.meta['OBSRDNC']
                 rdnoiseD = cosmics.meta['OBSRDND']
             except KeyError:  #- cosmics templates <= v0.2
+                print(cosmic.meta)
                 rdnoiseA = cosmics.meta['RDNOISE0']
                 rdnoiseB = cosmics.meta['RDNOISE1']
                 rdnoiseC = cosmics.meta['RDNOISE2']

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -299,6 +299,18 @@ def simulate(camera, simspec, psf, nspec=None, ncpu=None,
         else:
             noverscan = 50
 
+        #- Reproducibly random overscan bias level offsets across diff exp
+        assert channel in 'brz':
+        if channel == 'b':
+            irand = ispec
+        elif channel = 'r':
+            irand = 10 + ispec
+        elif channel = 'z':
+            irand = 20 + ispec
+
+        seeds = np.random.RandomState(0).randint(2**32-1, size=30)
+        rand = np.random.RandomState(seeds[irand])
+
         nyraw = ny
         nxraw = nx + nprescan + noverscan
         rawpix = np.empty( (nyraw*2, nxraw*2), dtype=np.int32 )
@@ -307,24 +319,28 @@ def simulate(camera, simspec, psf, nspec=None, ncpu=None,
         rawpix[0:nyraw, 0:nxraw] = \
             photpix2raw(pix[0:ny, 0:nx], gain, header['RDNOISE1'], 
                 readorder='lr', nprescan=nprescan, noverscan=noverscan,
+                offset=rand.uniform(100, 200),
                 noisydata=noisydata)
 
         #- Amp 2 Lower Right
         rawpix[0:nyraw, nxraw:nxraw+nxraw] = \
             photpix2raw(pix[0:ny, nx:nx+nx], gain, header['RDNOISE2'],
                 readorder='rl', nprescan=nprescan, noverscan=noverscan,
+                offset=rand.uniform(100, 200),
                 noisydata=noisydata)
 
         #- Amp 3 Upper Left
         rawpix[nyraw:nyraw+nyraw, 0:nxraw] = \
             photpix2raw(pix[ny:ny+ny, 0:nx], gain, header['RDNOISE3'],
                 readorder='lr', nprescan=nprescan, noverscan=noverscan,
+                offset=rand.uniform(100, 200),
                 noisydata=noisydata)
 
         #- Amp 4 Upper Right
         rawpix[nyraw:nyraw+nyraw, nxraw:nxraw+nxraw] = \
             photpix2raw(pix[ny:ny+ny, nx:nx+nx], gain, header['RDNOISE4'],
                 readorder='rl', nprescan=nprescan, noverscan=noverscan,
+                offset=rand.uniform(100, 200),
                 noisydata=noisydata)
 
         def xyslice2header(xyslice):

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -663,8 +663,10 @@ def get_nodes_per_exp(nnodes,nexposures,ncameras,user_nodes_per_comm_exp=None):
     #check if nframes is evenly divisible by nnodes
     nframes = ncameras*nexposures
     if nframes % nnodes !=0:
-        msg=("nframes {} must be evenly divisible by nnodes {}, try again".format(nframes, nnodes))
-        raise ValueError(msg)
+        ### msg=("nframes {} must be evenly divisible by nnodes {}, try again".format(nframes, nnodes))
+        ### raise ValueError(msg)
+        msg=("nframes {} is not evenly divisible by nnodes {}; packing will be inefficient".format(nframes, nnodes))
+        log.warning(msg)
     else:
         log.debug("nframes {} is evenly divisible by nnodes {}, check passed".format(nframes, nnodes))
     
@@ -694,8 +696,10 @@ def get_nodes_per_exp(nnodes,nexposures,ncameras,user_nodes_per_comm_exp=None):
             
     #finally check to make sure exposures*gcf/nnodes is an integer to avoid inefficient node use
     if (nexposures*nodes_per_comm_exp) % nnodes != 0:
-        msg=("nexposures {} * nodes_per_comm_exp {} does not divide evenly into nnodes {}, try again".format(nexposures, nodes_per_comm_exp, nnodes))
-        raise ValueError(msg)
+        ### msg=("nexposures {} * nodes_per_comm_exp {} does not divide evenly into nnodes {}, try again".format(nexposures, nodes_per_comm_exp, nnodes))
+        ### raise ValueError(msg)
+        msg=("nexposures {} * nodes_per_comm_exp {} does not divide evenly into nnodes {}; packing will be inefficient".format(nexposures, nodes_per_comm_exp, nnodes))
+        log.warning(msg)
     else:
         log.debug("nexposures {} * nodes_per_comm_exp {} divides evenly into nnodes {}, check passed".format(nexposures, nodes_per_comm_exp, nnodes))
         

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -446,7 +446,7 @@ def simulate(camera, simspec, psf, nspec=None, ncpu=None,
             image = desispec.preproc.preproc(rawpix, header, primary_header=simspec.header)
         else:
             log.debug('Skipping preprocessing')
-            image = Image(np.zeros(rawpix.shape), np.zeros(rawpix.shape), meta=header)
+            image = Image(np.zeros(truepix.shape), np.zeros(truepix.shape), meta=header)
 
     if (comm is None) or (comm.rank == 0):
         log.info('Finished pixsim.simulate for camera {} at {}'.format(camera,

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -119,6 +119,7 @@ def simulate_exposure(simspecfile, rawfile, cameras=None,
         #- rank must read it instead of rank 0 read + bcast
         channel = camera[0]
         if channel not in psfs:
+            log.info('Reading {} PSF at {}'.format(channel, asctime()))
             psfs[channel] = desimodel.io.load_psf(channel)
 
             #- Trim effective CCD size; mainly to limit memory for testing
@@ -132,10 +133,13 @@ def simulate_exposure(simspecfile, rawfile, cameras=None,
         if previous_channel != channel:
             if (addcosmics is True) and (node_rank == 0):
                 cosmics_file = io.find_cosmics(camera, simspec.header['EXPTIME'])
-                log.info('cosmics templates {}'.format(cosmics_file))
+                log.info('Reading cosmics templates {} at {}'.format(
+                    cosmics_file, asctime()))
                 shape = (psf.npix_y, psf.npix_x)
                 cosmics = io.read_cosmics(cosmics_file, expid, shape=shape)
             if (addcosmics is True) and (comm_node is not None):
+                if node_rank == 0:
+                    log.info('Broadcasting cosmics at {}'.format(asctime()))
                 cosmics = comm_node.bcast(cosmics, root=0)
             else:
                 log.debug("Cosmics not requested")
@@ -261,7 +265,7 @@ def simulate(camera, simspec, psf, nspec=None, ncpu=None,
         header['FEEVER'] = 'SIM'
         header['DETECTOR'] = 'SIM'
         gain = params['ccd'][channel]['gain']
-        for amp in ('1', '2', '3', '4'):
+        for amp in ('A', 'B', 'C', 'D'):
             header['GAIN'+amp] = gain
 
         #- Add cosmics from library of dark images
@@ -271,23 +275,17 @@ def simulate(camera, simspec, psf, nspec=None, ncpu=None,
             # set to zeros values with mask bit 0 (= dead column or hot pixels)
             cosmics_pix = cosmics.pix*((cosmics.mask&1)==0)
             pix = np.random.poisson(truepix) + cosmics_pix
-            header['RDNOISE1'] = cosmics.meta['RDNOISE1']
-            header['RDNOISE2'] = cosmics.meta['RDNOISE2']
-            header['RDNOISE3'] = cosmics.meta['RDNOISE3']
-            header['RDNOISE4'] = cosmics.meta['RDNOISE4']
+            header['RDNOISEA'] = cosmics.meta['RDNOISEA']
+            header['RDNOISEB'] = cosmics.meta['RDNOISEB']
+            header['RDNOISEC'] = cosmics.meta['RDNOISEC']
+            header['RDNOISED'] = cosmics.meta['RDNOISED']
         else:
             pix = truepix
             readnoise = params['ccd'][channel]['readnoise']
-            header['RDNOISE1'] = readnoise
-            header['RDNOISE2'] = readnoise
-            header['RDNOISE3'] = readnoise
-            header['RDNOISE4'] = readnoise
-
-        # if (comm is None) or (comm.rank == 0):
-        #     log.info('RDNOISE1 {}'.format(header['RDNOISE1']))
-        #     log.info('RDNOISE2 {}'.format(header['RDNOISE2']))
-        #     log.info('RDNOISE3 {}'.format(header['RDNOISE3']))
-        #     log.info('RDNOISE4 {}'.format(header['RDNOISE4']))
+            header['RDNOISEA'] = readnoise
+            header['RDNOISEB'] = readnoise
+            header['RDNOISEC'] = readnoise
+            header['RDNOISED'] = readnoise
 
         #- data already has noise if cosmics were added
         noisydata = (cosmics is not None)
@@ -300,12 +298,12 @@ def simulate(camera, simspec, psf, nspec=None, ncpu=None,
             noverscan = 50
 
         #- Reproducibly random overscan bias level offsets across diff exp
-        assert channel in 'brz':
+        assert channel in 'brz'
         if channel == 'b':
             irand = ispec
-        elif channel = 'r':
+        elif channel == 'r':
             irand = 10 + ispec
-        elif channel = 'z':
+        elif channel == 'z':
             irand = 20 + ispec
 
         seeds = np.random.RandomState(0).randint(2**32-1, size=30)
@@ -317,28 +315,28 @@ def simulate(camera, simspec, psf, nspec=None, ncpu=None,
 
         #- Amp 0 Lower Left
         rawpix[0:nyraw, 0:nxraw] = \
-            photpix2raw(pix[0:ny, 0:nx], gain, header['RDNOISE1'], 
+            photpix2raw(pix[0:ny, 0:nx], gain, header['RDNOISEA'], 
                 readorder='lr', nprescan=nprescan, noverscan=noverscan,
                 offset=rand.uniform(100, 200),
                 noisydata=noisydata)
 
         #- Amp 2 Lower Right
         rawpix[0:nyraw, nxraw:nxraw+nxraw] = \
-            photpix2raw(pix[0:ny, nx:nx+nx], gain, header['RDNOISE2'],
+            photpix2raw(pix[0:ny, nx:nx+nx], gain, header['RDNOISEB'],
                 readorder='rl', nprescan=nprescan, noverscan=noverscan,
                 offset=rand.uniform(100, 200),
                 noisydata=noisydata)
 
         #- Amp 3 Upper Left
         rawpix[nyraw:nyraw+nyraw, 0:nxraw] = \
-            photpix2raw(pix[ny:ny+ny, 0:nx], gain, header['RDNOISE3'],
+            photpix2raw(pix[ny:ny+ny, 0:nx], gain, header['RDNOISEC'],
                 readorder='lr', nprescan=nprescan, noverscan=noverscan,
                 offset=rand.uniform(100, 200),
                 noisydata=noisydata)
 
         #- Amp 4 Upper Right
         rawpix[nyraw:nyraw+nyraw, nxraw:nxraw+nxraw] = \
-            photpix2raw(pix[ny:ny+ny, nx:nx+nx], gain, header['RDNOISE4'],
+            photpix2raw(pix[ny:ny+ny, nx:nx+nx], gain, header['RDNOISED'],
                 readorder='rl', nprescan=nprescan, noverscan=noverscan,
                 offset=rand.uniform(100, 200),
                 noisydata=noisydata)
@@ -354,29 +352,29 @@ def simulate(camera, simspec, psf, nspec=None, ncpu=None,
                                            yy.start+1, yy.stop)
             return value
 
-        #- Amp order from DESI-1964
-        #-   3 4
-        #-   1 2
+        #- Amp order from DESI-1964 (previously 1-4 instead of A-D)
+        #-   C D
+        #-   A B
         xoffset = nprescan+nx+noverscan
-        header['PRESEC1']  = xyslice2header(np.s_[0:nyraw, 0:0+nprescan])
-        header['DATASEC1'] = xyslice2header(np.s_[0:nyraw, nprescan:nprescan+nx])
-        header['BIASSEC1'] = xyslice2header(np.s_[0:nyraw, nprescan+nx:nprescan+nx+noverscan])
-        header['CCDSEC1']  = xyslice2header(np.s_[0:ny, 0:nx])
+        header['PRESECA']  = xyslice2header(np.s_[0:nyraw, 0:0+nprescan])
+        header['DATASECA'] = xyslice2header(np.s_[0:nyraw, nprescan:nprescan+nx])
+        header['BIASSECA'] = xyslice2header(np.s_[0:nyraw, nprescan+nx:nprescan+nx+noverscan])
+        header['CCDSECA']  = xyslice2header(np.s_[0:ny, 0:nx])
 
-        header['PRESEC2']  = xyslice2header(np.s_[0:nyraw, xoffset+noverscan+nx:xoffset+noverscan+nx+nprescan])
-        header['DATASEC2'] = xyslice2header(np.s_[0:nyraw, xoffset+noverscan:xoffset+noverscan+nx])
-        header['BIASSEC2'] = xyslice2header(np.s_[0:nyraw, xoffset:xoffset+noverscan])
-        header['CCDSEC2']  = xyslice2header(np.s_[0:ny, nx:2*nx])
+        header['PRESECB']  = xyslice2header(np.s_[0:nyraw, xoffset+noverscan+nx:xoffset+noverscan+nx+nprescan])
+        header['DATASECB'] = xyslice2header(np.s_[0:nyraw, xoffset+noverscan:xoffset+noverscan+nx])
+        header['BIASSECB'] = xyslice2header(np.s_[0:nyraw, xoffset:xoffset+noverscan])
+        header['CCDSECB']  = xyslice2header(np.s_[0:ny, nx:2*nx])
 
-        header['PRESEC3']  = xyslice2header(np.s_[nyraw:2*nyraw, 0:0+nprescan])
-        header['DATASEC3'] = xyslice2header(np.s_[nyraw:2*nyraw, nprescan:nprescan+nx])
-        header['BIASSEC3'] = xyslice2header(np.s_[nyraw:2*nyraw, nprescan+nx:nprescan+nx+noverscan])
-        header['CCDSEC3']  = xyslice2header(np.s_[ny:2*ny, 0:nx])
+        header['PRESECC']  = xyslice2header(np.s_[nyraw:2*nyraw, 0:0+nprescan])
+        header['DATASECC'] = xyslice2header(np.s_[nyraw:2*nyraw, nprescan:nprescan+nx])
+        header['BIASSECC'] = xyslice2header(np.s_[nyraw:2*nyraw, nprescan+nx:nprescan+nx+noverscan])
+        header['CCDSECC']  = xyslice2header(np.s_[ny:2*ny, 0:nx])
 
-        header['PRESEC4']  = xyslice2header(np.s_[nyraw:2*nyraw, xoffset+noverscan+nx:xoffset+noverscan+nx+nprescan])
-        header['DATASEC4'] = xyslice2header(np.s_[nyraw:2*nyraw, xoffset+noverscan:xoffset+noverscan+nx])
-        header['BIASSEC4'] = xyslice2header(np.s_[nyraw:2*nyraw, xoffset:xoffset+noverscan])
-        header['CCDSEC4']  = xyslice2header(np.s_[ny:2*ny, nx:2*nx])
+        header['PRESECD']  = xyslice2header(np.s_[nyraw:2*nyraw, xoffset+noverscan+nx:xoffset+noverscan+nx+nprescan])
+        header['DATASECD'] = xyslice2header(np.s_[nyraw:2*nyraw, xoffset+noverscan:xoffset+noverscan+nx])
+        header['BIASSECD'] = xyslice2header(np.s_[nyraw:2*nyraw, xoffset:xoffset+noverscan])
+        header['CCDSECD']  = xyslice2header(np.s_[ny:2*ny, nx:2*nx])
 
         if preproc:
             log.debug('Running preprocessing at {}'.format(asctime()))

--- a/py/desisim/scripts/pixsim.py
+++ b/py/desisim/scripts/pixsim.py
@@ -88,7 +88,9 @@ def parse(options=None):
         help="Include debug log info")
     parser.add_argument("--overwrite", action="store_true", 
         help="Overwrite existing raw and simpix files")
-    parser.add_argument("--seed", type=int, help="random number seed")
+
+    #- Not yet supported so don't pretend it is
+    ### parser.add_argument("--seed", type=int, help="random number seed")
 
     parser.add_argument("--ncpu", type=int, 
         help="Number of cpu cores per thread to use", default=0)

--- a/py/desisim/test/test_io.py
+++ b/py/desisim/test/test_io.py
@@ -114,7 +114,7 @@ class TestIO(unittest.TestCase):
     def test_read_cosmics(self):
         #- hardcoded cosmics version
         infile = (os.environ['DESI_ROOT'] +
-            '/spectro/templates/cosmics/v0.2/cosmics-bias-r.fits')
+            '/spectro/templates/cosmics/v0.3/cosmics-bias-r.fits')
 
         shape = (10, 11)
         c1 = io.read_cosmics(infile, expid=0, shape=shape, jitter=True)

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -47,7 +47,7 @@ class TestPixsim(unittest.TestCase):
             os.environ[e] = cls.testEnv[e]
         if desi_templates_available:
             cls.cosmics = (os.environ['DESI_ROOT'] +
-                '/spectro/templates/cosmics/v0.2/cosmics-bias-r.fits')
+                '/spectro/templates/cosmics/v0.3/cosmics-bias-r.fits')
         else:
             cls.cosmics = None
 

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -152,7 +152,8 @@ class TestPixsim(unittest.TestCase):
         psf = desimodel.io.load_psf(camera[0])
         psf.npix_y, psf.npix_x = self.ccdshape
 
-        image, rawpix, truepix = pixsim.simulate(camera, simspec, psf, nspec=nspec)
+        image, rawpix, truepix = pixsim.simulate(camera, simspec, psf,
+            nspec=nspec, preproc=False)
 
         self.assertTrue(isinstance(image, desispec.image.Image))
         self.assertTrue(isinstance(rawpix, np.ndarray))

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -170,8 +170,9 @@ class TestPixsim(unittest.TestCase):
         self.assertEqual(pixsim.get_nodes_per_exp(17,3,17), 17)
         self.assertEqual(pixsim.get_nodes_per_exp(12,12,6), 6)
 
-        with self.assertRaises(ValueError):
-            pixsim.get_nodes_per_exp(34,3,17)   #- 3*17 % 34 != 0
+        #- Now prints warning but isn't an error
+        # with self.assertRaises(ValueError):
+        #     pixsim.get_nodes_per_exp(34,3,17)   #- 3*17 % 34 != 0
 
         #- TODO: add more failure cases
 

--- a/py/desisim/test/test_quickgen.py
+++ b/py/desisim/test/test_quickgen.py
@@ -81,7 +81,7 @@ class TestQuickgen(unittest.TestCase):
             os.environ[e] = cls.testEnv[e]
         if desi_templates_available:
             cls.cosmics = (os.environ['DESI_ROOT'] +
-                '/spectro/templates/cosmics/v0.2/cosmics-bias-r.fits')
+                '/spectro/templates/cosmics/v0.3/cosmics-bias-r.fits')
         else:
             cls.cosmics = None
 


### PR DESCRIPTION
This PR makes updates to the pixsim header keywords for consistency with real data, in preparation for Survey Validation.

  * Switches from CCD amp names 1-4 to amp names A-D (like real data)
    * Requires deishub/desispec#807 to be able to preproc these
  * Drops GAIN* keywords that ICS isn't planning to write into real data
    * $DESI_SPECTRO_CALIB tracks our gains instead in a more flexible way
  * Adds additional keywords to match real data.  Some are useful (e.g. "ST" = local sidereal time); others are amusingly mysterious (e.g. "VESSEL").
  * MJD -> MJD-OBS

Also, if pixsims MPI subcommunicators don't pack evenly into the nodes, it now prints a warning instead of raising an error.  This makes it easier to simulate a prime number of exposures without being super constrained on how many nodes you have to ask for.

Example pixsims generated with these are at NERSC in /global/cscratch1/sd/sjbailey/desi/svdc2019d/spectro/data, and have been processed with the desispec "sv" branch in PR desihub/desispec#807.

