### PR TITLE
Smoothing source contribution to noise in quickquasars DESI mocks

### DIFF
--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -147,6 +147,11 @@ Use 'all' or no argument for mock version < 7.3 or final metal runs. ",nargs='?'
 
     parser.add_argument('--save-resolution',action='store_true', help="Save full resolution in spectra file. By default only one matrix is saved in the truth file.")
 
+    parser.add_argument('--source-contr-smoothing', type=float, default=0, \
+        help="When this argument > 0 A, source electrons' contribution to the noise is smoothed " \
+        "by a Gaussian kernel using FFT. Default is 0 (turned off). Pipeline does this by 10 A. " \
+        "Larger smoothing might be needed for better decoupling. Does not apply to eBOSS mocks.")
+
     if options is None:
         args = parser.parse_args()
     else:
@@ -725,7 +730,7 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
     resolution=sim_spectra(qso_wave,qso_flux, args.program, obsconditions=obsconditions,spectra_filename=ofilename,
                            sourcetype="qso", skyerr=args.skyerr,ra=metadata["RA"],dec=metadata["DEC"],targetid=targetid,
                            meta=specmeta,seed=seed,fibermap_columns=fibermap_columns,use_poisson=False,
-                           specsim_config_file=specsim_config_file, dwave_out=dwave_out, save_resolution=args.save_resolution)
+                           specsim_config_file=specsim_config_file, dwave_out=dwave_out, save_resolution=args.save_resolution, source_contribution_smoothing=args.source_contr_smoothing)
 
     ### Keep input redshift
     Z_spec = metadata['Z'].copy()


### PR DESCRIPTION
There is now an option in quickquasars to smooth out the source contribution to noise for DESI mocks in order to de-bias the weights in Lya forest analyses. The value passed will the Gaussian sigma for the smoothing in Angstrom. This smoothing is implemented with FFTs on a padded array in quickspectra.py.