### PR TITLE
fitsio str vs. bytes

### DIFF
--- a/bin/wrap-fastframe
+++ b/bin/wrap-fastframe
@@ -143,9 +143,10 @@ if rank < len(simspecfiles):
 
             runtime = time.time() - t0
             if err != 0:
-                print("ERROR: rank {} simspec {} error code {} after {:.1f} sec".format(
-                    rank, os.path.basename(filename), err, runtime))
-                raise RuntimeError
+                msg = "ERROR: rank {} simspec {} error code {} after {:.1f} sec; see {}".format(
+                    rank, os.path.basename(filename), err, runtime, logfile)
+                print(msg)
+                raise RuntimeError(msg)
 
             print("rank {} took {:.1f} seconds for {} frame".format(rank, runtime, flavor))
             sys.stdout.flush()

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -263,8 +263,13 @@ def write_simspec(sim, truth, fibermap, obs, expid, night, objmeta=None,
                     objhdu.header['EXTNAME'] = extname
                     hx.append(objhdu)
 
-    log.info('Writing {}'.format(filename))
-    hx.writeto(filename, overwrite=overwrite)
+    tmpfilename = filename + '.tmp'
+    if not overwrite and os.path.exists(filename):
+        os.rename(filename, tmpfilename)
+
+    hx.writeto(tmpfilename, overwrite=overwrite)
+    os.rename(tmpfilename, filename)
+    log.info(f'Wrote {filename}')
 
 def write_simspec_arc(filename, wave, phot, header, fibermap, overwrite=False):
     '''

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -827,7 +827,7 @@ def get_mock_spectra(fiberassign, mockdir=None, nside=64, obscon=None):
     return flux, wave, astropy.table.Table(meta), objmeta
 
 def read_mock_spectra(truthfile, targetids, mockdir=None):
-    '''
+    r'''
     Reads mock spectra from a truth file
 
     Args:
@@ -839,6 +839,7 @@ def read_mock_spectra(truthfile, targetids, mockdir=None):
         flux[nspec, nwave]: flux in 1e-17 erg/s/cm2/Angstrom
         wave[nwave]: wavelengths in Angstroms
         truth[nspec]: metadata truth table
+        objtruth: dictionary keyed by objtype type with type-specific truth
     '''
     if len(targetids) != len(np.unique(targetids)):
         from desiutil.log import get_logger
@@ -860,10 +861,19 @@ def read_mock_spectra(truthfile, targetids, mockdir=None):
 
         if 'OBJTYPE' in truth.dtype.names:
             # output of desisim.obs.new_exposure
-            objtype = [oo.decode('ascii').strip().upper() for oo in truth['OBJTYPE']]
+            if isinstance(truth['OBJTYPE'][0], bytes):
+                objtype = [oo.decode('ascii').strip().upper() \
+                        for oo in truth['OBJTYPE']]
+            else:
+                objtype = [oo.strip().upper() for oo in truth['OBJTYPE']]
         else:
             # output of desitarget.mock.build.write_targets_truth
-            objtype = [oo.decode('ascii').strip().upper() for oo in truth['TEMPLATETYPE']]
+            if isinstance(truth['TEMPLATETYPE'][0], bytes):
+                objtype = [oo.decode('ascii').strip().upper() \
+                        for oo in truth['TEMPLATETYPE']]
+            else:
+                objtype = [oo.strip().upper() for oo in truth['TEMPLATETYPE']]
+
         for obj in set(objtype):
             extname = 'TRUTH_{}'.format(obj)
             if extname in fx:

--- a/py/desisim/test/test_obs.py
+++ b/py/desisim/test/test_obs.py
@@ -1,6 +1,7 @@
 import unittest, os
 from uuid import uuid1
 from shutil import rmtree
+from pkg_resources import resource_filename
 
 import numpy as np
 from astropy.io import fits
@@ -188,6 +189,24 @@ class TestObs(unittest.TestCase):
         for i in range(10):
             self.assertIn(i*500, fm['FIBER'])
             self.assertIn(i*500+499, fm['FIBER'])
+
+    def test_read_mock_spectra(self):
+        #- piggyback on desitarget mock data
+        truthfile = resource_filename('desitarget', 'test/t/truth-mocks.fits')
+        if not os.path.exists(truthfile):
+            print(f"Please update desitarget to get {truthfile}")
+            return
+
+        truth = Table.read(truthfile, 'TRUTH')
+        targetids = truth['TARGETID'][0::2]
+        flux, wave, truth2, objtruth = \
+                desisim.simexp.read_mock_spectra(truthfile, targetids)
+
+        self.assertEqual(flux.shape[0], len(targetids))
+        self.assertEqual(flux.shape[1], len(wave))
+        self.assertEqual(len(truth2), len(targetids))
+        self.assertTrue(np.all(truth2['TARGETID'] == targetids))
+
     
 
 #- This runs all test* functions in any TestCase class in this file


### PR DESCRIPTION
More updates for supporting fitsio 1.x (str) vs. <1 (bytes), this time in `desisim.simexp.read_mock_spectra`.  It includes a new unit test that piggy backs upon the test mock spectra in desitarget.

This also updates `desisim.io.write_simspec` to use a temporary file when writing to avoid partially written files with the final filename.

Reviews from anyone are welcome, but this is needed for next software release so I'll leave it open for a bit while testing other repos, but I will self merge this when needed for a desisim tag.