### PR TITLE
update to v3.2 basis templates

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ desisim change log
 0.34.1 (unreleased)
 -------------------
 
-* No changes yet.
+* Update `desisim.module` to use latest `v3.2` basis templates (`PR #513`_). 
+
+.. _`PR #513`: https://github.com/desihub/desisim/pull/513
+
 
 0.34.0 (2019-10-17)
 -------------------

--- a/etc/desisim.module
+++ b/etc/desisim.module
@@ -78,6 +78,5 @@ setenv [string toupper $product] $PRODUCT_DIR
 #
 # Add any non-standard Module code below this point.
 #
-setenv DESI_BASIS_TEMPLATES $env(DESI_ROOT)/spectro/templates/basis_templates/v3.1
-
+setenv DESI_BASIS_TEMPLATES $env(DESI_ROOT)/spectro/templates/basis_templates/v3.2
 


### PR DESCRIPTION
In this PR I update `desisim.module` to use the `v3.2` basis templates, which are identical to `v3.1` except for the BAL templates, which were updated from `v2.1` to `v3.0` (see #504 and #509)--
  https://desi.lbl.gov/svn/data/basis_templates/tags/v3.2/

@jfarr03 @paulmartini let's hold off on merging this PR until the `19.9` software release is out.

At that point, @sbailey, you'll also need do some magical incantation at NERSC to use these updated basis templates and we'll also need to update the instructions on the wiki:
* https://desi.lbl.gov/trac/wiki/Pipeline/GettingStarted/Laptop#SimulatingDESIdata
* https://desi.lbl.gov/trac/wiki/Pipeline/GettingStarted/Laptop#Defineinputtemplatelocations

@paulmartini @jfarr03 any tests of `quickquasars` using these templates (which you can do by pointing your `DESI_BASIS_TEMPLATES` environment variable to `/global/projecta/projectdirs/desi/spectro/templates/basis_templates/v3.2`) is much appreciated.

In particular, note that we only read a subset of the available columns into the metadata table returned by `desisim.io.read_basis_templates`, although you may want additional columns returned--
https://github.com/desihub/desisim/blob/master/py/desisim/io.py#L980-L981