### PR TITLE
restore template-generating code to a working state

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -17,16 +17,17 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                python-version: [3.7, 3.8]  # fitsio does not like Python < 3.7
-                # astropy-version: ['<3.0', '<4.1']  #, '<5.0']
+                python-version: [3.8]  # fitsio does not like Python < 3.7, astropy does not like Python < 3.8, might be too soon for 3.9.
+                astropy-version: ['==4.0.1.post1', '==5.0']  # everest & fuji versions
+                fitsio-version: ['==1.1.2', '==1.1.6']  # everest & fuji versions
         env:
-            DESIUTIL_VERSION: 3.1.0
+            DESIUTIL_VERSION: 3.2.3
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
-            DESIMODEL_DATA: branches/test-0.9.9
+            DESIMODEL_DATA: branches/test-0.12
             # DESISIM: ${GITHUB_WORKSPACE}/desisim
             DESISIM_TESTDATA_VERSION: master
             # DESI_ROOT: ${DESISIM}/desi
-            DESI_BASIS_TEMPLATES: ${DESI_ROOT}/spectro/templates/basis_templates/v3.2
+            # DESI_BASIS_TEMPLATES: ${DESI_ROOT}/spectro/templates/basis_templates/v3.2
             SIMQSO_VERSION: v1.2.4
 
         steps:
@@ -44,8 +45,11 @@ jobs:
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
+                python -m pip install -U 'astropy${{ matrix.astropy-version }}'
                 # python -m pip install git+https://github.com/imcgreer/simqso.git@${SIMQSO_VERSION}#egg=simqso
                 python -m pip install git+https://github.com/moustakas/simqso.git@astropy-updates#egg=simqso
+                python -m pip cache remove fitsio
+                python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
             - name: Verify Installation
               run: pip list
             - name: Install desimodel Data
@@ -67,10 +71,11 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.8]
+                fitsio-version: ['==1.1.2']  # everest version
         env:
-            DESIUTIL_VERSION: 3.1.0
+            DESIUTIL_VERSION: 3.2.3
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
-            DESIMODEL_DATA: branches/test-0.9.9
+            DESIMODEL_DATA: branches/test-0.12
             # DESISIM: ${GITHUB_WORKSPACE}/desisim
             DESISIM_TESTDATA_VERSION: master
             # DESI_ROOT: ${DESISIM}/desi
@@ -94,6 +99,8 @@ jobs:
                 python -m pip install -r requirements.txt
                 # python -m pip install git+https://github.com/imcgreer/simqso.git@${SIMQSO_VERSION}#egg=simqso
                 python -m pip install git+https://github.com/moustakas/simqso.git@astropy-updates#egg=simqso
+                python -m pip cache remove fitsio
+                python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
             - name: Verify Installation
               run: pip list
             - name: Install desimodel Data
@@ -112,50 +119,50 @@ jobs:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: coveralls
 
-#     docs:
-#         name: Doc test
-#         runs-on: ${{ matrix.os }}
-#         strategy:
-#             fail-fast: false
-#             matrix:
-#                 os: [ubuntu-latest]
-#                 python-version: [3.8]
-# 
-#         steps:
-#             - name: Checkout code
-#               uses: actions/checkout@v2
-#               with:
-#                 fetch-depth: 0
-#             - name: Set up Python ${{ matrix.python-version }}
-#               uses: actions/setup-python@v2
-#               with:
-#                 python-version: ${{ matrix.python-version }}
-#             - name: Install Python dependencies
-#               run: python -m pip install --upgrade pip wheel Sphinx
-#             - name: Test the documentation
-#               run: sphinx-build -W --keep-going -b html doc doc/_build/html
-# 
-#     style:
-#         name: Style check
-#         runs-on: ${{ matrix.os }}
-#         strategy:
-#             fail-fast: false
-#             matrix:
-#                 os: [ubuntu-latest]
-#                 python-version: [3.8]
-# 
-#         steps:
-#             - name: Checkout code
-#               uses: actions/checkout@v2
-#               with:
-#                 fetch-depth: 0
-#             - name: Set up Python ${{ matrix.python-version }}
-#               uses: actions/setup-python@v2
-#               with:
-#                 python-version: ${{ matrix.python-version }}
-#             - name: Install Python dependencies
-#               run: python -m pip install --upgrade pip wheel pycodestyle
-#             - name: Test the style; failures are allowed
-#               # This is equivalent to an allowed falure.
-#               continue-on-error: true
-#               run: pycodestyle --count py/desisim
+    docs:
+        name: Doc test
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest]
+                python-version: [3.8]
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 0
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v2
+              with:
+                python-version: ${{ matrix.python-version }}
+            - name: Install Python dependencies
+              run: python -m pip install --upgrade pip wheel Sphinx
+            - name: Test the documentation
+              run: sphinx-build -W --keep-going -b html doc doc/_build/html
+
+    style:
+        name: Style check
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest]
+                python-version: [3.8]
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 0
+            - name: Set up Python ${{ matrix.python-version }}
+              uses: actions/setup-python@v2
+              with:
+                python-version: ${{ matrix.python-version }}
+            - name: Install Python dependencies
+              run: python -m pip install --upgrade pip wheel pycodestyle
+            - name: Test the style; failures are allowed
+              # This is equivalent to an allowed falure.
+              continue-on-error: true
+              run: pycodestyle --count py/desisim

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
         env:
             DESIUTIL_VERSION: 3.1.0
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
-            DESIMODEL_DATA: branches/0.9.9
+            DESIMODEL_DATA: branches/test-0.9.9
             # DESISIM: ${GITHUB_WORKSPACE}/desisim
             DESISIM_TESTDATA_VERSION: master
             # DESI_ROOT: ${DESISIM}/desi
