### PR TITLE
support mocks in dark/bright subdirs

### DIFF
--- a/bin/wrap-newexp
+++ b/bin/wrap-newexp
@@ -120,8 +120,10 @@ else:
 if comm is not None:
     todo = comm.bcast(todo, root=0)
 
-#- Proceed with simulating exposures, using all ranks
+#- Track failures from each rank, starting out optimistically
+failed = False
 
+#- Proceed with simulating exposures, using all ranks
 if rank == 0:
     print('{} MPI ranks processing {}/{} exposures'.format(size, len(todo), len(obs)))
 
@@ -168,6 +170,7 @@ if rank < len(todo):
                     print("SUCCESS: {} night {} expid {} took {:.1f} seconds".format(
                         cmd.split()[0], thisobs['NIGHT'], thisobs['EXPID'],  runtime))
                 else:
+                    failed = True
                     print('FAILED: night {} expid {}; see {}'.format(
                         thisobs['NIGHT'], thisobs['EXPID'], logfile))
 
@@ -179,7 +182,7 @@ if rank < len(todo):
             sys.stdout.flush()
 
 if comm is not None:
-    comm.barrier()
+    failed = comm.gather(failed, root=0)
 
 if rank == 0:
     import collections
@@ -188,6 +191,13 @@ if rank == 0:
     print('{:.1f} minutes for {} arc, {} flat, {} science exposures'.format(
         tottime/60, nflavor['arc'], nflavor['flat'], nflavor['science']
     ))
+    if np.any(failed):
+        print('Some ranks had failures')
 
 if comm is not None:
     MPI.Finalize()
+
+if np.any(failed):
+    sys.exit(1)
+else:
+    sys.exit(0)

--- a/py/desisim/scripts/newexp_mock.py
+++ b/py/desisim/scripts/newexp_mock.py
@@ -77,9 +77,18 @@ def main(args=None):
             args.nspec, len(fiberassign)))
         sys.exit(1)
 
-    log.info('Simulating night {} expid {} tile {}'.format(night, args.expid, tileid))
+    log.info('Simulating night {} expid {} tile {} {}'.format(
+        night, args.expid, tileid, program))
+
+    if program.lower() in ('bright', 'sv_bgs', 'sv_mws'):
+        mock_obscon = 'bright'
+    else:
+        mock_obscon = 'dark'  #- includes gray for mocks
+
     try:
-        flux, wave, meta, objmeta = get_mock_spectra(fiberassign, mockdir=args.mockdir, nside=args.nside)
+        flux, wave, meta, objmeta = get_mock_spectra(
+                fiberassign, mockdir=args.mockdir,
+                nside=args.nside, obscon=mock_obscon)
     except Exception as err:
         log.fatal('Failed expid {} fiberassign {} tile {}'.format(
             args.expid, args.fiberassign, tileid))

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -457,6 +457,7 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, redshift=Non
 
     #- Extract fiber locations from meta Table -> xy[nspec,2]
     assert np.all(fibermap['FIBER'] == fiberpos['FIBER'][0:nspec])
+
     if 'XFOCAL_DESIGN' in fibermap.dtype.names:
         xy = np.vstack([fibermap['XFOCAL_DESIGN'], fibermap['YFOCAL_DESIGN']]).T * u.mm
     elif 'X' in fibermap.dtype.names:
@@ -745,10 +746,15 @@ def testslit_fibermap():
 #- MOVE THESE TO desitarget.mocks.io (?)
 #-------------------------------------------------------------------------
 
-def get_mock_spectra(fiberassign, mockdir=None, nside=64):
+def get_mock_spectra(fiberassign, mockdir=None, nside=64, obscon=None):
     '''
     Args:
         fiberassign: table loaded from fiberassign tile file
+
+    Options:
+        mockdir (str): base directory under which files are found
+        nside (int): healpix nside for file directory grouping
+        obscon (str): (observing conditions) None/dark/bright extra dir level
 
     Returns (flux, wave, meta) tuple
     '''
@@ -772,7 +778,8 @@ def get_mock_spectra(fiberassign, mockdir=None, nside=64):
     ## TODO: check desi_mask.NO_TARGET once that bit exists
 
     for truthfile, targetids in zip(*targets2truthfiles(
-                        fiberassign[~unassigned], basedir=mockdir, nside=nside)):
+                        fiberassign[~unassigned], basedir=mockdir, nside=nside,
+                        obscon=obscon)):
 
         #- Sky fibers aren't in the truth files
         ok = ~np.in1d(targetids, skyids)
@@ -897,13 +904,17 @@ def read_mock_spectra(truthfile, targetids, mockdir=None):
 
     return reordered_flux, wave, reordered_truth, objtruth
 
-def targets2truthfiles(targets, basedir, nside=64):
+def targets2truthfiles(targets, basedir, nside=64, obscon=None):
     '''
     Return list of mock truth files that contain these targets
 
     Args:
         targets: table with TARGETID column, e.g. from fiber assignment
         basedir: base directory under which files are found
+
+    Options:
+        nside (int): healpix nside for file directory grouping
+        obscon (str): (observing conditions) None/dark/bright extra dir level
 
     Returns (truthfiles, targetids):
         truthfiles: list of truth filenames
@@ -926,7 +937,8 @@ def targets2truthfiles(targets, basedir, nside=64):
     truthfiles = list()
     targetids = list()
     for ipix in sorted(np.unique(pixels)):
-        filename = mockio.findfile('truth', nside, ipix, basedir=basedir)
+        filename = mockio.findfile('truth', nside, ipix,
+                                   basedir=basedir, obscon=obscon)
         truthfiles.append(filename)
         ii = (pixels == ipix)
         targetids.append(np.asarray(targets['TARGETID'][ii]))


### PR DESCRIPTION
This PR updates desisim newexp-mock to support the updates in desihub/desitarget#543 to split the mocks into separate dark/bright directories, just like the target and MTL files for real data are split.

In particular it uses the PROGRAM of a tile to propagate `obscon` to `get_mock_spectra` which passes it to `desitarget.mock.io.findfile`.  The mapping of PROGRAM to obscon is a bit fragile.

This has been tested with the minitest notebook (along with desihub/desitarget#543 and desihub/fiberassign#223).