### PR TITLE
fix tests and support numpy 2.x

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -76,12 +76,18 @@ jobs:
               run: |
                 mkdir -p ${GITHUB_WORKSPACE}/desimodel
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data ${GITHUB_WORKSPACE}/desimodel/data
+            - name: Install surveyops snapshot
+              env:
+                SURVEYOPS_VERSION: '2.0'
+              run: |
+                wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_${SURVEYOPS_VERSION}_ops.tar.gz
+                tar xzf surveyops_${SURVEYOPS_VERSION}_ops.tar.gz
             - name: Install desisim Data
               run: |
                 wget https://github.com/desihub/desisim-testdata/archive/${DESISIM_TESTDATA_VERSION}.zip
                 unzip ${DESISIM_TESTDATA_VERSION}.zip
             - name: Run the test
-              run: PYTHONPATH=${GITHUB_WORKSPACE}/py DESIMODEL=${GITHUB_WORKSPACE}/desimodel DESISIM=${GITHUB_WORKSPACE} DESI_ROOT=${GITHUB_WORKSPACE}/desisim-testdata-${DESISIM_TESTDATA_VERSION}/desi DESI_BASIS_TEMPLATES=${GITHUB_WORKSPACE}/desisim-testdata-${DESISIM_TESTDATA_VERSION}/desi/spectro/templates/basis_templates/v3.2 pytest
+              run: PYTHONPATH=${GITHUB_WORKSPACE}/py DESIMODEL=${GITHUB_WORKSPACE}/desimodel DESISIM=${GITHUB_WORKSPACE} DESI_ROOT=${GITHUB_WORKSPACE}/desisim-testdata-${DESISIM_TESTDATA_VERSION}/desi DESI_BASIS_TEMPLATES=${GITHUB_WORKSPACE}/desisim-testdata-${DESISIM_TESTDATA_VERSION}/desi/spectro/templates/basis_templates/v3.2 DESI_SURVEYOPS=$(pwd) pytest
 
     coverage:
         name: Test coverage
@@ -135,12 +141,18 @@ jobs:
               run: |
                 mkdir -p ${GITHUB_WORKSPACE}/desimodel
                 svn export https://desi.lbl.gov/svn/code/desimodel/${DESIMODEL_DATA}/data ${GITHUB_WORKSPACE}/desimodel/data
+            - name: Install surveyops snapshot
+              env:
+                SURVEYOPS_VERSION: '2.0'
+              run: |
+                wget -nv https://data.desi.lbl.gov/public/epo/example_files/surveyops_${SURVEYOPS_VERSION}_ops.tar.gz
+                tar xzf surveyops_${SURVEYOPS_VERSION}_ops.tar.gz
             - name: Install desisim Data
               run: |
                 wget https://github.com/desihub/desisim-testdata/archive/${DESISIM_TESTDATA_VERSION}.zip
                 unzip ${DESISIM_TESTDATA_VERSION}.zip
             - name: Run the test
-              run: PYTHONPATH=${GITHUB_WORKSPACE}/py DESIMODEL=${GITHUB_WORKSPACE}/desimodel DESISIM=${GITHUB_WORKSPACE} DESI_ROOT=${GITHUB_WORKSPACE}/desisim-testdata-${DESISIM_TESTDATA_VERSION}/desi DESI_BASIS_TEMPLATES=${GITHUB_WORKSPACE}/desisim-testdata-${DESISIM_TESTDATA_VERSION}/desi/spectro/templates/basis_templates/v3.2 pytest --cov
+              run: PYTHONPATH=${GITHUB_WORKSPACE}/py DESIMODEL=${GITHUB_WORKSPACE}/desimodel DESISIM=${GITHUB_WORKSPACE} DESI_ROOT=${GITHUB_WORKSPACE}/desisim-testdata-${DESISIM_TESTDATA_VERSION}/desi DESI_BASIS_TEMPLATES=${GITHUB_WORKSPACE}/desisim-testdata-${DESISIM_TESTDATA_VERSION}/desi/spectro/templates/basis_templates/v3.2 DESI_SURVEYOPS=$(pwd) pytest --cov
             - name: Coveralls
               env:
                 COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,12 +22,12 @@ jobs:
                       # numba doesn't yet support numpy/2.3; could be relaxed in the future
                       numpy-version: '<2.3'
                       scipy-version: ''
-                      astropy-version: '<8'
+                      astropy-version: '<7'
                     - os: ubuntu-latest
                       python-version: '3.12'
                       numpy-version: '<2.3'
                       scipy-version: '<2'
-                      astropy-version: '<7.1'
+                      astropy-version: '<7'
                     - os: ubuntu-latest
                       python-version: '3.11'
                       numpy-version: '<2.1'
@@ -42,7 +42,8 @@ jobs:
         env:
             DESIUTIL_VERSION: 3.5.0
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
-            DESIMODEL_DATA: branches/test-0.19
+            # desisim -> specsim needs data/specpsf/psf-quicksim-rebin.fits which isn't in trimmed down test data
+            DESIMODEL_DATA: trunk
             # DESISIM: ${GITHUB_WORKSPACE}/desisim
             DESISIM_TESTDATA_VERSION: main
             # DESI_ROOT: ${DESISIM}/desi
@@ -100,14 +101,15 @@ jobs:
             matrix:
                 os: [ubuntu-22.04]
                 python-version: ['3.10']
-                astropy-version: ['<6.1']  # Compatilbilty with desiconda 20240425-2.2.0.
+                astropy-version: ['<6.1']  # Compatibilty with desiconda 20240425-2.2.0.
                 fitsio-version: ['<2']
-                numpy-version: ['<1.23']  # Compatilbilty with desiconda 20240425-2.2.0.
+                numpy-version: ['<1.23']  # Compatibilty with desiconda 20240425-2.2.0.
                 scipy-version: ['<1.9']
         env:
             DESIUTIL_VERSION: 3.4.3
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
-            DESIMODEL_DATA: branches/test-0.19
+            # desisim -> specsim needs data/specpsf/psf-quicksim-rebin.fits which isn't in trimmed down test data
+            DESIMODEL_DATA: trunk
             # DESISIM: ${GITHUB_WORKSPACE}/desisim
             DESISIM_TESTDATA_VERSION: main
             # DESI_ROOT: ${DESISIM}/desi

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,19 +20,23 @@ jobs:
                     - os: ubuntu-latest
                       python-version: '3.13'
                       numpy-version: '<3'
+                      scipy-version: ''
                       astropy-version: '<8'
                     - os: ubuntu-latest
                       python-version: '3.12'
                       numpy-version: '<2.3'
+                      scipy-version: '<2'
                       astropy-version: '<7.1'
                     - os: ubuntu-latest
                       python-version: '3.11'
                       numpy-version: '<2.1'
+                      scipy-version: '<2'
                       astropy-version: '<7'
                     # Similar to NERSC but with last NumPy < 2.
                     - os: ubuntu-latest
                       python-version: '3.10'
                       numpy-version: '<2'
+                      scipy-version: '<1.9'
                       astropy-version: '<6.1'
         env:
             DESIUTIL_VERSION: 3.5.0
@@ -61,6 +65,7 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 python -m pip install --upgrade --upgrade-strategy only-if-needed 'numpy${{ matrix.numpy-version }}'
+                python -m pip install --upgrade --upgrade-strategy only-if-needed 'scipy${{ matrix.scipy-version }}'
                 python -m pip install --upgrade --upgrade-strategy only-if-needed 'astropy${{ matrix.astropy-version }}'
                 python -m pip install git+https://github.com/${SIMQSO_REPO}/simqso.git@${SIMQSO_VERSION}#egg=simqso
             - name: Verify Installation
@@ -87,6 +92,7 @@ jobs:
                 astropy-version: ['<6.1']  # Compatilbilty with desiconda 20240425-2.2.0.
                 fitsio-version: ['<2']
                 numpy-version: ['<1.23']  # Compatilbilty with desiconda 20240425-2.2.0.
+                scipy-version: ['<1.9']
         env:
             DESIUTIL_VERSION: 3.4.3
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
@@ -114,6 +120,7 @@ jobs:
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
                 python -m pip install -U 'numpy${{ matrix.numpy-version }}'
+                python -m pip install -U 'scipy${{ matrix.scipy-version }}'
                 python -m pip install -U 'astropy${{ matrix.astropy-version }}'
                 python -m pip install git+https://github.com/${SIMQSO_REPO}/simqso.git@${SIMQSO_VERSION}#egg=simqso
                 python -m pip cache remove fitsio

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -62,8 +62,10 @@ jobs:
               with:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
+              # setuptools version restriction due to specsim ah_helpers needing setuptools.package_index
+              # which was removed in setuptools/80.3.0
               run: |
-                python -m pip install --upgrade pip setuptools wheel
+                python -m pip install --upgrade pip 'setuptools<80' wheel
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
@@ -126,7 +128,7 @@ jobs:
                 python-version: ${{ matrix.python-version }}
             - name: Install Python dependencies
               run: |
-                python -m pip install --upgrade pip setuptools wheel
+                python -m pip install --upgrade pip 'setuptools<80' wheel
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,8 +54,6 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
-              with:
-                fetch-depth: 0
             - name: Install System Packages
               run: sudo apt install libbz2-dev subversion
             - name: Set up Python ${{ matrix.python-version }}
@@ -120,8 +118,6 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
-              with:
-                fetch-depth: 0
             - name: Install System Packages
               run: sudo apt install libbz2-dev subversion
             - name: Set up Python ${{ matrix.python-version }}