@@ -70,7 +70,7 @@ jobs:
         env:
             DESIUTIL_VERSION: 3.1.0
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
-            DESIMODEL_DATA: branches/0.9.9
+            DESIMODEL_DATA: branches/test-0.9.9
             # DESISIM: ${GITHUB_WORKSPACE}/desisim
             DESISIM_TESTDATA_VERSION: master
             # DESI_ROOT: ${DESISIM}/desi

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
             matrix:
                 os: [ubuntu-latest]
                 python-version: [3.8]  # fitsio does not like Python < 3.7, astropy does not like Python < 3.8, might be too soon for 3.9.
-                astropy-version: ['==4.0.1.post1', '==5.0']  # everest & fuji versions
+                astropy-version: ['==4.0.1.post1']  #, '==5.0']  # everest & fuji versions
                 fitsio-version: ['==1.1.2', '==1.1.6']  # everest & fuji versions
         env:
             DESIUTIL_VERSION: 3.2.3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,7 +22,7 @@ jobs:
         env:
             DESIUTIL_VERSION: 3.1.0
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
-            DESIMODEL_DATA: branches/test-0.12
+            DESIMODEL_DATA: branches/0.9.9
             # DESISIM: ${GITHUB_WORKSPACE}/desisim
             DESISIM_TESTDATA_VERSION: master
             # DESI_ROOT: ${DESISIM}/desi
@@ -70,7 +70,7 @@ jobs:
         env:
             DESIUTIL_VERSION: 3.1.0
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
-            DESIMODEL_DATA: branches/test-0.12
+            DESIMODEL_DATA: branches/0.9.9
             # DESISIM: ${GITHUB_WORKSPACE}/desisim
             DESISIM_TESTDATA_VERSION: master
             # DESI_ROOT: ${DESISIM}/desi
@@ -92,7 +92,8 @@ jobs:
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install git+https://github.com/imcgreer/simqso.git@${SIMQSO_VERSION}#egg=simqso
+                # python -m pip install git+https://github.com/imcgreer/simqso.git@${SIMQSO_VERSION}#egg=simqso
+                python -m pip install git+https://github.com/moustakas/simqso.git@astropy-updates#egg=simqso
             - name: Verify Installation
               run: pip list
             - name: Install desimodel Data

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -112,50 +112,50 @@ jobs:
                 GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: coveralls
 
