### PR TITLE
[WIP] Add freeze_iers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ env:
         # - DESIMODEL_DATA=branches/test-0.9.6
         - DESISIM_TESTDATA_VERSION=master
         - SPECSIM_VERSION=v0.12
+        - DESISURVEY_VERSION=0.12.1
         # - DESISPEC_VERSION=0.26.0
         - DESISPEC_VERSION=master
         - DESITARGET_VERSION=master
@@ -78,7 +79,7 @@ env:
         # These pip packages need to be installed in a certain order, so we
         # do that separately from the astropy/ci-helpers scripts.
         - DESIHUB_PIP_DEPENDENCIES="desiutil=${DESIUTIL_VERSION}"
-        - DESIHUB_PIP_ALL_DEPENDENCIES="desiutil=${DESIUTIL_VERSION} desimodel=${DESIMODEL_VERSION} specter=${SPECTER_VERSION} desispec=${DESISPEC_VERSION} desitarget=${DESITARGET_VERSION} specsim=${SPECSIM_VERSION}"
+        - DESIHUB_PIP_ALL_DEPENDENCIES="desiutil=${DESIUTIL_VERSION} desimodel=${DESIMODEL_VERSION} specter=${SPECTER_VERSION} desispec=${DESISPEC_VERSION} desitarget=${DESITARGET_VERSION} specsim=${SPECSIM_VERSION} desisurvey=${DESISURVEY_VERSION}"
         # Debug the Travis install process.
         - DEBUG=False
     matrix:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -134,7 +134,7 @@ napoleon_include_private_with_doc = True
 # some external dependencies are not met at build time and break the
 # building process.
 autodoc_mock_imports = []
-for missing in ('astropy', 'desimodel', 'desiutil', 'desispec', 'desitarget', 'fitsio',
+for missing in ('astropy', 'desimodel', 'desiutil', 'desispec', 'desisurvey', 'desitarget', 'fitsio',
                 'healpy', 'matplotlib', 'numpy', 'scipy', 'speclite', 'specsim', 'yaml'):
     try:
         foo = import_module(missing)

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -14,7 +14,6 @@ import random
 from time import asctime
 import socket
 
-from astropy.time import Time
 import astropy.units as u
 
 import numpy as np
@@ -29,9 +28,12 @@ from desiutil.log import get_logger
 log = get_logger()
 
 # Inhibit download of IERS-A catalog, even from a good server.
-# Note that this is triggered by a call to astropy.time.Time().sidereal_time().
+# Note that this is triggered by a call to astropy.time.Time(),
+# which is subsequently used to compute sidereal_time().
+# It's the initialization of astropy.time.Time() itself that makes the call.
 from desisurvey.utils import freeze_iers
 freeze_iers()
+from astropy.time import Time
 
 def simulate_exposure(simspecfile, rawfile, cameras=None,
         ccdshape=None, simpixfile=None, addcosmics=None, comm=None,

--- a/py/desisim/scripts/newarc.py
+++ b/py/desisim/scripts/newarc.py
@@ -7,6 +7,9 @@ import warnings
 
 import numpy as np
 import astropy.table
+# See pixsim.py
+from desisurvey.utils import freeze_iers
+freeze_iers()
 import astropy.time
 from astropy.io import fits
 import astropy.units as u
@@ -64,19 +67,19 @@ def parse(options=None):
 def main(args=None):
     '''
     TODO: document
-    
+
     Note: this bypasses specsim since we don't have an arclamp model in
     surface brightness units; we only have electrons on the CCD
     '''
     import desiutil.log
     log = desiutil.log.get_logger()
-    
+
     if isinstance(args, (list, tuple, type(None))):
         args = parse(args)
-    
+
     log.info('reading arc data from {}'.format(args.arcfile))
     arcdata = astropy.table.Table.read(args.arcfile)
-    
+
     wave, phot, fibermap = \
         desisim.simexp.simarc(arcdata, nspec=args.nspec, nonuniform=args.nonuniform)
 

--- a/py/desisim/scripts/newflat.py
+++ b/py/desisim/scripts/newflat.py
@@ -7,6 +7,9 @@ import warnings
 
 import numpy as np
 import astropy.table
+# See pixsim.py
+from desisurvey.utils import freeze_iers
+freeze_iers()
 import astropy.time
 from astropy.io import fits
 import astropy.units as u
@@ -97,6 +100,3 @@ def main(args=None):
     #- metadata truth and obs dictionary are None
     desisim.io.write_simspec(sim, None, fibermap, None, args.expid, args.night,
         filename=args.simspec, header=header, overwrite=args.clobber)
-
-
-

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -8,6 +8,9 @@ import datetime, time
 import numpy as np
 
 import astropy.table
+# See pixsim.py
+from desisurvey.utils import freeze_iers
+freeze_iers()
 import astropy.time
 from astropy.io import fits
 import fitsio
@@ -853,10 +856,10 @@ def read_mock_spectra(truthfile, targetids, mockdir=None):
 
         if 'OBJTYPE' in truth.dtype.names:
             # output of desisim.obs.new_exposure
-            objtype = [oo.decode('ascii').strip().upper() for oo in truth['OBJTYPE']] 
+            objtype = [oo.decode('ascii').strip().upper() for oo in truth['OBJTYPE']]
         else:
             # output of desitarget.mock.build.write_targets_truth
-            objtype = [oo.decode('ascii').strip().upper() for oo in truth['TEMPLATETYPE']] 
+            objtype = [oo.decode('ascii').strip().upper() for oo in truth['TEMPLATETYPE']]
         for obj in set(objtype):
             extname = 'TRUTH_{}'.format(obj)
             if extname in fx:

--- a/py/desisim/util.py
+++ b/py/desisim/util.py
@@ -85,6 +85,9 @@ def dateobs2night(dateobs):
     TODO: consider adding format option to pass to astropy.time.Time without
         otherwise questioning the dateobs format
     '''
+    # See pixsim.py
+    from desisurvey.utils import freeze_iers
+    freeze_iers()
     import astropy.time
     import datetime
     if isinstance(dateobs, float):


### PR DESCRIPTION
This PR adds `freeze_iers()` calls where needed to prevent downloads of the IERS-A table.  At this point, I have updated pixsim.py, such that it can run to completion during integration tests, but the logging output from the integration test indicates that there are other modules or executables that are attempting the download, possibly `newexp-random`.

Do not merge until the additional download attempts are isolated.