### PR TITLE
fix negative arc line ringing

### DIFF
--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -121,6 +121,10 @@ def new_exposure(program, nspec=5000, night=None, expid=None, tileid=None,
         else :
             infile = arc_lines_filename
         arcdata = fits.getdata(infile, 1)
+
+        #- clip unphysical negative values in arc template
+        arcdata['ELECTRONS'] = arcdata['ELECTRONS'].clip(0)
+
         if exptime is None:
             exptime = 5
         wave, phot, fibermap = desisim.simexp.simarc(arcdata, nspec=nspec, testslit=testslit)


### PR DESCRIPTION
Fixes #547 where pixsim tests were failing due to negative pixels being passed to `np.poisson()`.  It turns out that `desi/spectro/templates/calib/v0.4/arc-lines-average-in-vacuum-from-winlight-20170118.fits` has some negative values in the wings of arc lines.  Prior to [specter commit #6a0d107](https://github.com/desihub/specter/commit/6a0d10766f4b187d3c5151c40797b6d9c8d745c5), `psf.project` was clipping these negative values but now it allows you to project negative values if you really really want to so you have to fix it on the input side.

The fix is simple: clip negative values from the input arc file prior to simulating.