@@ -176,8 +172,6 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
-              with:
-                fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v5
               with:
@@ -199,8 +193,6 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
-              with:
-                fetch-depth: 0
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v5
               with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -54,6 +54,8 @@ jobs:
               uses: actions/checkout@v4
               with:
                 fetch-depth: 0
+            - name: Install System Packages
+              run: sudo apt install libbz2-dev subversion
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v5
               with:
@@ -109,6 +111,8 @@ jobs:
               uses: actions/checkout@v4
               with:
                 fetch-depth: 0
+            - name: Install System Packages
+              run: sudo apt install libbz2-dev subversion
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v5
               with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,7 +19,8 @@ jobs:
                 include:
                     - os: ubuntu-latest
                       python-version: '3.13'
-                      numpy-version: '<3'
+                      # numba doesn't yet support numpy/2.3; could be relaxed in the future
+                      numpy-version: '<2.3'
                       scipy-version: ''
                       astropy-version: '<8'
                     - os: ubuntu-latest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,13 +16,26 @@ jobs:
         strategy:
             fail-fast: true
             matrix:
-                os: [ubuntu-22.04]
-                python-version: ['3.10']
-                astropy-version: ['<6.1']  # Compatilbilty with desiconda 20240425-2.2.0.
-                fitsio-version: ['==1.2.1', '<2']
-                numpy-version: ['<1.23']  # Compatilbilty with desiconda 20240425-2.2.0.
+                include:
+                    - os: ubuntu-latest
+                      python-version: '3.13'
+                      numpy-version: '<3'
+                      astropy-version: '<8'
+                    - os: ubuntu-latest
+                      python-version: '3.12'
+                      numpy-version: '<2.3'
+                      astropy-version: '<7.1'
+                    - os: ubuntu-latest
+                      python-version: '3.11'
+                      numpy-version: '<2.1'
+                      astropy-version: '<7'
+                    # Similar to NERSC but with last NumPy < 2.
+                    - os: ubuntu-latest
+                      python-version: '3.10'
+                      numpy-version: '<2'
+                      astropy-version: '<6.1'
         env:
-            DESIUTIL_VERSION: 3.4.3
+            DESIUTIL_VERSION: 3.5.0
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
             DESIMODEL_DATA: branches/test-0.18
             # DESISIM: ${GITHUB_WORKSPACE}/desisim
@@ -47,11 +60,9 @@ jobs:
                 python -m pip install pytest
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install -U 'numpy${{ matrix.numpy-version }}'
-                python -m pip install -U 'astropy${{ matrix.astropy-version }}'
+                python -m pip install --upgrade --upgrade-strategy only-if-needed 'numpy${{ matrix.numpy-version }}'
+                python -m pip install --upgrade --upgrade-strategy only-if-needed 'astropy${{ matrix.astropy-version }}'
                 python -m pip install git+https://github.com/${SIMQSO_REPO}/simqso.git@${SIMQSO_VERSION}#egg=simqso
-                python -m pip cache remove fitsio
-                python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'
             - name: Verify Installation
               run: pip list
             - name: Install desimodel Data

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,7 +40,7 @@ jobs:
                       scipy-version: '<1.9'
                       astropy-version: '<6.1'
         env:
-            DESIUTIL_VERSION: 3.5.0
+            DESIUTIL_VERSION: 3.5.2
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
             # desisim -> specsim needs data/specpsf/psf-quicksim-rebin.fits which isn't in trimmed down test data
             DESIMODEL_DATA: trunk
@@ -103,10 +103,10 @@ jobs:
                 python-version: ['3.10']
                 astropy-version: ['<6.1']  # Compatibilty with desiconda 20240425-2.2.0.
                 fitsio-version: ['<2']
-                numpy-version: ['<1.23']  # Compatibilty with desiconda 20240425-2.2.0.
+                numpy-version: ['<2']
                 scipy-version: ['<1.9']
         env:
-            DESIUTIL_VERSION: 3.4.3
+            DESIUTIL_VERSION: 3.5.2
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
             # desisim -> specsim needs data/specpsf/psf-quicksim-rebin.fits which isn't in trimmed down test data
             DESIMODEL_DATA: trunk
@@ -134,9 +134,9 @@ jobs:
                 python -m pip install pytest pytest-cov coveralls
                 python -m pip install git+https://github.com/desihub/desiutil.git@${DESIUTIL_VERSION}#egg=desiutil
                 python -m pip install -r requirements.txt
-                python -m pip install -U 'numpy${{ matrix.numpy-version }}'
-                python -m pip install -U 'scipy${{ matrix.scipy-version }}'
-                python -m pip install -U 'astropy${{ matrix.astropy-version }}'
+                python -m pip install --upgrade --upgrade-strategy only-if-needed 'numpy${{ matrix.numpy-version }}'
+                python -m pip install --upgrade --upgrade-strategy only-if-needed 'scipy${{ matrix.scipy-version }}'
+                python -m pip install --upgrade --upgrade-strategy only-if-needed 'astropy${{ matrix.astropy-version }}'
                 python -m pip install git+https://github.com/${SIMQSO_REPO}/simqso.git@${SIMQSO_VERSION}#egg=simqso
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,7 +41,7 @@ jobs:
         env:
             DESIUTIL_VERSION: 3.5.0
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
-            DESIMODEL_DATA: branches/test-0.18
+            DESIMODEL_DATA: branches/test-0.19
             # DESISIM: ${GITHUB_WORKSPACE}/desisim
             DESISIM_TESTDATA_VERSION: main
             # DESI_ROOT: ${DESISIM}/desi
@@ -96,7 +96,7 @@ jobs:
         env:
             DESIUTIL_VERSION: 3.4.3
             # DESIMODEL: ${GITHUB_WORKSPACE}/desimodel
-            DESIMODEL_DATA: branches/test-0.18
+            DESIMODEL_DATA: branches/test-0.19
             # DESISIM: ${GITHUB_WORKSPACE}/desisim
             DESISIM_TESTDATA_VERSION: main
             # DESI_ROOT: ${DESISIM}/desi

--- a/doc/rtd-requirements.txt
+++ b/doc/rtd-requirements.txt
@@ -1,3 +1,1 @@
-setuptools>60
-Sphinx>6,<7
 sphinx-rtd-theme>1

--- a/doc/rtd-requirements.txt
+++ b/doc/rtd-requirements.txt
@@ -1,4 +1,3 @@
 setuptools>60
 Sphinx>6,<7
 sphinx-rtd-theme>1
-urllib3<2

--- a/py/desisim/__init__.py
+++ b/py/desisim/__init__.py
@@ -8,7 +8,6 @@ desisim
 Tools for DESI instrument simulations, including input templates.
 It does not cover cosmology simulations.
 """
-from __future__ import absolute_import
 # from . import pixsim
 # from . import obs
 # from . import io

--- a/py/desisim/archetypes.py
+++ b/py/desisim/archetypes.py
@@ -6,8 +6,6 @@ Archetype routines for desisim.
 
 """
 
-from __future__ import absolute_import, division, print_function
-
 import os
 import numpy as np
 

--- a/py/desisim/bal.py
+++ b/py/desisim/bal.py
@@ -5,7 +5,6 @@ desisim.bal
 Functions and methods for inserting BALs into QSO spectra.
 
 """
-from __future__ import division, print_function
 
 import numpy as np
 

--- a/py/desisim/batch/__init__.py
+++ b/py/desisim/batch/__init__.py
@@ -5,7 +5,6 @@ desisim.batch
 Batch scripts.  Why exactly is this sub-package different from
 :mod:`desisim.scripts`?
 """
-from __future__ import absolute_import, division, print_function
 import math
 
 from desiutil.log import get_logger

