### PR TITLE
new keyword in quickcat to indicate which HDU to read in fba files

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,11 +5,13 @@ desisim change log
 0.35.2 (unreleased)
 -------------------
 
+* New keyword in quickcat to indicate which HDU to read in fba files (`PR #538`_)
 * Fix sky level Travis test failure (#534) and "low QSO flux" template unit test
   failure (#507) (`PR #536`_).
 * Add freeze_iers to more functions in simexp (direct to master).
 * Add the option to run quickquasars in eBOSS mode (`PR #481`_)
 
+.. _`PR #538`: https://github.com/desihub/desisim/pull/538
 .. _`PR #536`: https://github.com/desihub/desisim/pull/536
 .. _`PR #481`: https://github.com/desihub/desisim/pull/481
 

--- a/py/desisim/quickcat.py
+++ b/py/desisim/quickcat.py
@@ -560,7 +560,7 @@ def get_median_obsconditions(tileids):
 
     return obsconditions
 
-def quickcat(tilefiles, targets, truth, zcat=None, obsconditions=None, perfect=False):
+def quickcat(tilefiles, targets, truth, fassignhdu='FIBERASSIGN', zcat=None, obsconditions=None, perfect=False):
     """
     Generates quick output zcatalog
 
@@ -588,7 +588,7 @@ def quickcat(tilefiles, targets, truth, zcat=None, obsconditions=None, perfect=F
     tileids = list()
     for infile in tilefiles:
         
-        fibassign, header = fits.getdata(infile, 'FIBERASSIGN', header=True)
+        fibassign, header = fits.getdata(infile, fassignhdu, header=True)
  
         # hack needed here rnc 7/26/18
         if 'TILEID' in header:


### PR DESCRIPTION
This simple fix will allow reading either `fba-` or `fiberassign-` files to build a redshift catalog. The old hardcoded option only works for `fiberassign-` files.