### PR TITLE
multiprocessing.Pool with fork instead of forkserver

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -52,7 +52,9 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
             - name: Install System Packages
-              run: sudo apt install libbz2-dev subversion
+              run: |
+                  sudo apt-get -y update
+                  sudo apt install libbz2-dev subversion
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v5
               with:
@@ -116,7 +118,9 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v4
             - name: Install System Packages
-              run: sudo apt install libbz2-dev subversion
+              run: |
+                  sudo apt-get -y update
+                  sudo apt install libbz2-dev subversion
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v5
               with:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -19,14 +19,12 @@ jobs:
                 include:
                     - os: ubuntu-latest
                       python-version: '3.14'
-                      # numba doesn't yet support numpy/2.3; could be relaxed in the future
-                      numpy-version: '<2.3'
+                      numpy-version: '<2.6'
                       scipy-version: ''
                       astropy-version: '<8'
                     # similar to matterhorn environment
                     - os: ubuntu-latest
                       python-version: '3.13'
-                      # numba doesn't yet support numpy/2.3; could be relaxed in the future
                       numpy-version: '<2.3'
                       scipy-version: ''
                       astropy-version: '<8'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,22 +18,19 @@ jobs:
             matrix:
                 include:
                     - os: ubuntu-latest
+                      python-version: '3.14'
+                      # numba doesn't yet support numpy/2.3; could be relaxed in the future
+                      numpy-version: '<2.3'
+                      scipy-version: ''
+                      astropy-version: '<8'
+                    # similar to matterhorn environment
+                    - os: ubuntu-latest
                       python-version: '3.13'
                       # numba doesn't yet support numpy/2.3; could be relaxed in the future
                       numpy-version: '<2.3'
                       scipy-version: ''
                       astropy-version: '<8'
-                    - os: ubuntu-latest
-                      python-version: '3.12'
-                      numpy-version: '<2.3'
-                      scipy-version: '<2'
-                      astropy-version: '<7'
-                    - os: ubuntu-latest
-                      python-version: '3.11'
-                      numpy-version: '<2.1'
-                      scipy-version: '<2'
-                      astropy-version: '<7'
-                    # Similar to NERSC but with last NumPy < 2.
+                    # Similar to old NERSC environments but with last NumPy < 2.
                     - os: ubuntu-latest
                       python-version: '3.10'
                       numpy-version: '<2'

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -65,11 +65,7 @@ jobs:
               run: |
                 python -m pip install --upgrade pip 'setuptools<80' wheel
                 python -m pip install pytest
-                python -m pip install desiutil==${DESIUTIL_VERSION}
-                python -m pip install --no-build-isolation -r requirements.txt
-                python -m pip install --upgrade --upgrade-strategy only-if-needed 'numpy${{ matrix.numpy-version }}'
-                python -m pip install --upgrade --upgrade-strategy only-if-needed 'scipy${{ matrix.scipy-version }}'
-                python -m pip install --upgrade --upgrade-strategy only-if-needed 'astropy${{ matrix.astropy-version }}'
+                python -m pip install --no-build-isolation -r requirements.txt desiutil==${DESIUTIL_VERSION} 'numpy${{ matrix.numpy-version }}' 'scipy${{ matrix.scipy-version }}' 'astropy${{ matrix.astropy-version }}'
                 python -m pip install --no-build-isolation git+https://github.com/${SIMQSO_REPO}/simqso.git@${SIMQSO_VERSION}#egg=simqso
             - name: Verify Installation
               run: pip list
@@ -129,11 +125,7 @@ jobs:
               run: |
                 python -m pip install --upgrade pip 'setuptools<80' wheel
                 python -m pip install pytest pytest-cov coveralls
-                python -m pip install desiutil==${DESIUTIL_VERSION}
-                python -m pip install --no-build-isolation -r requirements.txt
-                python -m pip install --upgrade --upgrade-strategy only-if-needed 'numpy${{ matrix.numpy-version }}'
-                python -m pip install --upgrade --upgrade-strategy only-if-needed 'scipy${{ matrix.scipy-version }}'
-                python -m pip install --upgrade --upgrade-strategy only-if-needed 'astropy${{ matrix.astropy-version }}'
+                python -m pip install --no-build-isolation -r requirements.txt desiutil==${DESIUTIL_VERSION} 'numpy${{ matrix.numpy-version }}' 'scipy${{ matrix.scipy-version }}' 'astropy${{ matrix.astropy-version }}'
                 python -m pip install --no-build-isolation git+https://github.com/${SIMQSO_REPO}/simqso.git@${SIMQSO_VERSION}#egg=simqso
                 python -m pip cache remove fitsio
                 python -m pip install --no-deps --force-reinstall --ignore-installed 'fitsio${{ matrix.fitsio-version }}'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,7 +40,7 @@ extensions = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