-    docs:
-        name: Doc test
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ubuntu-latest]
-                python-version: [3.8]
-
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
-              with:
-                fetch-depth: 0
-            - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
-              with:
-                python-version: ${{ matrix.python-version }}
-            - name: Install Python dependencies
-              run: python -m pip install --upgrade pip wheel Sphinx
-            - name: Test the documentation
-              run: sphinx-build -W --keep-going -b html doc doc/_build/html
-
-    style:
-        name: Style check
-        runs-on: ${{ matrix.os }}
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [ubuntu-latest]
-                python-version: [3.8]
-
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v2
-              with:
-                fetch-depth: 0
-            - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
-              with:
-                python-version: ${{ matrix.python-version }}
-            - name: Install Python dependencies
-              run: python -m pip install --upgrade pip wheel pycodestyle
-            - name: Test the style; failures are allowed
-              # This is equivalent to an allowed falure.
-              continue-on-error: true
-              run: pycodestyle --count py/desisim
+#     docs:
+#         name: Doc test
+#         runs-on: ${{ matrix.os }}
+#         strategy:
+#             fail-fast: false
+#             matrix:
+#                 os: [ubuntu-latest]
+#                 python-version: [3.8]
+# 
+#         steps:
+#             - name: Checkout code
+#               uses: actions/checkout@v2
+#               with:
+#                 fetch-depth: 0
+#             - name: Set up Python ${{ matrix.python-version }}
+#               uses: actions/setup-python@v2
+#               with:
+#                 python-version: ${{ matrix.python-version }}
+#             - name: Install Python dependencies
+#               run: python -m pip install --upgrade pip wheel Sphinx
+#             - name: Test the documentation
+#               run: sphinx-build -W --keep-going -b html doc doc/_build/html
+# 
+#     style:
+#         name: Style check
+#         runs-on: ${{ matrix.os }}
+#         strategy:
+#             fail-fast: false
+#             matrix:
+#                 os: [ubuntu-latest]
+#                 python-version: [3.8]
+# 
+#         steps:
+#             - name: Checkout code
+#               uses: actions/checkout@v2
+#               with:
+#                 fetch-depth: 0
+#             - name: Set up Python ${{ matrix.python-version }}
+#               uses: actions/setup-python@v2
+#               with:
+#                 python-version: ${{ matrix.python-version }}
+#             - name: Install Python dependencies
+#               run: python -m pip install --upgrade pip wheel pycodestyle
+#             - name: Test the style; failures are allowed
+#               # This is equivalent to an allowed falure.
+#               continue-on-error: true
+#               run: pycodestyle --count py/desisim

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -44,7 +44,8 @@ jobs:
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install git+https://github.com/imcgreer/simqso.git@${SIMQSO_VERSION}#egg=simqso
+                # python -m pip install git+https://github.com/imcgreer/simqso.git@${SIMQSO_VERSION}#egg=simqso
+                python -m pip install git+https://github.com/moustakas/simqso/tree/astropy-updates
             - name: Verify Installation
               run: pip list
             - name: Install desimodel Data

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -47,7 +47,7 @@ jobs:
                 python -m pip install -r requirements.txt
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
                 # python -m pip install git+https://github.com/imcgreer/simqso.git@${SIMQSO_VERSION}#egg=simqso
-                python -m pip install git+https://github.com/moustakas/simqso.git@astropy-updates#egg=simqso
+                python -m pip install git+https://github.com/desihub/simqso.git@master#egg=simqso
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
             - name: Verify Installation
@@ -98,7 +98,7 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 # python -m pip install git+https://github.com/imcgreer/simqso.git@${SIMQSO_VERSION}#egg=simqso
-                python -m pip install git+https://github.com/moustakas/simqso.git@astropy-updates#egg=simqso
+                python -m pip install git+https://github.com/desihub/simqso.git@master#egg=simqso
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
             - name: Verify Installation

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -45,7 +45,7 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 # python -m pip install git+https://github.com/imcgreer/simqso.git@${SIMQSO_VERSION}#egg=simqso
-                python -m pip install git+https://github.com/moustakas/simqso/tree/astropy-updates
+                python -m pip install git+https://github.com/moustakas/simqso.git@astropy-updates#egg=simqso
             - name: Verify Installation
               run: pip list
             - name: Install desimodel Data

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,10 @@ desisim change log
 0.35.7 (unreleased)
 -------------------
 
-* No changes yet
+* Restore template-generating code to a working state (PR `#556`_).
+
+.. _`#556`: https://github.com/desihub/desisim/pull/556
+
 
 0.35.6 (2021-03-31)
 -------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -12,7 +12,7 @@ desisim change log
 
 * lighterweight quickquasars (PR `#552`_).
 
-.. _`PR #552`: https://github.com/desihub/desisim/pull/552
+.. _`#552`: https://github.com/desihub/desisim/pull/552
 
 0.35.5 (2021-02-15)
 -------------------

