### PR TITLE
also test astropy/7.x

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -66,7 +66,7 @@ jobs:
               run: |
                 python -m pip install --upgrade pip 'setuptools<80' wheel
                 python -m pip install pytest
-                python -m pip install desiutil.git==${DESIUTIL_VERSION}
+                python -m pip install desiutil==${DESIUTIL_VERSION}
                 python -m pip install --no-build-isolation -r requirements.txt
                 python -m pip install --upgrade --upgrade-strategy only-if-needed 'numpy${{ matrix.numpy-version }}'
                 python -m pip install --upgrade --upgrade-strategy only-if-needed 'scipy${{ matrix.scipy-version }}'


### PR DESCRIPTION
This PR updates the github tests to include astropy/7.x .  Tests pass at NERSC with astropy/7.1.0 .