### PR TITLE
Remove DesiTest

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,13 +16,13 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                os: [ubuntu-latest]
-                python-version: [3.8]  # fitsio does not like Python < 3.7, astropy does not like Python < 3.8, might be too soon for 3.9.
-                astropy-version: ['==4.0.1.post1', '==5.0']  # everest & fuji versions
-                fitsio-version: ['==1.1.2', '==1.1.6']  # everest & fuji versions
-                numpy-version: ['<1.23']  # to keep asscalar, used by astropy
+                os: [ubuntu-22.04]
+                python-version: ['3.10']
+                astropy-version: ['<6.1', '<7']
+                fitsio-version: ['<2']
+                numpy-version: ['<1.23']
         env:
-            DESIUTIL_VERSION: 3.2.3
+            DESIUTIL_VERSION: 3.4.3
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
             DESIMODEL_DATA: branches/test-0.18
             # DESISIM: ${GITHUB_WORKSPACE}/desisim
@@ -33,16 +33,16 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
-                python -m pip install --upgrade pip wheel
+                python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
@@ -71,14 +71,14 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                os: [ubuntu-latest]
-                python-version: [3.8]
-                fitsio-version: ['==1.1.6']  # fuji version
+                os: [ubuntu-22.04]
+                python-version: ['3.10']
+                fitsio-version: ['<2']
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
         env:
-            DESIUTIL_VERSION: 3.2.3
+            DESIUTIL_VERSION: 3.4.3
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
-            DESIMODEL_DATA: branches/test-0.17
+            DESIMODEL_DATA: branches/test-0.18
             # DESISIM: ${GITHUB_WORKSPACE}/desisim
             DESISIM_TESTDATA_VERSION: main
             # DESI_ROOT: ${DESISIM}/desi
@@ -87,16 +87,16 @@ jobs:
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
-                python -m pip install --upgrade pip wheel
+                python -m pip install --upgrade pip setuptools wheel
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
@@ -130,19 +130,19 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: [3.8]
+                python-version: ['3.10']
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
-              run: python -m pip install --upgrade pip wheel Sphinx
+              run: python -m pip install --upgrade pip wheel setuptools Sphinx sphinx-rtd-theme
             - name: Test the documentation
               run: sphinx-build -W --keep-going -b html doc doc/_build/html
 
@@ -153,19 +153,19 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                python-version: [3.8]
+                python-version: ['3.10']
 
         steps:
             - name: Checkout code
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
               with:
                 fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v2
+              uses: actions/setup-python@v5
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
-              run: python -m pip install --upgrade pip wheel pycodestyle
+              run: python -m pip install --upgrade pip setuptools wheel pycodestyle
             - name: Test the style; failures are allowed
               # This is equivalent to an allowed falure.
               continue-on-error: true

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -73,6 +73,7 @@ jobs:
             matrix:
                 os: [ubuntu-22.04]
                 python-version: ['3.10']
+                astropy-version: ['<6.1']
                 fitsio-version: ['<2']
                 numpy-version: ['<1.23']  # to keep asscalar, used by astropy
         env:
@@ -102,6 +103,7 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
+                python -m pip install -U 'astropy${{ matrix.astropy-version }}'
                 python -m pip install git+https://github.com/${SIMQSO_REPO}/simqso.git@${SIMQSO_VERSION}#egg=simqso
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,9 +18,9 @@ jobs:
             matrix:
                 os: [ubuntu-22.04]
                 python-version: ['3.10']
-                astropy-version: ['<6.1', '<7']
-                fitsio-version: ['<2']
-                numpy-version: ['<1.23']
+                astropy-version: ['<6.1']
+                fitsio-version: ['==1.2.1', '<2']
+                numpy-version: ['<2']
         env:
             DESIUTIL_VERSION: 3.4.3
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
@@ -74,7 +74,7 @@ jobs:
                 os: [ubuntu-22.04]
                 python-version: ['3.10']
                 fitsio-version: ['<2']
-                numpy-version: ['<1.23']  # to keep asscalar, used by astropy
+                numpy-version: ['<2']  # to keep asscalar, used by astropy
         env:
             DESIUTIL_VERSION: 3.4.3
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
                 python-version: ['3.10']
                 astropy-version: ['<6.1']
                 fitsio-version: ['==1.2.1', '<2']