--- a/py/desisim/batch/pixsim.py
+++ b/py/desisim/batch/pixsim.py
@@ -23,7 +23,6 @@ Submitted batch job 233895
 Submitted batch job 233901
 '''
 
-from __future__ import absolute_import, division, print_function
 import os
 import numpy as np
 

--- a/py/desisim/dla.py
+++ b/py/desisim/dla.py
@@ -5,12 +5,10 @@ desisim.dla
 Functions and methods for inserting DLAs into QSO spectra.
 
 """
-from __future__ import division, print_function
-
 import numpy as np
 from scipy.special import wofz
 
-from pkg_resources import resource_filename
+from importlib import resources
 
 from astropy import constants as const
 from desiutil.log import get_logger
@@ -180,7 +178,7 @@ def init_fNHI(slls=False, mix=True):
     from astropy.io import fits
     from scipy import interpolate as scii
     # f(N)
-    fN_file = resource_filename('desisim','data/fN_spline_z24.fits.gz')
+    fN_file = str(resources.files('desisim').joinpath('data', 'fN_spline_z24.fits.gz'))
     hdu = fits.open(fN_file)
     fN_data = hdu[1].data
     # Instantiate

--- a/py/desisim/eboss.py
+++ b/py/desisim/eboss.py
@@ -178,14 +178,14 @@ def create_sdss2desi_redshift_distribution_ratio(sdss_cat,desi_cat,out,dz=0.04,m
 
     sdss['LOWD'] = {}
     pixLowD = unique_pix[density<densityCut]
-    w = np.in1d(pix,pixLowD)
+    w = np.isin(pix,pixLowD)
     sdss['LOWD']['HIST'], zhist = np.histogram(sdss['Z'][w],bins=bins,density=True)
     sdss['LOWD']['ZHIST'] = np.array([ zhist[i]+(zhist[i+1]-zhist[i])/2. for i in range(zhist.size-1) ])
     sdss['LOWD']['PIXS'] = pixLowD
 
     sdss['HIGHD'] = {}
     pixHighD = unique_pix[density>=densityCut]
-    w = np.in1d(pix,pixHighD)
+    w = np.isin(pix,pixHighD)
     sdss['HIGHD']['HIST'], zhist = np.histogram(sdss['Z'][w],bins=bins,density=True)
     sdss['HIGHD']['ZHIST'] = np.array([ zhist[i]+(zhist[i+1]-zhist[i])/2. for i in range(zhist.size-1) ])
     sdss['HIGHD']['PIXS'] = pixHighD
@@ -339,7 +339,7 @@ class RedshiftDistributionEBOSS(object):
 
         frac = np.ones(ra.size)
         for k in ['LOW_DENSITY','HIGH_DENSITY']:
-            w = np.in1d(pix,self.hist[k]['PIX'])
+            w = np.isin(pix,self.hist[k]['PIX'])
             frac[w] = self.hist[k]['HIST'][bins[w]]
 
         return frac

--- a/py/desisim/eboss.py
+++ b/py/desisim/eboss.py
@@ -5,11 +5,10 @@ desisim.eboss
 Functions and methods for mimicking eBOSS survey.
 
 """
-from __future__ import division, print_function
 import numpy as np
 import os
 import healpy
-from pkg_resources import resource_filename
+from importlib import resources
 import astropy.io.fits as pyfits
 
 def create_sdss_footprint(sdss_cat,out,mjd_min=55000,zmin=1.8,nside=16,nest=True):
@@ -78,7 +77,7 @@ class FootprintEBOSS(object):
         if not nside==16:
             raise ValueError('add eBOSS footprint for nside='+str(nside))
 
-        fname=resource_filename('desisim','data/eboss_footprint_nside_16.txt')
+        fname=str(resources.files('desisim').joinpath('data', 'eboss_footprint_nside_16.txt'))
         print('in read_sdss_footprint from file',fname)
         if not os.path.isfile(fname):
             print('eBOSS footprint file',fname)
@@ -293,7 +292,7 @@ class RedshiftDistributionEBOSS(object):
         if not nside==16:
             raise ValueError('add eBOSS footprint for nside = {}'.format(nside))
 
-        fname = resource_filename('desisim','data/eboss_redshift_distributon_fraction_dz_004_nside_16.txt')
+        fname = str(resources.files('desisim').joinpath('data', 'eboss_redshift_distributon_fraction_dz_004_nside_16.txt'))
         print('in read_sdss_redshift_distribution from file {}'.format(fname))
         if not os.path.isfile(fname):
             print('eBOSS redshift distribution fraction file'.format(fname))

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -5,8 +5,6 @@ desisim.io
 I/O routines for desisim
 """
 
-from __future__ import absolute_import, division, print_function
-
 import os
 import time
 from glob import glob

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -432,7 +432,7 @@ def fibers2cameras(fibers):
     cameras = list()
     for spectrograph in range(10):
         ii = np.arange(500) + spectrograph*500
-        if np.any(np.in1d(ii, fibers)):
+        if np.any(np.isin(ii, fibers)):
             for channel in ['b', 'r', 'z']:
                 cameras.append(channel + str(spectrograph))
     return cameras
@@ -533,7 +533,7 @@ def read_simspec(filename, cameras=None, comm=None, readflux=True, readphot=True
     for camera in cameras:
         spectrograph = int(camera[1])   #- e.g. b0
         fibers = np.arange(500, dtype=int) + spectrograph*500
-        ii |= np.in1d(fibermap['FIBER'], fibers)
+        ii |= np.isin(fibermap['FIBER'], fibers)
 
     assert np.any(ii), "input simspec doesn't cover cameras {}".format(cameras)
 

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -123,9 +123,10 @@ def write_simspec(sim, truth, fibermap, obs, expid, night, objmeta=None,
     from desiutil.log import get_logger
     log = get_logger()
 
-    import warnings
     warnings.filterwarnings("ignore", message=".*Dex.* did not parse as fits unit")
     warnings.filterwarnings("ignore", message=".*nanomaggies.* did not parse as fits unit")
+    warnings.filterwarnings("ignore", message=".*nmgy.* did not parse as fits unit")
+    warnings.filterwarnings("ignore", message=".*nmgy.* could not be saved")
     warnings.filterwarnings("ignore", message=r".*10\*\*6 arcsec.* did not parse as fits unit")
 
     if filename is None:
@@ -278,9 +279,10 @@ def write_simspec_arc(filename, wave, phot, header, fibermap, overwrite=False):
     import astropy.table
     import astropy.units as u
 
-    import warnings
     warnings.filterwarnings("ignore", message=".*Dex.* did not parse as fits unit")
     warnings.filterwarnings("ignore", message=".*nanomaggies.* did not parse as fits unit")
+    warnings.filterwarnings("ignore", message=".*nmgy.* did not parse as fits unit")
+    warnings.filterwarnings("ignore", message=".*nmgy.* could not be saved")
     warnings.filterwarnings("ignore", message=r".*10\*\*6 arcsec.* did not parse as fits unit")
                     
     hx = fits.HDUList()

--- a/py/desisim/lya_spectra.py
+++ b/py/desisim/lya_spectra.py
@@ -5,7 +5,6 @@ desisim.lya_spectra
 Function to simulate a QSO spectrum including Lyman-alpha absorption.
 
 """
-from __future__ import division, print_function
 
 import numpy as np
 from desisim.dla import insert_dlas

--- a/py/desisim/lya_spectra.py
+++ b/py/desisim/lya_spectra.py
@@ -276,7 +276,7 @@ def apply_metals_transmission(qso_wave,qso_flux,trans_wave,trans,metals,mocktype
         nolstMetals = ''
         for m in absorber_IGM.keys():
             lstMetals += m+', '
-        for m in np.array(metals)[~np.in1d(metals,[mm for mm in absorber_IGM.keys()])]:
+        for m in np.array(metals)[~np.isin(metals,[mm for mm in absorber_IGM.keys()])]:
             nolstMetals += m+', '
         raise Exception("Input metals {} are not in the list, available metals are {}".format(nolstMetals[:-2],lstMetals[:-2])) from e
     except TypeError as e:

--- a/py/desisim/lya_spectra.py
+++ b/py/desisim/lya_spectra.py
@@ -421,15 +421,14 @@ def get_spectra(lyafile, nqso=None, wave=None, templateid=None, normfilter='sdss
                     dla_NHI += [idla['N'] for idla in dlas]
                     dla_id += [indx]*ndla
 
-        padflux, padwave = normfilt.pad_spectrum(flux1, wave, method='edge')
-        normmaggies = np.array(normfilt.get_ab_maggies(padflux, padwave,
-                                                       mask_invalid=True)[normfilter])
+        padflux, padwave = normfilt.pad_spectrum(flux1[0], wave, method='edge')
+        normmaggies = normfilt.get_ab_maggies(padflux, padwave, mask_invalid=True)[normfilter][0]
 
         factor = 10**(-0.4 * mag_g[ii]) / normmaggies
         flux1 *= factor
         for key in ('FLUX_G', 'FLUX_R', 'FLUX_Z', 'FLUX_W1', 'FLUX_W2'):
             meta[key][ii] *= factor
-        flux[ii, :] = flux1[:]
+        flux[ii, :] = flux1[0]
 
     h.close()
 

--- a/py/desisim/obs.py
+++ b/py/desisim/obs.py
@@ -4,7 +4,6 @@ desisim.obs
 
 Utility functions related to simulating observations for DESI
 """
-from __future__ import absolute_import, division, print_function
 
 import os, sys
 import numpy as np

--- a/py/desisim/pixelsplines.py
+++ b/py/desisim/pixelsplines.py
@@ -6,7 +6,6 @@ Pixel-integrated spline utilities.
 
 Written by A. Bolton, U. of Utah, 2010-2013.
 """
-from __future__ import absolute_import, division, print_function
 
 import numpy as n
 from scipy import linalg as la

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -5,8 +5,6 @@ desisim.pixsim
 Tools for DESI pixel level simulations using specter
 """
 
-from __future__ import absolute_import, division, print_function
-
 import sys
 import os
 import os.path

--- a/py/desisim/qso_template/boss_qsos_figs.py
+++ b/py/desisim/qso_template/boss_qsos_figs.py
@@ -10,7 +10,6 @@
 #;-
 #;------------------------------------------------------------------------------
 """
-from __future__ import print_function, absolute_import, division
 
 import numpy as np
 import os

--- a/py/desisim/qso_template/desi_qso_templ.py
+++ b/py/desisim/qso_template/desi_qso_templ.py
@@ -6,7 +6,6 @@ Module for Fitting PCA to the BOSS QSOs
 
 01-Dec-2014 by JXP
 """
-from __future__ import print_function, absolute_import, division
 
 import numpy as np
 import os

--- a/py/desisim/qso_template/fit_boss_qsos.py
+++ b/py/desisim/qso_template/fit_boss_qsos.py
@@ -6,7 +6,6 @@ Module for Fitting PCA to the BOSS QSOs
 
 01-Dec-2014 by JXP
 """
-from __future__ import print_function, absolute_import, division
 
 import numpy as np
 import os

--- a/py/desisim/qso_template/qso_pca.py
+++ b/py/desisim/qso_template/qso_pca.py
@@ -6,7 +6,6 @@ Module for generate QSO PCA templates
 
 24-Nov-2014 by JXP
 """
-from __future__ import print_function, absolute_import, division
 
 import numpy as np
 import os

--- a/py/desisim/qso_template/tests.py
+++ b/py/desisim/qso_template/tests.py
@@ -8,7 +8,6 @@ Module for generate QSO PCA templates
 
 I don't think the documentation of this module is correct.
 """
-from __future__ import print_function, absolute_import, division
 
 import numpy as np
 import os

--- a/py/desisim/quickcat.py
+++ b/py/desisim/quickcat.py
@@ -30,6 +30,8 @@ from desitarget.targetmask import desi_mask, bgs_mask, mws_mask
 from desiutil.log import get_logger
 log = get_logger()
 
+from desisim.util import hadec2airmass
+
 #- redshift errors, zwarn, cata fail rate fractions from
 #- /project/projectdirs/desi/datachallenge/redwood/spectro/redux/redwood/
 #- sigmav = c sigmaz / (1+z)
@@ -522,7 +524,7 @@ def get_median_obsconditions(tileids):
     import desimodel.io
     tiles = desimodel.io.load_tiles()
     tileids = np.asarray(tileids)
-    ii = np.in1d(tiles['TILEID'], tileids)
+    ii = np.isin(tiles['TILEID'], tileids)
 
     tiles = tiles[ii]
     assert len(tiles) == len(tileids)
@@ -535,33 +537,32 @@ def get_median_obsconditions(tileids):
     tiles = tiles[j[k]]
     assert np.all(tiles['TILEID'] == tileids)
 
-    #- fix type bug after reading desi-tiles.fits
-    if tiles['OBSCONDITIONS'].dtype == np.float64:
-        tiles = Table(tiles)
-        tiles.replace_column('OBSCONDITIONS', tiles['OBSCONDITIONS'].astype(int))
-
     n = len(tileids)
+
+    #- ensure UPPERCASE just in case
+    program = np.char.upper(tiles['PROGRAM'])
 
     obsconditions = Table()
     obsconditions['TILEID'] = tileids
-    obsconditions['AIRMASS'] = tiles['AIRMASS']
+    obsconditions['AIRMASS'] = hadec2airmass(tiles['DESIGNHA'], tiles['DEC'])
     obsconditions['EBMV'] = tiles['EBV_MED']
     obsconditions['LINTRANS'] = np.ones(n)
     obsconditions['SEEING'] = np.ones(n) * 1.1
 
     #- Add lunar conditions, defaulting to dark time
-    from desitarget.targetmask import obsconditions as obsbits
     obsconditions['MOONFRAC'] = np.zeros(n)
     obsconditions['MOONALT'] = -20.0 * np.ones(n)
     obsconditions['MOONSEP'] = 180.0 * np.ones(n)
 
-    ii = (tiles['OBSCONDITIONS'] & obsbits.GRAY) != 0
-    obsconditions['MOONFRAC'][ii] = 0.1
-    obsconditions['MOONALT'][ii] = 10.0
-    obsconditions['MOONSEP'][ii] = 60.0
-
-    ii = (tiles['OBSCONDITIONS'] & obsbits.BRIGHT) != 0
+    #- bright, bright1b programs
+    ii = np.char.startswith(program, 'BRIGHT')
     obsconditions['MOONFRAC'][ii] = 0.7
+    obsconditions['MOONALT'][ii] = 60.0
+    obsconditions['MOONSEP'][ii] = 50.0
+
+    #- backup program
+    ii = np.char.startswith(program, 'BACKUP')
+    obsconditions['MOONFRAC'][ii] = 1.0
     obsconditions['MOONALT'][ii] = 60.0
     obsconditions['MOONSEP'][ii] = 50.0
 
@@ -615,7 +616,7 @@ def quickcat(tilefiles, targets, truth, fassignhdu='FIBERASSIGN', zcat=None, obs
 
     #- Trim obsconditions to just the tiles that were observed
     if obsconditions is not None:
-        ii = np.in1d(obsconditions['TILEID'], tileids)
+        ii = np.isin(obsconditions['TILEID'], tileids)
         if np.any(ii == False):
             obsconditions = obsconditions[ii]
         assert len(obsconditions) > 0
@@ -635,7 +636,7 @@ def quickcat(tilefiles, targets, truth, fassignhdu='FIBERASSIGN', zcat=None, obs
     #- Trim truth down to just ones that have already been observed
     log.info('{} QC Trimming truth to just observed targets'.format(asctime()))
     obs_targetids = np.array(list(nobs.keys()))
-    iiobs = np.in1d(truth['TARGETID'], obs_targetids)
+    iiobs = np.isin(truth['TARGETID'], obs_targetids)
     truth = truth[iiobs]
     targets = targets[iiobs]
 
@@ -684,15 +685,15 @@ def quickcat(tilefiles, targets, truth, fassignhdu='FIBERASSIGN', zcat=None, obs
         zcat = zcat.copy()
 
         # needed to have the same ordering both in zcat and newzcat
-        # to ensure consistent use of masks from np.in1d()
+        # to ensure consistent use of masks from np.isin()
         zcat.sort(keys='TARGETID')
         newzcat.sort(keys='TARGETID') 
         
         #- targets that are in both zcat and newzcat
-        repeats = np.in1d(zcat['TARGETID'], newzcat['TARGETID'])
+        repeats = np.isin(zcat['TARGETID'], newzcat['TARGETID'])
 
         #- update numobs in both zcat and newzcat
-        ii = np.in1d(newzcat['TARGETID'], zcat['TARGETID'][repeats])
+        ii = np.isin(newzcat['TARGETID'], zcat['TARGETID'][repeats])
         orig_numobs = zcat['NUMOBS'][repeats].copy()
         new_numobs = newzcat['NUMOBS'][ii].copy()
         zcat['NUMOBS'][repeats] += new_numobs
@@ -701,15 +702,15 @@ def quickcat(tilefiles, targets, truth, fassignhdu='FIBERASSIGN', zcat=None, obs
         #- replace only repeats that had ZWARN flags in original zcat
         #- replace in new
         replace = repeats & (zcat['ZWARN'] != 0)
-        jj = np.in1d(newzcat['TARGETID'], zcat['TARGETID'][replace])
+        jj = np.isin(newzcat['TARGETID'], zcat['TARGETID'][replace])
         zcat[replace] = newzcat[jj]
 
         #- trim newzcat to ones that shouldn't override original zcat
-        discard = np.in1d(newzcat['TARGETID'], zcat['TARGETID'])
+        discard = np.isin(newzcat['TARGETID'], zcat['TARGETID'])
         newzcat = newzcat[~discard]
 
         #- Should be non-overlapping now
-        assert np.all(np.in1d(zcat['TARGETID'], newzcat['TARGETID']) == False)
+        assert np.all(np.isin(zcat['TARGETID'], newzcat['TARGETID']) == False)
 
         #- merge them
         newzcat = vstack([zcat, newzcat])

--- a/py/desisim/quickcat.py
+++ b/py/desisim/quickcat.py
@@ -6,12 +6,10 @@ Code for quickly generating an output zcatalog given fiber assignment tiles,
 a truth catalog, and optionally a previous zcatalog.
 '''
 
