### PR TITLE
Pin numpy version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ env:
         # The following versions are the 'default' for tests, unless
         # overidden underneath. They are defined here in order to save having
         # to repeat them for all configurations.
-        # - NUMPY_VERSION=1.10
+        - NUMPY_VERSION='<1.17'
         # - SCIPY_VERSION=0.16
         - ASTROPY_VERSION=2.0.8
         # - SPHINX_VERSION=1.6.6

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -31,8 +31,13 @@ from speclite import filters
 from desitarget.cuts import isQSO_colors
 from desiutil.dust import SFDMap, ext_odonnell
 
-c = speed_of_light/1000. #- km/s
-
+try:
+    c = speed_of_light/1000. #- km/s
+except TypeError:
+    #
+    # This can happen in documentation builds.
+    #
+    c = 299792458.0/1000.0
 
 def parse(options=None):
     parser=argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter,


### PR DESCRIPTION
After creating tag 0.33.0, tests were running with Numpy/1.17 and failing.  This sets the version to 1.16.

@sbailey, there are some other versions in the .travis.yml file that could use some freshening up.  Do you want to go ahead with that?