### PR TITLE
fix CCDSIZE keyword formatting in simulated raw data

### DIFF
--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -404,7 +404,7 @@ def simulate(camera, simspec, psf, nspec=None, ncpu=None,
         header['SPECGRPH'] = ispec
         header['CCDNAME'] = 'CCDS' + str(ispec) + str(channel).upper()
         header['CCDPREP'] = 'purge,clear'
-        header['CCDSIZE'] = str(rawpix.shape)
+        header['CCDSIZE'] = '{},{}'.format(rawpix.shape[0], rawpix.shape[1])
         header['CCDTEMP'] = 850.0
         header['CPUTEMP'] = 63.7
         header['CASETEMP'] = 62.8


### PR DESCRIPTION
This PR fixes the formatting of the CCDSIZE header keyword in simulated data.
Correct, matches real data format:
```
CCDSIZE = '4096,4204'
```
Previous, incorrect:
```
CCDSIZE = '(4096, 4204)'
```
Until yesterday this keyword wasn't used and thus wasn't a problem, but now it is used by the TSNR calculation in desispec which was failing on simulated data due to this keyword.  Nightly integration tests at NERSC caught the problem.