-from __future__ import absolute_import, division, print_function
-
 import os
 import yaml
 from collections import Counter
-from pkg_resources import resource_filename
+from importlib import resources
 from time import asctime
 
 import numpy as np
@@ -190,10 +188,10 @@ def get_redshift_efficiency(simtype, targets, truth, targets_in_tile, obsconditi
     
     if (simtype == 'ELG'):
         # Read the model OII flux threshold (FDR fig 7.12 modified to fit redmonster efficiency on OAK)
-        # filename = resource_filename('desisim', 'data/quickcat_elg_oii_flux_threshold.txt')
+        # filename = str(resources.files('desisim').joinpath('data', 'quickcat_elg_oii_flux_threshold.txt'))
         
         # Read the model OII flux threshold (FDR fig 7.12)
-        filename = resource_filename('desisim', 'data/elg_oii_flux_threshold_fdr.txt')
+        filename = str(resources.files('desisim').joinpath('data', 'elg_oii_flux_threshold_fdr.txt'))
         fdr_z, modified_fdr_oii_flux_threshold = np.loadtxt(filename, unpack=True)
         
         # Compute OII flux thresholds for truez
@@ -362,7 +360,7 @@ def get_observed_redshifts(targets, truth, targets_in_tile, obsconditions, param
     
     if parameter_filename is None :
         # Load efficiency parameters yaml file
-        parameter_filename = resource_filename('desisim', 'data/quickcat.yaml')
+        parameter_filename = str(resources.files('desisim').joinpath('data', 'quickcat.yaml'))
     
     params=None
     with open(parameter_filename,"r") as file :

--- a/py/desisim/quicksurvey.py
+++ b/py/desisim/quicksurvey.py
@@ -264,7 +264,7 @@ class SimSetup(object):
 
         #update obsconditions from progress_data
 #        progress_data = Table.read(self.progress_files[epoch + 1])
-#        ii = np.in1d(progress_data['TILEID'], self.observed_tiles)
+#        ii = np.isin(progress_data['TILEID'], self.observed_tiles)
 #        obsconditions = progress_data[ii]
         obsconditions = None
         print('tilefiles', len(self.tilefiles))

--- a/py/desisim/quicksurvey.py
+++ b/py/desisim/quicksurvey.py
@@ -12,7 +12,6 @@ Directly depends on the following DESI products:
 * `fiberassign <https://github.com/desihub/fiberassign>`_
 '''
 
-from __future__ import absolute_import, division, print_function
 import gc
 import numpy as np
 import os

--- a/py/desisim/scripts/__init__.py
+++ b/py/desisim/scripts/__init__.py
@@ -8,5 +8,3 @@ desisim.scripts
 
 Main functions and command-line parsing.
 """
-
-from __future__ import absolute_import, division

--- a/py/desisim/scripts/brightsims.py
+++ b/py/desisim/scripts/brightsims.py
@@ -5,8 +5,6 @@ desisim.scripts.brightsims
 Generate a canonical set of bright-time simulations.
 """
 
-from __future__ import division, print_function
-
 import os
 import sys
 import numpy as np

--- a/py/desisim/scripts/brightsims_aug2017.py
+++ b/py/desisim/scripts/brightsims_aug2017.py
@@ -5,8 +5,6 @@ desisim.scripts.brightsims
 Generate a canonical set of bright-time simulations.
 """
 
-from __future__ import division, print_function
-
 import os
 import sys
 import numpy as np

--- a/py/desisim/scripts/fastframe.py
+++ b/py/desisim/scripts/fastframe.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import sys, os
 import numpy as np
 from astropy.table import Table

--- a/py/desisim/scripts/lya_simqso_model.py
+++ b/py/desisim/scripts/lya_simqso_model.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 import os
 import numpy as np
-from pkg_resources import resource_filename
+from importlib import resources
 from astropy.cosmology import FlatLambdaCDM
 import simqso.sqgrids  as grids
 from simqso.lumfun import QlfEvolParam,PolyEvolParam,DoublePowerLawLF
@@ -122,7 +122,7 @@ def EmLineTemplate_modified_develop(*args,**kwargs):
                                   'MgIIb':0.8,'MgIIn':0.8
                                   #Add more lines if needed.
                                   }) 
-    kwargs['EmissionLineTrendFilename']=resource_filename('desisim', 'data/emlinetrends_develop')
+    kwargs['EmissionLineTrendFilename']=str(resources.files('desisim').joinpath('data','emlinetrends_develop'))
     return grids.generateBEffEmissionLines(*args,**kwargs)
 
 def EmLineTemplate_modified(*args,**kwargs):
@@ -136,7 +136,7 @@ def EmLineTemplate_modified(*args,**kwargs):
                                 'LyAb':1.2,'LyAn':1.2,
                                 'CIII*':1.7
                                 })
-    kwargs['EmissionLineTrendFilename']=resource_filename('desisim', 'data/emlinetrends_Harris2016mod_v2')
+    kwargs['EmissionLineTrendFilename']=str(resources.files('desisim').joinpath('data', 'emlinetrends_Harris2016mod_v2'))
     print('Using emission lines file: {}'.format(kwargs['EmissionLineTrendFilename']))
     return grids.generateBEffEmissionLines(*args,**kwargs)
 

--- a/py/desisim/scripts/newarc.py
+++ b/py/desisim/scripts/newarc.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import sys, os
 import argparse
 import datetime

--- a/py/desisim/scripts/newexp_mock.py
+++ b/py/desisim/scripts/newexp_mock.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import sys, os
 import argparse
 

--- a/py/desisim/scripts/newexp_random.py
+++ b/py/desisim/scripts/newexp_random.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import sys, os
 import argparse
 

--- a/py/desisim/scripts/newflat.py
+++ b/py/desisim/scripts/newflat.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import sys, os
 import argparse
 import datetime

--- a/py/desisim/scripts/pixsim.py
+++ b/py/desisim/scripts/pixsim.py
@@ -4,7 +4,6 @@ desisim.scripts.pixsim
 
 This is a module.
 """
-from __future__ import absolute_import, division, print_function
 
 import os,sys
 import os.path

--- a/py/desisim/scripts/pixsim_nights.py
+++ b/py/desisim/scripts/pixsim_nights.py
@@ -4,7 +4,6 @@ desisim.scripts.pixsim_nights
 
 This is a module.
 """
-from __future__ import absolute_import, division, print_function
 
 import os,sys
 import os.path

--- a/py/desisim/scripts/quickgalaxies.py
+++ b/py/desisim/scripts/quickgalaxies.py
@@ -2,7 +2,6 @@
 desisim.scripts.quickgalaxies
 =============================
 """
-from __future__ import absolute_import, division, print_function
 
 import healpy as hp
 import numpy as np

--- a/py/desisim/scripts/quickgen.py
+++ b/py/desisim/scripts/quickgen.py
@@ -47,7 +47,6 @@ Quickgen quickly simulates pipeline outputs if given input files.
     zrange-qso, zrange-elg, zrange-lrg, zrange-bgs, sne-rfluxratiorange,
     add-SNeIa
 """
-from __future__ import absolute_import, division, print_function
 
 import argparse
 import astropy.units as u

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -716,7 +716,7 @@ def simulate_one_healpix(ifilename,args,model,obsconditions,decam_and_wise_filte
             # restore random state to get the same random numbers later
             # as when we don't insert BALs
             np.random.set_state(rnd_state)
-            w = np.in1d(qsometa['TARGETID'], meta_bal['TARGETID'])
+            w = np.isin(qsometa['TARGETID'], meta_bal['TARGETID'])
             qsometa['BAL_TEMPLATEID'][w] = meta_bal['BAL_TEMPLATEID']
             hdu_bal=pyfits.convenience.table_to_hdu(meta_bal); hdu_bal.name="BAL_META"
             #Trim to only show the version, assuming it is located in os.environ['DESI_BASIS_TEMPLATES']

--- a/py/desisim/scripts/quickquasars.py
+++ b/py/desisim/scripts/quickquasars.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import sys, os
 import argparse
 import time

--- a/py/desisim/scripts/quickspectra.py
+++ b/py/desisim/scripts/quickspectra.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 import sys, os
 import argparse
 import time

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -450,7 +450,7 @@ def simulate_spectra(wave, flux, fibermap=None, obsconditions=None, redshift=Non
     #- Set fiber locations from meta Table or default fiberpos
     fiberpos = desimodel.io.load_fiberpos()
     if fibermap is not None and len(fiberpos) != len(fibermap):
-        ii = np.in1d(fiberpos['FIBER'], fibermap['FIBER'])
+        ii = np.isin(fiberpos['FIBER'], fibermap['FIBER'])
         fiberpos = fiberpos[ii]
 
     if fibermap is None:
@@ -789,7 +789,7 @@ def get_mock_spectra(fiberassign, mockdir=None, nside=64, obscon=None):
                         obscon=obscon)):
 
         #- Sky fibers aren't in the truth files
-        ok = ~np.in1d(targetids, skyids)
+        ok = ~np.isin(targetids, skyids)
 
         tmpflux, tmpwave, tmpmeta, tmpobjmeta = read_mock_spectra(truthfile, targetids[ok])
 
@@ -803,7 +803,7 @@ def get_mock_spectra(fiberassign, mockdir=None, nside=64, obscon=None):
             for key in tmpobjmeta.keys():
                 objmeta[key] = list()
 
-        ii = np.in1d(fiberassign['TARGETID'], tmpmeta['TARGETID'])
+        ii = np.isin(fiberassign['TARGETID'], tmpmeta['TARGETID'])
         flux[ii] = tmpflux
         meta[ii] = tmpmeta
         assert np.all(wave == tmpwave)
@@ -879,18 +879,18 @@ def read_mock_spectra(truthfile, targetids, mockdir=None):
             if extname in fx:
                 objtruth[obj] = fx[extname].read()
 
-    missing = np.in1d(targetids, truth['TARGETID'], invert=True)
+    missing = np.isin(targetids, truth['TARGETID'], invert=True)
     if np.any(missing):
         missingids = targetids[missing]
         raise ValueError('Targets missing from {}: {}'.format(truthfile, missingids))
 
     #- Trim to just the spectra for these targetids
-    ii = np.in1d(truth['TARGETID'], targetids)
+    ii = np.isin(truth['TARGETID'], targetids)
     flux = flux[ii]
     truth = truth[ii]
     if bool(objtruth):
         for obj in objtruth.keys():
-            ii = np.in1d(objtruth[obj]['TARGETID'], targetids)
+            ii = np.isin(objtruth[obj]['TARGETID'], targetids)
             objtruth[obj] = objtruth[obj][ii]
 
     assert set(targetids) == set(truth['TARGETID'])

--- a/py/desisim/simexp.py
+++ b/py/desisim/simexp.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import sys
 import os.path
 import warnings

--- a/py/desisim/spec_qa/high_level.py
+++ b/py/desisim/spec_qa/high_level.py
@@ -5,7 +5,6 @@ desisim.spec_qa.high_level
 Module to run high_level QA on a given DESI run
  Written by JXP on 3 Sep 2015
 """
-from __future__ import print_function, absolute_import, division
 
 import numpy as np
 import sys, os, pdb, glob

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -6,7 +6,6 @@ Module to run high_level QA on a given DESI run
 
 Written by JXP on 3 Sep 2015
 """
-from __future__ import print_function, absolute_import, division
 
 import matplotlib
 # matplotlib.use('Agg')

--- a/py/desisim/spec_qa/redshifts.py
+++ b/py/desisim/spec_qa/redshifts.py
@@ -323,8 +323,8 @@ def match_truth_z(simz_tab, zb_tab, mini_read=False, outfil=None):
     # Match up
     sim_id = np.array(simz_tab['TARGETID'])
     z_id = np.array(zb_tab['TARGETID'])
-    inz = np.in1d(z_id,sim_id,assume_unique=True)
-    ins = np.in1d(sim_id,z_id,assume_unique=True)
+    inz = np.isin(z_id,sim_id,assume_unique=True)
+    ins = np.isin(sim_id,z_id,assume_unique=True)
 
     z_idx = np.arange(z_id.shape[0])[inz]
     sim_idx = np.arange(sim_id.shape[0])[ins]

--- a/py/desisim/spec_qa/s2n.py
+++ b/py/desisim/spec_qa/s2n.py
@@ -3,7 +3,6 @@ desisim.spec_qa.s2n
 =========================
 Module to examine S/N in object spectra
 """
-from __future__ import print_function, absolute_import, division
 
 import matplotlib
 # matplotlib.use('Agg')

--- a/py/desisim/spec_qa/utils.py
+++ b/py/desisim/spec_qa/utils.py
@@ -6,7 +6,6 @@ Module to run high_level QA on a given DESI run
 
 Written by JXP on 3 Sep 2015
 """
-from __future__ import print_function, absolute_import, division
 
 import numpy as np
 import sys, os, pdb, glob

--- a/py/desisim/specsim.py
+++ b/py/desisim/specsim.py
@@ -5,8 +5,6 @@ desisim.specsim
 DESI wrapper functions for external specsim classes.
 '''
 
-from __future__ import absolute_import, division, print_function
-
 #- Cached simulators, keyed by config string
 _simulators = dict()
 

--- a/py/desisim/survey_release.py
+++ b/py/desisim/survey_release.py
@@ -5,7 +5,6 @@ desisim.survey_release
 Functions and methods for mimicking a DESI release footprint and object density with adequate exposure times.
 
 """
-from __future__ import division, print_function
 import os
 import desisim
 import numpy as np

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -5,8 +5,6 @@ desisim.targets
 Utility functions for working with simulated targets.
 """
 
-from __future__ import absolute_import, division, print_function
-
 import os
 import sys
 import string

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -215,22 +215,22 @@ class EMSpectrum(object):
         nline = len(line)
 
         # Convenience variables.
-        is4959 = np.where(line['name'] == '[OIII]_4959')[0]
-        is5007 = np.where(line['name'] == '[OIII]_5007')[0]
-        is6548 = np.where(line['name'] == '[NII]_6548')[0]
-        is6584 = np.where(line['name'] == '[NII]_6584')[0]
-        is6716 = np.where(line['name'] == '[SII]_6716')[0]
-        is6731 = np.where(line['name'] == '[SII]_6731')[0]
-        #is3869 = np.where(line['name'] == '[NeIII]_3869')[0]
-        is3726 = np.where(line['name'] == '[OII]_3726')[0]
-        is3729 = np.where(line['name'] == '[OII]_3729')[0]
+        is4959 = np.where(line['name'] == '[OIII]_4959')[0][0]
+        is5007 = np.where(line['name'] == '[OIII]_5007')[0][0]
+        is6548 = np.where(line['name'] == '[NII]_6548')[0][0]
+        is6584 = np.where(line['name'] == '[NII]_6584')[0][0]
+        is6716 = np.where(line['name'] == '[SII]_6716')[0][0]
+        is6731 = np.where(line['name'] == '[SII]_6731')[0][0]
+        #is3869 = np.where(line['name'] == '[NeIII]_3869')[0][0]
+        is3726 = np.where(line['name'] == '[OII]_3726')[0][0]
+        is3729 = np.where(line['name'] == '[OII]_3729')[0][0]
 
-        is6300 = np.where(line['name'] == '[OI]_6300')[0]
-        is6363 = np.where(line['name'] == '[OI]_6363')[0]
-        is9532 = np.where(line['name'] == '[SIII]_9532')[0]
-        is9069 = np.where(line['name'] == '[SIII]_9069')[0]
-        is7135 = np.where(line['name'] == '[ArIII]_7135')[0]
-        is7751 = np.where(line['name'] == '[ArIII]_7751')[0]
+        is6300 = np.where(line['name'] == '[OI]_6300')[0][0]
+        is6363 = np.where(line['name'] == '[OI]_6363')[0][0]
+        is9532 = np.where(line['name'] == '[SIII]_9532')[0][0]
+        is9069 = np.where(line['name'] == '[SIII]_9069')[0][0]
+        is7135 = np.where(line['name'] == '[ArIII]_7135')[0][0]
+        is7751 = np.where(line['name'] == '[ArIII]_7751')[0][0]
 
         # Draw from the MoGs for forbidden lines.
         if oiiihbeta is None or oiihbeta is None or niihbeta is None or siihbeta is None:
@@ -801,6 +801,12 @@ class GALAXY(object):
                         oiidoublet, oiihbeta, niihbeta, siihbeta, oiiihbeta = \
                             self.lineratios(nobj=1, oiiihbrange=oiiihbrange,
                                             rand=templaterand, agnlike=agnlike)
+                        # convert length-1 arrays to scalars
+                        oiidoublet = oiidoublet[0]
+                        oiihbeta = oiihbeta[0]
+                        niihbeta = niihbeta[0]
+                        siihbeta = siihbeta[0]
+                        oiiihbeta = oiiihbeta[0]
 
                         if self.normline.upper() == 'OII':
                             ewoii = 10.0**(np.polyval(self.ewoiicoeff, d4000) + # rest-frame EW([OII]), Angstrom
@@ -1506,7 +1512,7 @@ class SUPERSTAR(object):
             baseflux = griddata(base_properties, self.baseflux,
                                 input_properties, method='nearest')
             interptemplateid = griddata(base_properties, np.arange(nbase),
-                                        input_properties, method='nearest')
+                                        input_properties, method='nearest').astype(int)
             #interptemplateid = np.array([int(tempid) for tempid in interptemplateid])
 
         # Build each spectrum in turn.
@@ -2229,12 +2235,12 @@ class QSO():
             if use_redshift is None:
                 redshift = templaterand.uniform(zrange[0], zrange[1])
             else:
-                redshift = np.atleast_1d(use_redshift[ii])
+                redshift = np.atleast_1d(use_redshift)[ii]
 
             if use_mag is None:
                 mag = templaterand.uniform(magrange[0], magrange[1])
             else:
-                mag = np.atleast_1d(use_mag[ii])
+                mag = np.atleast_1d(use_mag)[ii]
 
             zwave = self.eigenwave * (1+redshift) # [observed-frame, Angstrom]
 

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -5,8 +5,6 @@ desisim.templates
 Functions to simulate spectral templates for DESI.
 """
 
-from __future__ import division, print_function
-
 import os
 import sys
 import numpy as np
@@ -97,7 +95,7 @@ class EMSpectrum(object):
     def __init__(self, minwave=3650.0, maxwave=7075.0, cdelt_kms=20.0, log10wave=None,
                  include_mgii=False):
 
-        from pkg_resources import resource_filename
+        from importlib import resources
         from astropy.table import Table, Column, vstack
         from desiutil.sklearn import GaussianMixtureModel
 
@@ -112,9 +110,9 @@ class EMSpectrum(object):
             self.log10wave = log10wave
 
         # Read the files which contain the recombination and forbidden lines.
-        recombfile = resource_filename('desisim', 'data/recombination_lines.ecsv')
-        forbidfile = resource_filename('desisim', 'data/forbidden_lines.ecsv')
-        forbidmogfile = resource_filename('desisim','data/forbidden_mogs.fits')
+        recombfile = str(resources.files('desisim').joinpath('data', 'recombination_lines.ecsv'))
+        forbidfile = str(resources.files('desisim').joinpath('data', 'forbidden_lines.ecsv'))
+        forbidmogfile = str(resources.files('desisim').joinpath('data', 'forbidden_mogs.fits'))
 
         if not os.path.isfile(recombfile):
             log.fatal('Required data file {} not found!'.format(recombfile))

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -28,7 +28,7 @@ def _check_input_meta(input_meta, ignore_templateid=False):
         required_cols = ('SEED', 'REDSHIFT', 'MAG', 'MAGFILTER')
     else:
         required_cols = ('TEMPLATEID', 'SEED', 'REDSHIFT', 'MAG', 'MAGFILTER')
-    if not np.all(np.in1d(required_cols, cols)):
+    if not np.all(np.isin(required_cols, cols)):
         log.warning('Input metadata table (input_meta) is missing one or more required columns {}'.format(
             required_cols))
         raise ValueError
@@ -39,7 +39,7 @@ def _check_input_objmeta(input_objmeta, objtype):
     _, ref = empty_metatable(objtype=objtype)
 
     required_cols = ref.colnames
-    if not np.all(np.in1d(required_cols, cols)):
+    if not np.all(np.isin(required_cols, cols)):
         log.warning('Input object metadata table (input_objmeta) is missing one or more required columns {}'.format(
             required_cols))
         raise ValueError
@@ -50,7 +50,7 @@ def _check_star_properties(star_properties, WD=False):
     required_cols = ['REDSHIFT', 'MAG', 'MAGFILTER', 'TEFF', 'LOGG']
     if not WD:
         required_cols = required_cols + ['FEH']
-    if not np.all(np.in1d(required_cols, cols)):
+    if not np.all(np.isin(required_cols, cols)):
         log.warning('Input star_properties is missing one or more required columns {}'.format(
             required_cols))
         raise ValueError

--- a/py/desisim/test/__init__.py
+++ b/py/desisim/test/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import unittest
 
 def test_suite():

--- a/py/desisim/test/test_batch.py
+++ b/py/desisim/test/test_batch.py
@@ -36,7 +36,7 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(calc_nodes(11, 10, 20), 6)
     
     def test_batch_newexp(self):
-        flavors = ['arc', 'flat', 'bright', 'gray', 'dark']
+        flavors = ['arc', 'flat', 'bright', 'dark']
         expids = list(range(len(flavors)))
         night = '20101020'
         if os.path.exists(self.batchfile):

--- a/py/desisim/test/test_io.py
+++ b/py/desisim/test/test_io.py
@@ -156,10 +156,3 @@ class TestIO(unittest.TestCase):
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':
     unittest.main()
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m desisim.test.test_io
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desisim/test/test_lya.py
+++ b/py/desisim/test/test_lya.py
@@ -1,5 +1,5 @@
 import unittest
-from pkg_resources import resource_filename
+from importlib import resources
 
 import numpy as np
 try:
@@ -14,7 +14,7 @@ class TestLya(unittest.TestCase):
     
     @classmethod
     def setUpClass(cls):
-        cls.infile = resource_filename('desisim', 'test/data/simpleLyaSpec.fits.gz')
+        cls.infile = str(resources.files('desisim').joinpath('test', 'data', 'simpleLyaSpec.fits.gz'))
         if not missing_fitsio:
             fx = fitsio.FITS(cls.infile)
             cls.nspec = len(fx) - 1

--- a/py/desisim/test/test_lya.py
+++ b/py/desisim/test/test_lya.py
@@ -76,12 +76,5 @@ class TestLya(unittest.TestCase):
 
         #flux, wave, meta = lya_spectra.get_spectra(self.infile, nqso=nqso, first=2)
 
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)
-
 if __name__ == '__main__':
     unittest.main()

--- a/py/desisim/test/test_obs.py
+++ b/py/desisim/test/test_obs.py
@@ -157,14 +157,12 @@ class TestObs(unittest.TestCase):
         
         #- different programs should be different tiles
         a = obs.get_next_tileid(program='dark')
-        b = obs.get_next_tileid(program='gray')
-        c = obs.get_next_tileid(program='bright')
+        b = obs.get_next_tileid(program='bright')
         self.assertNotEqual(a, b)
-        self.assertNotEqual(a, c)
         
         #- program is case insensitive
-        a = obs.get_next_tileid(program='GRAY')
-        b = obs.get_next_tileid(program='gray')
+        a = obs.get_next_tileid(program='dark')
+        b = obs.get_next_tileid(program='DARK')
         self.assertEqual(a, b)
 
     def test_specter_objtype(self):

--- a/py/desisim/test/test_obs.py
+++ b/py/desisim/test/test_obs.py
@@ -1,7 +1,7 @@
 import unittest, os
 from uuid import uuid1
 from shutil import rmtree
-from pkg_resources import resource_filename
+from importlib import resources
 
 import numpy as np
 from astropy.io import fits
@@ -190,7 +190,7 @@ class TestObs(unittest.TestCase):
 
     def test_read_mock_spectra(self):
         #- piggyback on desitarget mock data
-        truthfile = resource_filename('desitarget', 'test/t/truth-mocks.fits')
+        truthfile = str(resources.files('desitarget').joinpath('test', 't', 'truth-mocks.fits'))
         if not os.path.exists(truthfile):
             print(f"Please update desitarget to get {truthfile}")
             return

--- a/py/desisim/test/test_pixsim.py
+++ b/py/desisim/test/test_pixsim.py
@@ -291,10 +291,3 @@ class TestPixsim(unittest.TestCase):
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':
     unittest.main()
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m <modulename>
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desisim/test/test_quickcat.py
+++ b/py/desisim/test/test_quickcat.py
@@ -146,8 +146,8 @@ class TestQuickCat(unittest.TestCase):
         self.assertTrue(np.all(zcat3_sorted['Z'] != truth_sorted['TRUEZ']))
         
         #- successful targets in the first round of observations shouldn't be updated
-        ii2 = np.in1d(zcat2_sorted['TARGETID'], zcat3_sorted['TARGETID']) & (zcat2_sorted['ZWARN'] == 0)
-        ii3 = np.in1d(zcat3_sorted['TARGETID'], zcat2_sorted['TARGETID'][ii2])
+        ii2 = np.isin(zcat2_sorted['TARGETID'], zcat3_sorted['TARGETID']) & (zcat2_sorted['ZWARN'] == 0)
+        ii3 = np.isin(zcat3_sorted['TARGETID'], zcat2_sorted['TARGETID'][ii2])
         ii = zcat2_sorted['Z'][ii2] == zcat3_sorted['Z'][ii3]
         self.assertTrue(np.all(zcat2_sorted['Z'][ii2] == zcat3_sorted['Z'][ii3]))
         
@@ -161,8 +161,8 @@ class TestQuickCat(unittest.TestCase):
         self.assertTrue(np.all(zcat4_sorted['Z'] != truth_sorted['TRUEZ']))
 
         #- Check that NUMOBS was incremented
-        i3 = np.in1d(zcat3_sorted['TARGETID'], self.targets_in_tile[self.tileids[3]]) # ids observed in the last tile
-        i4 = np.in1d(zcat4_sorted['TARGETID'], self.targets_in_tile[self.tileids[3]]) # ids observed in the last tile
+        i3 = np.isin(zcat3_sorted['TARGETID'], self.targets_in_tile[self.tileids[3]]) # ids observed in the last tile
+        i4 = np.isin(zcat4_sorted['TARGETID'], self.targets_in_tile[self.tileids[3]]) # ids observed in the last tile
         self.assertTrue(np.all(zcat4_sorted['NUMOBS'][i4] == zcat3_sorted['NUMOBS'][i3]+1))
 
         #- ZWARN==0 targets should be preserved, while ZWARN!=0 updated

--- a/py/desisim/test/test_quickgen.py
+++ b/py/desisim/test/test_quickgen.py
@@ -86,7 +86,8 @@ class TestQuickgen(unittest.TestCase):
         else:
             cls.cosmics = None
 
-        #- Try to locate where the quickgen script will be
+        #- Try to locate where the quickgen script will be.
+        #- first check for an installed location.
         cls.topDir = os.path.dirname( # top-level
             os.path.dirname( # build/
                 os.path.dirname( # lib/
@@ -96,14 +97,16 @@ class TestQuickgen(unittest.TestCase):
                     )
                 )
             )
+
         cls.binDir = os.path.join(cls.topDir,'bin')
 
-        if not os.path.isdir(cls.binDir):
+        #- if that doesn't exist, check the current directory
+        if not os.path.exists(cls.binDir+'/quickgen'):
             cls.topDir = os.getcwd()
             cls.binDir = os.path.join(cls.topDir, 'bin')
         
-        if not os.path.isdir(cls.binDir):
-            raise RuntimeError('Unable to auto-locate desisim/bin from {}'.format(__file__))
+        if not os.path.exists(cls.binDir+'/quickgen'):
+            raise RuntimeError('Unable to auto-locate desisim/bin/quickgen from {}'.format(__file__))
 
     def setUp(self):
         self.night = '20150105'
@@ -446,10 +449,3 @@ class TestQuickgen(unittest.TestCase):
 #- This runs all test* functions in any TestCase class in this file
 if __name__ == '__main__':
     unittest.main()
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m desisim.test.test_io
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desisim/test/test_quickquasars.py
+++ b/py/desisim/test/test_quickquasars.py
@@ -1,4 +1,4 @@
-from pkg_resources import resource_filename
+from importlib import resources
 import unittest, os, shutil, tempfile, subprocess
 import numpy as np
 from desisim.scripts import quickquasars
@@ -9,13 +9,13 @@ from astropy.io import fits
 class Testquickquasars(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        os.environ['DUST_DIR']=resource_filename('desisim','test/data/')
+        os.environ['DUST_DIR']=str(resources.files('desisim').joinpath('test', 'data'))
         cls.origdir = os.getcwd()
         cls.testdir =tempfile.mkdtemp()
         os.chdir(cls.testdir)
-        #cls.infile = resource_filename('desisim','test/data/transmission-16-1630.fits.gz')       #London mock
-        cls.infile = resource_filename('desisim','test/data/Lv5-transmission-16-1531.fits')       #London mock
-        cls.infile2 = resource_filename('desisim','test/data/transmission-16-1747.fits.gz')    #Saclay mock
+        # cls.infile  = str(resources.files('desisim').joinpath('test','data','transmission-16-1630.fits.gz'))   #London mock
+        cls.infile  = str(resources.files('desisim').joinpath('test','data','Lv5-transmission-16-1531.fits'))  #London mock
+        cls.infile2 = str(resources.files('desisim').joinpath('test','data','transmission-16-1747.fits.gz'))   #Saclay mock
         cls.outspec1 = os.path.join(cls.testdir, 'spectra-16-1531.fits')
         cls.outzbest = os.path.join(cls.testdir, 'zbest-16-1531.fits')
         cls.outspec1_s=os.path.join(cls.testdir, 'spectra-16-1747.fits')

--- a/py/desisim/test/test_quickquasars.py
+++ b/py/desisim/test/test_quickquasars.py
@@ -75,10 +75,3 @@ class Testquickquasars(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m desisim.test.test_quickquasars
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desisim/test/test_quickspectra.py
+++ b/py/desisim/test/test_quickspectra.py
@@ -111,10 +111,3 @@ class TestQuickSpectra(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
-def test_suite():
-    """Allows testing of only this module with the command::
-
-        python setup.py test -m desisim.test.test_quickspectra
-    """
-    return unittest.defaultTestLoader.loadTestsFromName(__name__)

--- a/py/desisim/test/test_templates.py
+++ b/py/desisim/test/test_templates.py
@@ -289,27 +289,27 @@ class TestTemplates(unittest.TestCase):
             template_factory = T(wave=self.wave)
             flux, wave, meta, objmeta = template_factory.make_templates(self.nspec, seed=self.seed)
         
-            self.assertTrue(np.all(np.in1d(['TARGETID', 'OBJTYPE', 'SUBTYPE', 'TEMPLATEID', 'SEED',
+            self.assertTrue(np.all(np.isin(['TARGETID', 'OBJTYPE', 'SUBTYPE', 'TEMPLATEID', 'SEED',
                                             'REDSHIFT', 'MAG', 'MAGFILTER', 'FLUX_G', 'FLUX_R',
                                             'FLUX_Z', 'FLUX_W1', 'FLUX_W2'],
                                             meta.colnames)))
         
             if ( isinstance(template_factory, ELG) or isinstance(template_factory, LRG) or
                  isinstance(template_factory, BGS) ):
-                self.assertTrue(np.all(np.in1d(['TARGETID', 'OIIFLUX', 'HBETAFLUX', 'EWOII', 'EWHBETA',
+                self.assertTrue(np.all(np.isin(['TARGETID', 'OIIFLUX', 'HBETAFLUX', 'EWOII', 'EWHBETA',
                                                 'D4000', 'VDISP', 'OIIDOUBLET', 'OIIIHBETA', 'OIIHBETA',
                                                 'NIIHBETA', 'SIIHBETA'],
                                                 objmeta.colnames)))
                 
             if (isinstance(template_factory, STAR) or isinstance(template_factory, STD) or
                 isinstance(template_factory, MWS_STAR) ):
-                self.assertTrue(np.all(np.in1d(['TARGETID', 'TEFF', 'LOGG', 'FEH'], objmeta.colnames)))
+                self.assertTrue(np.all(np.isin(['TARGETID', 'TEFF', 'LOGG', 'FEH'], objmeta.colnames)))
         
             if isinstance(template_factory, WD):
-                self.assertTrue(np.all(np.in1d(['TARGETID', 'TEFF', 'LOGG'], objmeta.colnames)))
+                self.assertTrue(np.all(np.isin(['TARGETID', 'TEFF', 'LOGG'], objmeta.colnames)))
         
             if isinstance(template_factory, QSO):
-                self.assertTrue(np.all(np.in1d(['TARGETID', 'PCA_COEFF'], objmeta.colnames)))
+                self.assertTrue(np.all(np.isin(['TARGETID', 'PCA_COEFF'], objmeta.colnames)))
     
 if __name__ == '__main__':
     unittest.main()

--- a/py/desisim/test/test_templates.py
+++ b/py/desisim/test/test_templates.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import os
 import unittest
 import numpy as np

--- a/py/desisim/test/test_top_level.py
+++ b/py/desisim/test/test_top_level.py
@@ -4,8 +4,6 @@
 test top-level desisim functions
 """
 #
-from __future__ import absolute_import, division, print_function
-#
 import unittest
 import re
 from .. import __version__ as theVersion

--- a/py/desisim/util.py
+++ b/py/desisim/util.py
@@ -8,6 +8,39 @@ Utility functions for desisim.  These may belong elsewhere?
 from __future__ import print_function, division
 import numpy as np
 
+def hadec2airmass(ha, dec, latitude=31.96397222):
+    """
+    Return airmass of an observation at hour angle `ha` and declination `dec`
+
+    Args:
+        ha (float): hour angle in degrees
+        dec (float): declination in degrees
+
+    Options:
+        latitude (float): telescope latitude; defaults to Kitt Peak
+
+    Returns: airmass (float)
+
+    Code adapted from desisurvey.util
+    """
+    # convert inputs from degrees to radians
+    ha = np.radians(ha)
+    dec = np.radians(dec)
+    latitude = np.radians(latitude)
+
+    # cos(zenith)
+    cosZ = (np.sin(dec) * np.sin(latitude) +
+            np.cos(dec) * np.cos(latitude) * np.cos(ha))
+
+    # cos(zenith) -> airmass, following Rozenberg 1966
+    # see https://en.wikipedia.org/wiki/Air_mass_(astronomy)#Interpolative_formulas
+    airmass = 1. / (cosZ + 0.025 * np.exp(-11 * cosZ))
+
+    # ensure that rounding doesn't result in airmass<1
+    airmass = np.clip(airmass, 1.0, None)
+
+    return airmass
+
 
 def spline_medfilt2d(image, kernel_size=201):
     '''

--- a/py/desisim/util.py
+++ b/py/desisim/util.py
@@ -5,7 +5,6 @@ desisim.util
 Utility functions for desisim.  These may belong elsewhere?
 """
 
-from __future__ import print_function, division
 import numpy as np
 
 def hadec2airmass(ha, dec, latitude=31.96397222):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,21 @@
 pytz
 requests
 # Ensure scipy dependency does not bring in a recent version of numpy.
-scipy<1.9
+### scipy<1.9
+scipy
 # The version of astropy will be reset by GitHub Actions tests.
 astropy
 # Ensure compatibility with numpy <1.23.
-numba<0.60
+### numba<0.60
+numba
 # Ensure compatibility with numpy <1.23.
-matplotlib<3.9
+### matplotlib<3.9
+matplotlib
 healpy
 # It is becoming difficult to install speclite and specsim directly from
 # git+https, so installing from PyPI is definitely preferred here.
 speclite
 specsim
-# The version of fitsio will be reset by GitHub Actions tests.
 fitsio
 # Install desiutil separately since it is needed for the other installs.
 # git+https://github.com/desihub/desiutil.git@3.1.0#egg=desiutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ matplotlib
 healpy
 # It is becoming difficult to install speclite and specsim directly from
 # git+https, so installing from PyPI is definitely preferred here.
+# Update 2025-09-08: get specsim/main from github pending new tag
 speclite
-specsim
 fitsio
 # Install desiutil separately since it is needed for the other installs.
 # git+https://github.com/desihub/desiutil.git@3.1.0#egg=desiutil
@@ -25,6 +25,6 @@ git+https://github.com/desihub/desimodel.git@main#egg=desimodel
 git+https://github.com/desihub/desispec.git@main#egg=desispec
 # git+https://github.com/desihub/desitarget.git@0.50.0#egg=desitarget
 git+https://github.com/desihub/desitarget.git@main#egg=desitarget
-# git+https://github.com/desihub/specsim.git@main#egg=specsim
+git+https://github.com/desihub/specsim.git@main#egg=specsim
 # simqso install script requires numpy, so install separately.
 # git+https://github.com/imcgreer/simqso.git@v1.2.4#egg=simqso

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,10 +19,10 @@ specsim
 fitsio
 # Install desiutil separately since it is needed for the other installs.
 # git+https://github.com/desihub/desiutil.git@3.1.0#egg=desiutil
-git+https://github.com/desihub/specter.git@0.9.4#egg=specter
-git+https://github.com/desihub/desimodel.git@0.18.0#egg=desimodel
+git+https://github.com/desihub/specter.git@0.11.0#egg=specter
+git+https://github.com/desihub/desimodel.git@0.19.3#egg=desimodel
 # Don't forget to install desimodel test data.
-git+https://github.com/desihub/desispec.git@0.36.1#egg=desispec
+git+https://github.com/desihub/desispec.git@0.69.0#egg=desispec
 # git+https://github.com/desihub/desitarget.git@0.50.0#egg=desitarget
 git+https://github.com/desihub/desitarget.git@main#egg=desitarget
 # git+https://github.com/desihub/specsim.git@main#egg=specsim

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,10 +19,10 @@ specsim
 fitsio
 # Install desiutil separately since it is needed for the other installs.
 # git+https://github.com/desihub/desiutil.git@3.1.0#egg=desiutil
-git+https://github.com/desihub/specter.git@0.11.0#egg=specter
-git+https://github.com/desihub/desimodel.git@0.19.3#egg=desimodel
+git+https://github.com/desihub/specter.git@main#egg=specter
+git+https://github.com/desihub/desimodel.git@main#egg=desimodel
 # Don't forget to install desimodel test data.
-git+https://github.com/desihub/desispec.git@0.69.0#egg=desispec
+git+https://github.com/desihub/desispec.git@main#egg=desispec
 # git+https://github.com/desihub/desitarget.git@0.50.0#egg=desitarget
 git+https://github.com/desihub/desitarget.git@main#egg=desitarget
 # git+https://github.com/desihub/specsim.git@main#egg=specsim


### PR DESCRIPTION
This PR
  * fixes code+unittests under the current desiconda environment at NERSC (fixes #585, fixes #586)
  * Adds support for numpy/2.x and scipy/1.16.x (both at NERSC and on GitHub actions) (fixes #584)
  * Removes "from __future__ import ..." leftover from python 2.x days (changing many files)
  * Converts use of deprecated `pkg_resources.resource_filename` to `importlib.resources.files`

As you probably noticed, it took me many iterations to get the GitHub Actions workflow passing even after the tests were completely passing in an environment at NERSC.  The result is a somewhat fragile state and will need more attention, e.g. in how dependencies are specified in requirements.txt vs. `.github/workflows/python-package.yml`. I suggest that we save that for a separate PR that is adding pyproject.toml / setup.cfg (see #583).  Additionally, some of the fragility is due to specsim still using astropy_helpers which is incompatible with the latest setuptools.  Addressing desihub/specsim#139 will help with that.

For the record: this is not yet compatible with astropy 7.x, though in the chaos of getting tests to pass I don't recall if that is due to desisim itself or one of its dependencies.