--- a/py/desisim/data/forbidden_lines.ecsv
+++ b/py/desisim/data/forbidden_lines.ecsv
@@ -1,7 +1,7 @@
 # %ECSV 0.9
 # ---
 # datatype:
-# - {name: name, datatype: str}
+# - {name: name, datatype: string}
 # - {name: wave, datatype: float64}
 # - {name: ratio, datatype: float32}
 # meta: !!omap

--- a/py/desisim/data/recombination_lines.ecsv
+++ b/py/desisim/data/recombination_lines.ecsv
@@ -1,7 +1,7 @@
 # %ECSV 0.9
 # ---
 # datatype:
-# - {name: name, datatype: str}
+# - {name: name, datatype: string}
 # - {name: wave, datatype: float64}
 # - {name: ratio, datatype: float32}
 # meta: !!omap

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -232,6 +232,7 @@ def get_healpix_info(ifilename):
                     hpxnest=bool(head[k])
                 log.info("hpxnest from {} = {}".format(k,hpxnest))
                 break
+    hdulist.close()
 
     if healpix >= 0 and nside < 0 :
         log.error("Read healpix in header but not nside.")

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -211,8 +211,8 @@ def get_targets_parallel(nspec, program, tileid=None, nproc=None, seed=None, spe
             else:
                 args.append( (nspec-i, program, tileid, seeds[i], specify_targets, i) )
 
-        pool = mp.Pool(nproc)
-        results = pool.map(_wrap_get_targets, args)
+        with mp.Pool(nproc) as P:
+            results = P.map(_wrap_get_targets, args)
         fibermaps, targets = list(zip(*results))
         fibermap = np.concatenate(fibermaps)
 

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -451,6 +451,9 @@ class GALAXY(object):
         self.bassmzlswise = filters.load_filters('BASS-g', 'BASS-r', 'MzLS-z',
                                                  'wise2010-W1', 'wise2010-W2')
 
+        # Default fiber fractions based on https://github.com/desihub/desisim/pull/550
+        self.fiberflux_fraction = {'ELG': 0.6, 'LRG': 0.4, 'BGS': 0.3}
+
     def _blurmatrix(self, vdisp, log=None):
         """Pre-compute the blur_matrix as a dictionary keyed by each unique value of
         vdisp.
@@ -755,6 +758,8 @@ class GALAXY(object):
         else:
             outflux = np.zeros([nmodel, len(self.wave)]) # [erg/s/cm2/A]
 
+        fiberflux_fraction = self.fiberflux_fraction[self.objtype]
+
         for ii in range(nmodel):
             templaterand = np.random.RandomState(templateseed[ii])
 
@@ -869,12 +874,15 @@ class GALAXY(object):
                         for targtype in ('bright', 'faint', 'wise'):
                             _colormask.append(self.colorcuts_function(
                                 gflux=gflux, rflux=rflux, zflux=zflux,
-                                w1flux=w1flux, rfiberflux=rflux, rfibertotflux=rflux,
+                                w1flux=w1flux, rfiberflux=fiberflux_fraction*rflux, 
+                                rfibertotflux=fiberflux_fraction*rflux,
                                 south=south, targtype=targtype))
                         colormask = np.any( np.ma.getdata(np.vstack(_colormask)), axis=0 )
                     else:
                         colormask = self.colorcuts_function(gflux=gflux, rflux=rflux, zflux=zflux,
-                                                            gfiberflux=gflux, rfiberflux=rflux, zfiberflux=zflux,
+                                                            gfiberflux=fiberflux_fraction*gflux, 
+                                                            rfiberflux=fiberflux_fraction*rflux, 
+                                                            zfiberflux=fiberflux_fraction*zflux,
                                                             w1flux=w1flux, w2flux=w2flux, south=south)
                         
                 # If the color-cuts pass then populate the output flux vector

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -858,13 +858,13 @@ class GALAXY(object):
                 zlineflux = normlineflux[templateid] * magnorm
 
                 if south:
-                    gflux, rflux, zflux, w1flux, w2flux = synthnano['decam2014-g'], \
-                      synthnano['decam2014-r'], synthnano['decam2014-z'], \
-                      synthnano['wise2010-W1'], synthnano['wise2010-W2']
+                    gflux, rflux, zflux, w1flux, w2flux = np.ma.getdata(synthnano['decam2014-g']), \
+                      np.ma.getdata(synthnano['decam2014-r']), np.ma.getdata(synthnano['decam2014-z']), \
+                      np.ma.getdata(synthnano['wise2010-W1']), np.ma.getdata(synthnano['wise2010-W2'])
                 else:
-                    gflux, rflux, zflux, w1flux, w2flux = synthnano['BASS-g'], \
-                      synthnano['BASS-r'], synthnano['MzLS-z'], \
-                      synthnano['wise2010-W1'], synthnano['wise2010-W2']
+                    gflux, rflux, zflux, w1flux, w2flux = np.ma.getdata(synthnano['BASS-g']), \
+                      np.ma.getdata(synthnano['BASS-r']), np.ma.getdata(synthnano['MzLS-z']), \
+                      np.ma.getdata(synthnano['wise2010-W1']), np.ma.getdata(synthnano['wise2010-W2'])
 
                 if nocolorcuts or self.colorcuts_function is None:
                     colormask = np.repeat(1, nbasechunk)
@@ -1500,13 +1500,13 @@ class SUPERSTAR(object):
                     synthnano[key] = 1E9 * maggies[key] * magnorm
 
                 if south:
-                    gflux, rflux, zflux, w1flux, w2flux = synthnano['decam2014-g'], \
-                      synthnano['decam2014-r'], synthnano['decam2014-z'], \
-                      synthnano['wise2010-W1'], synthnano['wise2010-W2']
+                    gflux, rflux, zflux, w1flux, w2flux = np.ma.getdata(synthnano['decam2014-g']), \
+                      np.ma.getdata(synthnano['decam2014-r']), np.ma.getdata(synthnano['decam2014-z']), \
+                      np.ma.getdata(synthnano['wise2010-W1']), np.ma.getdata(synthnano['wise2010-W2'])
                 else:
-                    gflux, rflux, zflux, w1flux, w2flux = synthnano['BASS-g'], \
-                      synthnano['BASS-r'], synthnano['MzLS-z'], \
-                      synthnano['wise2010-W1'], synthnano['wise2010-W2']
+                    gflux, rflux, zflux, w1flux, w2flux = np.ma.getdata(synthnano['BASS-g']), \
+                      np.ma.getdata(synthnano['BASS-r']), np.ma.getdata(synthnano['MzLS-z']), \
+                      np.ma.getdata(synthnano['wise2010-W1']), np.ma.getdata(synthnano['wise2010-W2'])
 
                 if nocolorcuts or self.colorcuts_function is None:
                     colormask = np.repeat(1, nbasechunk)
@@ -1846,7 +1846,6 @@ class QSO():
 
         """
         from astropy.io import fits
-        from astropy import cosmology
         from speclite import filters
         from desisim.io import find_basis_template, read_basis_templates
         from desisim import lya_mock_p1d as lyamock
@@ -1869,7 +1868,11 @@ class QSO():
             wave = np.linspace(minwave, maxwave, npix)
         self.wave = wave
 
-        self.cosmo = cosmology.core.FlatLambdaCDM(70.0, 0.3)
+        try:
+            from astropy.cosmology import FlatLambdaCDM # astropy >v5.0
+        except:
+            from astropy.cosmology.core import FlatLambdaCDM
+        self.cosmo = FlatLambdaCDM(70.0, 0.3)
 
         self.lambda_lylimit = 911.76
         self.lambda_lyalpha = 1215.67
@@ -2219,13 +2222,13 @@ class QSO():
                     synthnano[key] = 1E9 * maggies[key] * magnorm
 
                 if south:
-                    gflux, rflux, zflux, w1flux, w2flux = synthnano['decam2014-g'], \
-                      synthnano['decam2014-r'], synthnano['decam2014-z'], \
-                      synthnano['wise2010-W1'], synthnano['wise2010-W2']
+                    gflux, rflux, zflux, w1flux, w2flux = np.ma.getdata(synthnano['decam2014-g']), \
+                      np.ma.getdata(synthnano['decam2014-r']), np.ma.getdata(synthnano['decam2014-z']), \
+                      np.ma.getdata(synthnano['wise2010-W1']), np.ma.getdata(synthnano['wise2010-W2'])
                 else:
-                    gflux, rflux, zflux, w1flux, w2flux = synthnano['BASS-g'], \
-                      synthnano['BASS-r'], synthnano['MzLS-z'], \
-                      synthnano['wise2010-W1'], synthnano['wise2010-W2']
+                    gflux, rflux, zflux, w1flux, w2flux = np.ma.getdata(synthnano['BASS-g']), \
+                      np.ma.getdata(synthnano['BASS-r']), np.ma.getdata(synthnano['MzLS-z']), \
+                      np.ma.getdata(synthnano['wise2010-W1']), np.ma.getdata(synthnano['wise2010-W2'])
                           
                 if nocolorcuts or self.colorcuts_function is None:
                     colormask = np.repeat(1, N_perz)
@@ -2335,7 +2338,6 @@ class SIMQSO():
             WISE2010-[W1,W2] FilterSequence.
 
         """
-        from astropy import cosmology
         from speclite import filters
         log = get_logger()
         try:
@@ -2393,7 +2395,11 @@ class SIMQSO():
         else:
             self.basewave = fixed_R_dispersion(basewave_min, basewave_max, basewave_R)
             
-        self.cosmo = cosmology.core.FlatLambdaCDM(70.0, 0.3)
+        try:
+            from astropy.cosmology import FlatLambdaCDM # astropy >v5.0
+        except:
+            from astropy.cosmology.core import FlatLambdaCDM
+        self.cosmo = FlatLambdaCDM(70.0, 0.3)
 
         self.lambda_lylimit = 911.76
         self.lambda_lyalpha = 1215.67
@@ -2523,13 +2529,13 @@ class SIMQSO():
             synthnano[key] = 1E9 * maggies[key]
 
         if south:
-            gflux, rflux, zflux, w1flux, w2flux = synthnano['decam2014-g'], \
-              synthnano['decam2014-r'], synthnano['decam2014-z'], \
-              synthnano['wise2010-W1'], synthnano['wise2010-W2']
+            gflux, rflux, zflux, w1flux, w2flux = np.ma.getdata(synthnano['decam2014-g']), \
+              np.ma.getdata(synthnano['decam2014-r']), np.ma.getdata(synthnano['decam2014-z']), \
+              np.ma.getdata(synthnano['wise2010-W1']), np.ma.getdata(synthnano['wise2010-W2'])
         else:
-            gflux, rflux, zflux, w1flux, w2flux = synthnano['BASS-g'], \
-              synthnano['BASS-r'], synthnano['MzLS-z'], \
-              synthnano['wise2010-W1'], synthnano['wise2010-W2']
+            gflux, rflux, zflux, w1flux, w2flux = np.ma.getdata(synthnano['BASS-g']), \
+              np.ma.getdata(synthnano['BASS-r']), np.ma.getdata(synthnano['MzLS-z']), \
+              np.ma.getdata(synthnano['wise2010-W1']), np.ma.getdata(synthnano['wise2010-W2'])
 
         if nocolorcuts or self.colorcuts_function is None:
             colormask = np.repeat(1, nmodel)

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -869,7 +869,8 @@ class GALAXY(object):
                 if nocolorcuts or self.colorcuts_function is None:
                     colormask = np.repeat(1, nbasechunk)
                 else:
-                    if self.objtype == 'BGS':
+                    # differentiate the different selections for BGS and ELG targets
+                    if self.objtype == 'BGS': 
                         _colormask = []
                         for targtype in ('bright', 'faint', 'wise'):
                             _colormask.append(self.colorcuts_function(
@@ -878,13 +879,21 @@ class GALAXY(object):
                                 rfibertotflux=fiberflux_fraction*rflux,
                                 south=south, targtype=targtype))
                         colormask = np.any( np.ma.getdata(np.vstack(_colormask)), axis=0 )
+                    elif self.objtype == 'ELG': # 
+                        colormask_vlo, _colormask = self.colorcuts_function(
+                            gflux=gflux, rflux=rflux, zflux=zflux,
+                            gfiberflux=fiberflux_fraction*gflux, 
+                            rfiberflux=fiberflux_fraction*rflux, 
+                            zfiberflux=fiberflux_fraction*zflux,
+                            w1flux=w1flux, w2flux=w2flux, south=south)
+                        colormask = np.any( np.ma.getdata(np.vstack([colormask_vlo, _colormask])), axis=0 )
                     else:
                         colormask = self.colorcuts_function(gflux=gflux, rflux=rflux, zflux=zflux,
                                                             gfiberflux=fiberflux_fraction*gflux, 
                                                             rfiberflux=fiberflux_fraction*rflux, 
                                                             zfiberflux=fiberflux_fraction*zflux,
                                                             w1flux=w1flux, w2flux=w2flux, south=south)
-                        
+
                 # If the color-cuts pass then populate the output flux vector
                 # (suitably normalized) and metadata table, convolve with the
                 # velocity dispersion, resample, and finish up.  Note that the

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -869,11 +869,12 @@ class GALAXY(object):
                         for targtype in ('bright', 'faint', 'wise'):
                             _colormask.append(self.colorcuts_function(
                                 gflux=gflux, rflux=rflux, zflux=zflux,
-                                w1flux=w1flux, w2flux=w2flux, south=south,
-                                targtype=targtype))
+                                w1flux=w1flux, rfiberflux=rflux, rfibertotflux=rflux,
+                                south=south, targtype=targtype))
                         colormask = np.any( np.ma.getdata(np.vstack(_colormask)), axis=0 )
                     else:
                         colormask = self.colorcuts_function(gflux=gflux, rflux=rflux, zflux=zflux,
+                                                            gfiberflux=gflux, rfiberflux=rflux, zfiberflux=zflux,
                                                             w1flux=w1flux, w2flux=w2flux, south=south)
                         
                 # If the color-cuts pass then populate the output flux vector
@@ -1011,8 +1012,8 @@ class BGS(GALAXY):
     """Generate Monte Carlo spectra of bright galaxy survey galaxies (BGSs)."""
 
     def __init__(self, minwave=3600.0, maxwave=10000.0, cdelt=0.2, wave=None,
-                 transient=None, tr_fluxratio=(0.01, 1.), tr_epoch=(-10,10), include_mgii=False, colorcuts_function=None,
-                 normfilter_north='BASS-r', normfilter_south='decam2014-r',
+                 transient=None, tr_fluxratio=(0.01, 1.), tr_epoch=(-10,10), include_mgii=False,
+                 colorcuts_function=None, normfilter_north='BASS-r', normfilter_south='decam2014-r',
                  baseflux=None, basewave=None, basemeta=None):
         """Initialize the BGS class.  See the GALAXY.__init__ method for documentation
          on the arguments plus the inherited attributes.

--- a/py/desisim/test/test_templates.py
+++ b/py/desisim/test/test_templates.py
@@ -171,8 +171,8 @@ class TestTemplates(unittest.TestCase):
                         badkeys.append(key)
 
             self.assertEqual(len(badkeys), 0, 'mismatch for spectral type {} in keys {}'.format(meta1['OBJTYPE'][0], badkeys))
-            # if np.all(np.allclose(flux1, flux2, rtol=1e-3)) is False:
-            #     import pdb ; pdb.set_trace()
+            #if np.all(np.allclose(flux1, flux2, atol=1e-3)) is False:
+            #    import pdb ; pdb.set_trace()
             self.assertTrue(np.all(np.isclose(flux1, flux2, atol=1e-3)))
             #self.assertTrue(np.allclose(flux1, flux2, rtol=1e-4))
             self.assertTrue(np.all(wave1 == wave2))

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ git+https://github.com/desihub/desimodel.git@0.13.0#egg=desimodel
 # Don't forget to install desimodel test data.
 git+https://github.com/desihub/desispec.git@0.36.1#egg=desispec
 # git+https://github.com/desihub/desitarget.git@0.50.0#egg=desitarget
-git+https://github.com/desihub/desitarget.git@fiberflux-to-colorcuts#egg=desitarget
+git+https://github.com/desihub/desitarget.git@master#egg=desitarget
 git+https://github.com/desihub/specsim.git@v0.14#egg=specsim
 # simqso install script requires numpy, so install separately.
 # git+https://github.com/imcgreer/simqso.git@v1.2.4#egg=simqso

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,8 @@ git+https://github.com/desihub/specter.git@0.9.4#egg=specter
 git+https://github.com/desihub/desimodel.git@0.13.0#egg=desimodel
 # Don't forget to install desimodel test data.
 git+https://github.com/desihub/desispec.git@0.36.1#egg=desispec
-git+https://github.com/desihub/desitarget.git@0.50.0#egg=desitarget
+# git+https://github.com/desihub/desitarget.git@0.50.0#egg=desitarget
+git+https://github.com/desihub/desitarget/tree/fiberflux-to-colorcuts
 git+https://github.com/desihub/specsim.git@v0.14#egg=specsim
 # simqso install script requires numpy, so install separately.
 # git+https://github.com/imcgreer/simqso.git@v1.2.4#egg=simqso

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ git+https://github.com/desihub/desimodel.git@0.13.0#egg=desimodel
 # Don't forget to install desimodel test data.
 git+https://github.com/desihub/desispec.git@0.36.1#egg=desispec
 # git+https://github.com/desihub/desitarget.git@0.50.0#egg=desitarget
-git+https://github.com/desihub/desitarget/tree/fiberflux-to-colorcuts
+git+https://github.com/desihub/desitarget.git@fiberflux-to-colorcuts#egg=desitarget
 git+https://github.com/desihub/specsim.git@v0.14#egg=specsim
 # simqso install script requires numpy, so install separately.
 # git+https://github.com/imcgreer/simqso.git@v1.2.4#egg=simqso


### PR DESCRIPTION
`desisim.templates` has been broken for some time (e.g., https://github.com/desihub/desisim/issues/553). The changes in this PR are needed to restore everything to a working state. 

WIP so not quite ready to merge. 

The companion PRs are https://github.com/imcgreer/simqso/pull/33 and https://github.com/desihub/desitarget/pull/786. However, I'm having trouble getting the Github actions tests to pass even though they pass on my laptop. I'll keep trying.

One of the "major" changes is that `desisim.templates` now has to estimate the fiberflux for the ELG and LRG target classes, in order to retrieve templates / models which pass our nominal color-cuts. Since the template-generating code doesn't know much physics, I opted to generate these fluxes statistically, using data from SV3. 

Here's my code, for the record:
```
import numpy as np
from astropy.table import Table
from desitarget.sv3.sv3_targetmask import desi_mask

cd, '/global/cfs/cdirs/desi/spectro/fastspecfit/everest-v1/catalogs'
darkmeta = Table.read('fastspec-everest-sv3-dark.fits', 'METADATA')
brightmeta = Table.read('fastspec-everest-sv3-bright.fits', 'METADATA')

for targ, zminmax, meta in zip( ('ELG', 'LRG', 'BGS_ANY'), ((0.6, 1.6), (0.3, 1.0), 
  (0.05, 0.5)), (darkmeta, darkmeta, brightmeta) ):
    indx = np.where((meta['SV3_DESI_TARGET'] & desi_mask[targ] != 0) * 
      (meta['Z'] > zminmax[0]) * (meta['Z'] < zminmax[1]) * (meta['ZWARN'] == 0) * 
      (meta['FLUX_G'] > 0) * (meta['FIBERFLUX_G'] > 0) * 
      (meta['FLUX_R'] > 0) * (meta['FIBERFLUX_R'] > 0) * 
      (meta['FLUX_Z'] > 0) * (meta['FIBERFLUX_Z'] > 0))[0] 
    print('Selected {:,} {}'.format(len(indx), targ))

    for band in ('G', 'R', 'Z'):
      ratio = meta['FIBERFLUX_{}'.format(band)][indx] / meta['FLUX_{}'.format(band)][indx]
      print('  Median, Mean, Sigma {} fiberflux / flux = {:.4f}, {:.4f}, {:.4f}'.format(
        band, np.median(ratio), np.mean(ratio), np.std(ratio)))
```
Output:
```
Selected 270,630 ELG
  Median, Mean, Sigma G fiberflux / flux = 0.6026, 0.5901, 0.1275
  Median, Mean, Sigma R fiberflux / flux = 0.6171, 0.6037, 0.1292
  Median, Mean, Sigma Z fiberflux / flux = 0.6307, 0.6164, 0.1311
Selected 115,565 LRG
  Median, Mean, Sigma G fiberflux / flux = 0.3992, 0.4096, 0.1366
  Median, Mean, Sigma R fiberflux / flux = 0.4087, 0.4191, 0.1392
  Median, Mean, Sigma Z fiberflux / flux = 0.4175, 0.4280, 0.1417
Selected 241,779 BGS_ANY
  Median, Mean, Sigma G fiberflux / flux = 0.3025, 0.3085, 0.1261
  Median, Mean, Sigma R fiberflux / flux = 0.3097, 0.3158, 0.1286
  Median, Mean, Sigma Z fiberflux / flux = 0.3165, 0.3225, 0.1311
```