### PR TITLE
Support for more data releases on SurveyRelease/Quickquasars

### DIFF
--- a/py/desisim/scripts/gen_qso_catalog.py
+++ b/py/desisim/scripts/gen_qso_catalog.py
@@ -31,7 +31,7 @@ def main():
     parser.add_argument("--zmax", type=float, default=10.0, required=False,
                         help='Maximum redshift')
                     
-    parser.add_argument("--release", type=str, default='jura', choices=['iron','jura','Y5'], required=False,
+    parser.add_argument("--release", type=str, default='loa', required=False,
                         help='DESI survey release to reproduce')
     
     parser.add_argument("--include-nonqso-targets", action='store_true', default=False, 

--- a/py/desisim/survey_release.py
+++ b/py/desisim/survey_release.py
@@ -364,6 +364,8 @@ def get_lya_tiles(release='Y5'):
         if release.upper() not in ['FUJI','FUGU']:
             surveys = ['main']
             redux_tiles_filename = os.path.join(os.environ['DESI_SPECTRO_REDUX'],f'{release}/tiles-{release}.fits')
+            if not os.path.exists(redux_tiles_filename):
+                raise ValueError(f"Tiles file for release {release} not found at {redux_tiles_filename}")
             redux_tiles=Table.read(redux_tiles_filename)
         else:
             fuji_tiles_filename= os.path.join(os.environ['DESI_SPECTRO_REDUX'],f'fuji/tiles-fuji.fits')


### PR DESCRIPTION
This PR introduces a small enhancement that allows SurveyRelease to search for any available mountain (survey release) rather than being restricted to a predefined list.

If the requested release cannot be found on DESI_SPECTRO_REDUX, SurveyRelease will raise a ValueError, making failures explicit and easier to debug.