### PR TITLE
Astropy4

### DIFF
--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -15,7 +15,6 @@ import warnings
 import fitsio
 from astropy.io import fits
 from astropy.table import Table
-from astropy.stats import sigma_clipped_stats
 import numpy as np
 
 from desispec.interpolation import resample_flux
@@ -30,6 +29,14 @@ from desiutil.log import get_logger
 log = get_logger()
 
 from desisim.util import spline_medfilt2d
+
+#- support API change from astropy 2 -> 4
+import astropy
+from astropy.stats import sigma_clipped_stats
+if astropy.__version__.startswith('2.'):
+    astropy_sigma_clipped_stats = sigma_clipped_stats
+    def sigma_clipped_stats(data, sigma=3.0, maxiters=5):
+        return astropy_sigma_clipped_stats(data, sigma=sigma, iters=maxiters)
 
 #-------------------------------------------------------------------------
 def findfile(filetype, night, expid, camera=None, outdir=None, mkdir=True):
@@ -811,23 +818,23 @@ def read_cosmics(filename, expid=1, shape=None, jitter=True):
     ny = pix.shape[0] // 2
     iixy = np.s_[0:ny, 0:nx]
     cx = pix[iixy][mask[iixy] == 0]
-    mean, median, std = sigma_clipped_stats(cx, sigma=3, iters=5)
+    mean, median, std = sigma_clipped_stats(cx, sigma=3, maxiters=5)
     meta['RDNOISEA'] = std
 
     #- Amp B lower right
     iixy = np.s_[0:ny, nx:2*nx]
     cx = pix[iixy][mask[iixy] == 0]
-    mean, median, std = sigma_clipped_stats(cx, sigma=3, iters=5)
+    mean, median, std = sigma_clipped_stats(cx, sigma=3, maxiters=5)
     meta['RDNOISEB'] = std
 
     #- Amp C upper left
     iixy = np.s_[ny:2*ny, 0:nx]
-    mean, median, std = sigma_clipped_stats(pix[iixy], sigma=3, iters=5)
+    mean, median, std = sigma_clipped_stats(pix[iixy], sigma=3, maxiters=5)
     meta['RDNOISEC'] = std
 
     #- Amp D upper right
     iixy = np.s_[ny:2*ny, nx:2*nx]
-    mean, median, std = sigma_clipped_stats(pix[iixy], sigma=3, iters=5)
+    mean, median, std = sigma_clipped_stats(pix[iixy], sigma=3, maxiters=5)
     meta['RDNOISED'] = std
     fx.close()
 

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -126,7 +126,7 @@ def write_simspec(sim, truth, fibermap, obs, expid, night, objmeta=None,
     import warnings
     warnings.filterwarnings("ignore", message=".*Dex.* did not parse as fits unit")
     warnings.filterwarnings("ignore", message=".*nanomaggies.* did not parse as fits unit")
-    warnings.filterwarnings("ignore", message=".*10\*\*6 arcsec.* did not parse as fits unit")
+    warnings.filterwarnings("ignore", message=r".*10\*\*6 arcsec.* did not parse as fits unit")
 
     if filename is None:
         filename = findfile('simspec', night, expid, outdir=outdir)
@@ -276,7 +276,7 @@ def write_simspec_arc(filename, wave, phot, header, fibermap, overwrite=False):
     import warnings
     warnings.filterwarnings("ignore", message=".*Dex.* did not parse as fits unit")
     warnings.filterwarnings("ignore", message=".*nanomaggies.* did not parse as fits unit")
-    warnings.filterwarnings("ignore", message=".*10\*\*6 arcsec.* did not parse as fits unit")
+    warnings.filterwarnings("ignore", message=r".*10\*\*6 arcsec.* did not parse as fits unit")
                     
     hx = fits.HDUList()
     hdr = desispec.io.util.fitsheader(header)

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import sys, os
 import argparse
 import time
+import warnings
 
 import numpy as np
 from scipy.constants import speed_of_light
@@ -736,7 +737,10 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
     hdr=pyfits.Header()
     hdr['GSEED']=global_seed
     hdr['PIXSEED']=seed
-    hdu = pyfits.convenience.table_to_hdu(meta)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=".*nanomaggies.*")
+        hdu = pyfits.convenience.table_to_hdu(meta)
+
     hdu.header['EXTNAME'] = 'TRUTH'
     hduqso=pyfits.convenience.table_to_hdu(qsometa)
     hduqso.header['EXTNAME'] = 'TRUTH_QSO'

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -301,7 +301,7 @@ def get_targets(nspec, program, tileid=None, seed=None, specify_targets=dict(), 
         ii = np.where(true_objtype == objtype)[0]
         nobj = len(ii)
 
-        fibermap['OBJTYPE'][ii] = target_objtype[ii]
+        fibermap['OBJTYPE'][ii] = target_objtype[ii].astype(fibermap['OBJTYPE'].dtype)
 
         if objtype in specify_targets.keys():
             obj_kwargs = specify_targets[objtype]


### PR DESCRIPTION
Support astropy 4.x by adapting to `sigma_clipped_stats` changing option `iters` to `maxiters`, while still supporting astropy 2.x (for now).

Also include miscellaneous warnings cleanup.