-                numpy-version: ['<2']
+                numpy-version: ['<1.23']
         env:
             DESIUTIL_VERSION: 3.4.3
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
@@ -29,7 +29,8 @@ jobs:
             DESISIM_TESTDATA_VERSION: main
             # DESI_ROOT: ${DESISIM}/desi
             # DESI_BASIS_TEMPLATES: ${DESI_ROOT}/spectro/templates/basis_templates/v3.2
-            SIMQSO_VERSION: v1.2.4
+            SIMQSO_REPO: desihub
+            SIMQSO_VERSION: main
 
         steps:
             - name: Checkout code
@@ -48,8 +49,7 @@ jobs:
                 python -m pip install -r requirements.txt
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
-                # python -m pip install git+https://github.com/imcgreer/simqso.git@${SIMQSO_VERSION}#egg=simqso
-                python -m pip install git+https://github.com/desihub/simqso.git@main#egg=simqso
+                python -m pip install git+https://github.com/${SIMQSO_REPO}/simqso.git@${SIMQSO_VERSION}#egg=simqso
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
             - name: Verify Installation
@@ -74,7 +74,7 @@ jobs:
                 os: [ubuntu-22.04]
                 python-version: ['3.10']
                 fitsio-version: ['<2']
-                numpy-version: ['<2']  # to keep asscalar, used by astropy
+                numpy-version: ['<1.23']  # to keep asscalar, used by astropy
         env:
             DESIUTIL_VERSION: 3.4.3
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
@@ -83,7 +83,8 @@ jobs:
             DESISIM_TESTDATA_VERSION: main
             # DESI_ROOT: ${DESISIM}/desi
             # DESI_BASIS_TEMPLATES: ${DESI_ROOT}/spectro/templates/basis_templates/v3.2
-            SIMQSO_VERSION: v1.2.4
+            SIMQSO_REPO: desihub
+            SIMQSO_VERSION: main
 
         steps:
             - name: Checkout code
@@ -101,8 +102,7 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
-                # python -m pip install git+https://github.com/imcgreer/simqso.git@${SIMQSO_VERSION}#egg=simqso
-                python -m pip install git+https://github.com/desihub/simqso.git@main#egg=simqso
+                python -m pip install git+https://github.com/${SIMQSO_REPO}/simqso.git@${SIMQSO_VERSION}#egg=simqso
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
             - name: Verify Installation

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,9 +18,9 @@ jobs:
             matrix:
                 os: [ubuntu-22.04]
                 python-version: ['3.10']
-                astropy-version: ['<6.1']
+                astropy-version: ['<6.1']  # Compatilbilty with desiconda 20240425-2.2.0.
                 fitsio-version: ['==1.2.1', '<2']
-                numpy-version: ['<1.23']
+                numpy-version: ['<1.23']  # Compatilbilty with desiconda 20240425-2.2.0.
         env:
             DESIUTIL_VERSION: 3.4.3
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
@@ -73,9 +73,9 @@ jobs:
             matrix:
                 os: [ubuntu-22.04]
                 python-version: ['3.10']
-                astropy-version: ['<6.1']
+                astropy-version: ['<6.1']  # Compatilbilty with desiconda 20240425-2.2.0.
                 fitsio-version: ['<2']
-                numpy-version: ['<1.23']  # to keep asscalar, used by astropy
+                numpy-version: ['<1.23']  # Compatilbilty with desiconda 20240425-2.2.0.
         env:
             DESIUTIL_VERSION: 3.4.3
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -11,12 +11,8 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 import sys
 import os
-import os.path
 from importlib import import_module
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -27,17 +23,6 @@ sys.path.insert(0, os.path.abspath('../py'))
 
 # If your documentation needs a minimal Sphinx version, state it here.
 
