### PR TITLE
add missing header keywords

### DIFF
--- a/py/desisim/scripts/fastframe.py
+++ b/py/desisim/scripts/fastframe.py
@@ -132,6 +132,17 @@ def main(args=None):
                 xivar *= dwave**2
 
             meta['BUNIT']=units
+            meta['DETECTOR'] = 'SIM'
+            if camera[0] == 'b':
+                meta['CCDSIZE'] = '4162,4232'
+            else:
+                meta['CCDSIZE'] = '4194,4256'
+
+            readnoise = sim.instrument.cameras[i].read_noise.value
+            meta['OBSRDNA'] = readnoise
+            meta['OBSRDNB'] = readnoise
+            meta['OBSRDNC'] = readnoise
+            meta['OBSRDND'] = readnoise
 
             frame = Frame(wave, xphot, xivar, resolution_data=Rdata[0:imax-imin],
                           spectrograph=spectro, fibermap=xfibermap, meta=meta)


### PR DESCRIPTION
This PR adds some header keywords that were missing from simulated output.  New template S/N ratio (TSNR) code in the spectro pipeline now requires these keywords, which was breaking the integration testing.  Hardcoding the CCDSIZE is admittedly yucky, but I didn't see how to access that information from the params available to fastframe at that point in the code.  I'm going to proceed with this so that I can proceed with integration testing, but if someone cares deeply enough they can separately contribute a cleaner solution later.