### PR TITLE
new fiberassign file names for newexp

### DIFF
--- a/py/desisim/scripts/newexp_mock.py
+++ b/py/desisim/scripts/newexp_mock.py
@@ -58,10 +58,10 @@ def main(args=None):
 
     if os.path.isdir(args.fiberassign):
         #- TODO: move file location logic to desispec / desitarget / fiberassign
-        args.fiberassign = os.path.join(args.fiberassign, 'tile-{:06d}.fits'.format(tileid))
+        args.fiberassign = os.path.join(args.fiberassign, 'fiberassign-{:06d}.fits'.format(tileid))
         if not os.path.exists(args.fiberassign):
             #- try previous name
-            args.fiberassign = os.path.join(os.path.dirname(args.fiberassign), 'tile_{:06d}.fits'.format(tileid))
+            args.fiberassign = os.path.join(os.path.dirname(args.fiberassign), 'tile-{:06d}.fits'.format(tileid))
 
     fiberassign = astropy.table.Table.read(args.fiberassign, 'FIBERASSIGN')
 


### PR DESCRIPTION
Small change to newexp_mock.py to look for new fiberassign file names (fiberassign-EXPID.fits), while falling back to looking for old fiberassign file names (tile-EXPID.fits), while deprecating the really old fiberassign file names (tile_EXPID.fits).  Maybe we're done renaming those files now that we're using them on sky...

I plan to self-merge this once tests pass.  This is needed for integration tests.