-try:
-    import sphinx.ext.napoleon
-    napoleon_extension = 'sphinx.ext.napoleon'
-except ImportError:
-    try:
-        import sphinxcontrib.napoleon
-        napoleon_extension = 'sphinxcontrib.napoleon'
-        needs_sphinx = '1.2'
-    except ImportError:
-        needs_sphinx = '1.3'
-
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
@@ -47,18 +32,18 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'sphinx_rtd_theme'
 ]
 
 # Configuration for intersphinx, copied from astropy.
 intersphinx_mapping = {
-    'python': ('http://docs.python.org/', None),
-    # 'python3': ('http://docs.python.org/3/', path.abspath(path.join(path.dirname(__file__), 'local/python3links.inv'))),
-    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
-    'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
-    'matplotlib': ('http://matplotlib.org/', None),
-    'astropy': ('http://docs.astropy.org/en/stable/', None),
-    'h5py': ('http://docs.h5py.org/en/latest/', None)
+    'python': ('https://docs.python.org/3/', None),
+    'numpy': ('https://numpy.org/doc/stable/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+    'matplotlib': ('https://matplotlib.org/stable/', None),
+    'astropy': ('https://docs.astropy.org/en/stable/', None),
+    'h5py': ('https://docs.h5py.org/en/latest/', None)
     }
 
 # Add any paths that contain templates here, relative to this directory.
@@ -147,12 +132,7 @@ for missing in ('astropy', 'desimodel', 'desiutil', 'desispec', 'desisurvey', 'd
 # a list of builtin themes.
 #html_theme = 'default'
 #html_theme = 'haiku'
-try:
-    import sphinx_rtd_theme
-    html_theme = 'sphinx_rtd_theme'
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
-except ImportError:
-    pass
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,19 @@
-# numpy<1.20
 pytz
 requests
+# Ensure scipy dependency does not bring in a recent version of numpy.
 scipy<1.9
+# The version of astropy will be reset by GitHub Actions tests.
 astropy
+# Ensure compatibility with numpy <1.23.
 numba<0.60
+# Ensure compatibility with numpy <1.23.
 matplotlib<3.9
 healpy
+# It is becoming difficult to install speclite and specsim directly from
+# git+https, so installing from PyPI is definitely preferred here.
 speclite
 specsim
+# The version of fitsio will be reset by GitHub Actions tests.
 fitsio
 # Install desiutil separately since it is needed for the other installs.
 # git+https://github.com/desihub/desiutil.git@3.1.0#egg=desiutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # numpy<1.20
 pytz
 requests
-astropy==5.0
+scipy<1.9
+astropy
 numba
 healpy
 speclite

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ astropy==5.0
 numba
 healpy
 speclite
+specsim
 fitsio
 # Install desiutil separately since it is needed for the other installs.
 # git+https://github.com/desihub/desiutil.git@3.1.0#egg=desiutil
@@ -14,6 +15,6 @@ git+https://github.com/desihub/desimodel.git@0.18.0#egg=desimodel
 git+https://github.com/desihub/desispec.git@0.36.1#egg=desispec
 # git+https://github.com/desihub/desitarget.git@0.50.0#egg=desitarget
 git+https://github.com/desihub/desitarget.git@main#egg=desitarget
-git+https://github.com/desihub/specsim.git@main#egg=specsim
+# git+https://github.com/desihub/specsim.git@main#egg=specsim
 # simqso install script requires numpy, so install separately.
 # git+https://github.com/imcgreer/simqso.git@v1.2.4#egg=simqso

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@
 pytz
 requests
 scipy<1.9
-astropy<0.60
+astropy
+numba<0.60
 healpy
 speclite
 specsim

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ requests
 scipy<1.9
 astropy
 numba<0.60
+matplotlib<3.9
 healpy
 speclite
 specsim

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@
 pytz
 requests
 scipy<1.9
-astropy
-numba
+astropy<0.60
 healpy
 speclite
 specsim

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup, find_packages
 #
 # DESI support code.
 #
-from desiutil.setup import DesiTest, DesiVersion, get_version
+from desiutil.setup import DesiVersion, get_version
 #
 # Begin setup
 #
@@ -55,7 +55,7 @@ setup_keywords['requires'] = ['Python (>2.7.0)']
 setup_keywords['zip_safe'] = False
 setup_keywords['packages'] = find_packages('py')
 setup_keywords['package_dir'] = {'':'py'}
-setup_keywords['cmdclass'] = {'version': DesiVersion, 'test': DesiTest, 'sdist': DistutilsSdist}
+setup_keywords['cmdclass'] = {'version': DesiVersion, 'sdist': DistutilsSdist}
 setup_keywords['test_suite']='{name}.test.test_suite'.format(**setup_keywords)
 #
 # Autogenerate command-line scripts.


### PR DESCRIPTION
This PR removes `desiutil.setup.DesiTest` from setup.py.

It looks like the format of `desimodel/data/focalplane/platescale.txt` has changed since the last time desisim was successfully tested, and that is causing the majority of the test errors.