+    # 'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'matplotlib': ('https://matplotlib.org/stable/', None),
     'astropy': ('https://docs.astropy.org/en/stable/', None),
     'h5py': ('https://docs.h5py.org/en/latest/', None)

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -1058,7 +1058,8 @@ def read_basis_templates(objtype, subtype='', outwave=None, nspec=None,
             args.append((outwave, wave, flux[jj,:]))
         import multiprocessing
         ncpu = multiprocessing.cpu_count() // 2   #- avoid hyperthreading
-        with multiprocessing.Pool(ncpu) as P:
+        #- Force 'fork' (see py/desisim/pixsim.py parallel_project for why)
+        with multiprocessing.get_context('fork').Pool(ncpu) as P:
             outflux = P.map(_resample_flux, args)
         outflux = np.array(outflux)
 

--- a/py/desisim/io.py
+++ b/py/desisim/io.py
@@ -1046,6 +1046,9 @@ def read_basis_templates(objtype, subtype='', outwave=None, nspec=None,
         these = np.random.choice(np.arange(ntemplates),nspec)
         flux = flux[these,:]
         meta = meta[these]
+        ntemplates = nspec
+    else:
+        nspec = ntemplates
 
     # Optionally resample the templates at specific wavelengths.  Use
     # multiprocessing to speed this up.

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -645,8 +645,8 @@ def parallel_project(psf, wave, phot, specmin=0, ncpu=None, comm=None):
             #- workers inheriting already-initialized parent state); Python
             #- 3.14+ defaults to 'forkserver' on Linux, which re-imports
             #- everything fresh in each worker and hangs here.
-            pool = mp.get_context('fork').Pool(ncpu)
-            xy_subimg = pool.map(_project, args)
+            with mp.get_context('fork').Pool(ncpu) as pool:
+                xy_subimg = pool.map(_project, args)
 
             #print("xy_subimg from pool")
             #print(xy_subimg)
@@ -656,10 +656,6 @@ def parallel_project(psf, wave, phot, specmin=0, ncpu=None, comm=None):
             for xyrange, subimg in xy_subimg:
                 xmin, xmax, ymin, ymax = xyrange
                 img[ymin:ymax, xmin:xmax] += subimg
-
-            #- Prevents hangs of Travis tests
-            pool.close()
-            pool.join()
 
     return img
 

--- a/py/desisim/pixsim.py
+++ b/py/desisim/pixsim.py
@@ -641,7 +641,11 @@ def parallel_project(psf, wave, phot, specmin=0, ncpu=None, comm=None):
 
             #- Create pool of workers to do the projection using _project
             #- xyrange, subimg = _project( [psf, wave, phot, specmin] )
-            pool = mp.Pool(ncpu)
+            #- Force 'fork' since this code relies on fork semantics (e.g.
+            #- workers inheriting already-initialized parent state); Python
+            #- 3.14+ defaults to 'forkserver' on Linux, which re-imports
+            #- everything fresh in each worker and hangs here.
+            pool = mp.get_context('fork').Pool(ncpu)
             xy_subimg = pool.map(_project, args)
 
             #print("xy_subimg from pool")

--- a/py/desisim/targets.py
+++ b/py/desisim/targets.py
@@ -209,7 +209,8 @@ def get_targets_parallel(nspec, program, tileid=None, nproc=None, seed=None, spe
             else:
                 args.append( (nspec-i, program, tileid, seeds[i], specify_targets, i) )
 
-        with mp.Pool(nproc) as P:
+        #- Force 'fork' (see py/desisim/pixsim.py parallel_project for why)
+        with mp.get_context('fork').Pool(nproc) as P:
             results = P.map(_wrap_get_targets, args)
         fibermaps, targets = list(zip(*results))
         fibermap = np.concatenate(fibermaps)

--- a/py/desisim/templates.py
+++ b/py/desisim/templates.py
@@ -2494,7 +2494,8 @@ class SIMQSO():
 
         # Initialize multiprocessing map object.
         if nproc > 1:
-            pool = multiprocessing.Pool(nproc)
+            #- Force 'fork' (see py/desisim/pixsim.py parallel_project for why)
+            pool = multiprocessing.get_context('fork').Pool(nproc)
             self.procMap = pool.map
         else:
             self.procMap = map


### PR DESCRIPTION
Python 3.14 switched the default multiprocessing method from "fork" to "forkserver".  This broke pixsim usage which relied upon the copy-on-write inheritance of large objects (fork) instead of having multiprocessing pickle the objects and pass replicated versions into each worker process (forkserver).

This PR updates the multiprocessing usage to explicitly use fork.  Without this fix, the worker processes keep crashing and multiprocessing keeps spawning new ones and the whole thing hangs.

I added python 3.14 to the test setup, while also keeping 3.13 and 3.10 but dropped intermediate 3.11 and 3.12.

Diagnosed and implemented by Claude, checked by me.