### PR TITLE
use desiutil.iers.freeze_iers instead of desisurvey.utils.freeze_iers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ env:
         # - SCIPY_VERSION=0.16
         - ASTROPY_VERSION=2.0.16
         # - SPHINX_VERSION=1.6.6
-        - DESIUTIL_VERSION=2.0.1
+        - DESIUTIL_VERSION=2.0.3
         - SPECLITE_VERSION=0.8
         - SPECTER_VERSION=0.8.3
         - DESIMODEL_VERSION=0.10.2

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -31,7 +31,7 @@ log = get_logger()
 # Note that this is triggered by a call to astropy.time.Time(),
 # which is subsequently used to compute sidereal_time().
 # It's the initialization of astropy.time.Time() itself that makes the call.
-from desisurvey.utils import freeze_iers
+from desiutil.iers import freeze_iers
 freeze_iers()
 from astropy.time import Time
 

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -32,7 +32,6 @@ log = get_logger()
 # which is subsequently used to compute sidereal_time().
 # It's the initialization of astropy.time.Time() itself that makes the call.
 from desiutil.iers import freeze_iers
-freeze_iers()
 from astropy.time import Time
 
 def simulate_exposure(simspecfile, rawfile, cameras=None,
@@ -214,6 +213,7 @@ def simulate(camera, simspec, psf, nspec=None, ncpu=None,
             of truth for image.pix
     """
 
+    freeze_iers()
     if (comm is None) or (comm.rank == 0):
         log.info('Starting pixsim.simulate camera {} at {}'.format(camera,
             asctime()))

--- a/py/desisim/scripts/newarc.py
+++ b/py/desisim/scripts/newarc.py
@@ -8,8 +8,6 @@ import warnings
 import numpy as np
 import astropy.table
 # See pixsim.py
-from desiutil.iers import freeze_iers
-freeze_iers()
 import astropy.time
 from astropy.io import fits
 import astropy.units as u
@@ -73,6 +71,9 @@ def main(args=None):
     '''
     import desiutil.log
     log = desiutil.log.get_logger()
+
+    from desiutil.iers import freeze_iers
+    freeze_iers()
 
     if isinstance(args, (list, tuple, type(None))):
         args = parse(args)

--- a/py/desisim/scripts/newarc.py
+++ b/py/desisim/scripts/newarc.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 import astropy.table
 # See pixsim.py
-from desisurvey.utils import freeze_iers
+from desiutil.iers import freeze_iers
 freeze_iers()
 import astropy.time
 from astropy.io import fits

--- a/py/desisim/scripts/newflat.py
+++ b/py/desisim/scripts/newflat.py
@@ -8,8 +8,6 @@ import warnings
 import numpy as np
 import astropy.table
 # See pixsim.py
-from desiutil.iers import freeze_iers
-freeze_iers()
 import astropy.time
 from astropy.io import fits
 import astropy.units as u
@@ -70,6 +68,9 @@ def main(args=None):
     '''
     import desiutil.log
     log = desiutil.log.get_logger()
+
+    from desiutil.iers import freeze_iers
+    freeze_iers()
 
     if isinstance(args, (list, tuple, type(None))):
         args = parse(args)

--- a/py/desisim/scripts/newflat.py
+++ b/py/desisim/scripts/newflat.py
@@ -8,7 +8,7 @@ import warnings
 import numpy as np
 import astropy.table
 # See pixsim.py
-from desisurvey.utils import freeze_iers
+from desiutil.iers import freeze_iers
 freeze_iers()
 import astropy.time
 from astropy.io import fits

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -9,7 +9,7 @@ import numpy as np
 
 import astropy.table
 # See pixsim.py
-from desisurvey.utils import freeze_iers
+from desiutil.iers import freeze_iers
 freeze_iers()
 import astropy.time
 from astropy.io import fits

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -9,8 +9,6 @@ import numpy as np
 
 import astropy.table
 # See pixsim.py
-from desiutil.iers import freeze_iers
-freeze_iers()
 import astropy.time
 from astropy.io import fits
 import fitsio
@@ -395,6 +393,9 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, redshift=Non
 
     from desiutil.log import get_logger
     log = get_logger('DEBUG')
+
+    from desiutil.iers import freeze_iers
+    freeze_iers()
 
     # Input cosmology to calculate the angular diameter distance of the galaxy's redshift
     from astropy.cosmology import FlatLambdaCDM

--- a/py/desisim/util.py
+++ b/py/desisim/util.py
@@ -86,7 +86,7 @@ def dateobs2night(dateobs):
         otherwise questioning the dateobs format
     '''
     # See pixsim.py
-    from desisurvey.utils import freeze_iers
+    from desiutil.iers import freeze_iers
     freeze_iers()
     import astropy.time
     import datetime


### PR DESCRIPTION
This PR replaces desisurvey.utils.freeze_iers with desiutil.iers.freeze_iers to remove the desisurvey dependency in desisim and get a version of freeze_iers that works with astropy 3.x and 4.x.

Requires desiutil >= 2.0.3 .

Intended for software release 20.4, with tags to be made this afternoon (i.e. comment quickly if you have concerns).